### PR TITLE
feat: Add delete endpoint by slug API and service

### DIFF
--- a/backend/src/syfthub/api/endpoints/endpoints.py
+++ b/backend/src/syfthub/api/endpoints/endpoints.py
@@ -142,6 +142,16 @@ async def update_endpoint_by_slug(
     )
 
 
+@router.delete("/slug/{endpoint_slug}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_endpoint_by_slug(
+    endpoint_slug: str,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    endpoint_service: Annotated[EndpointService, Depends(get_endpoint_service)],
+) -> None:
+    """Delete an endpoint by slug."""
+    endpoint_service.delete_endpoint_by_slug(endpoint_slug, current_user)
+
+
 @router.delete("/{endpoint_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_endpoint(
     endpoint_id: int,

--- a/backend/src/syfthub/services/endpoint_service.py
+++ b/backend/src/syfthub/services/endpoint_service.py
@@ -497,6 +497,32 @@ class EndpointService(BaseService):
 
         return True
 
+    def delete_endpoint_by_slug(self, endpoint_slug: str, current_user: User) -> bool:
+        """Delete endpoint by slug."""
+        endpoint = self.endpoint_repository.get_by_user_and_slug(
+            current_user.id, endpoint_slug
+        )
+        if not endpoint:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Endpoint not found",
+            )
+
+        if not self._can_modify_endpoint(endpoint, current_user):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Permission denied: insufficient permissions",
+            )
+
+        success = self.endpoint_repository.delete_endpoint(endpoint.id)
+        if not success:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to delete endpoint",
+            )
+
+        return True
+
     def star_endpoint(self, endpoint_id: int, current_user: User) -> bool:
         """Star a endpoint."""
         # Check if endpoint exists and is accessible


### PR DESCRIPTION
## Summary
This PR introduces a new API endpoint and service method to delete an endpoint by its slug, enhancing flexibility in endpoint management.

## Changes
- Added `DELETE /slug/{endpoint_slug}` route to delete an endpoint by slug.
- Implemented `delete_endpoint_by_slug` method in `EndpointService` with proper permission checks and error handling.
- Extended test suite with comprehensive tests for deleting endpoints by slug, covering success, not found, permission denied, case insensitivity, ownership, and error scenarios.

## Notes
The implementation ensures only authorized users can delete their own endpoints via slug, with consistent case-insensitive lookup. Tests validate behavior and security constraints.