### PR TITLE
fix: Correct response source formatting in chat_with_syfthub

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1733,10 +1733,10 @@ def chat_with_syfthub(
             data_sources=data_sources or []
         )
 
-        # Format sources for output
+        # Format sources for output (retrieval_info contains metadata about each data source)
         sources_info = []
-        if response.sources:
-            for source in response.sources:
+        if response.retrieval_info:
+            for source in response.retrieval_info:
                 source_entry = {
                     "path": source.path,
                     "status": source.status.value if hasattr(source.status, 'value') else str(source.status),


### PR DESCRIPTION
## Summary
Fixes the output formatting in the `chat_with_syfthub` function to correctly utilize `retrieval_info` instead of the outdated `sources`.

## Changes
- Updated the conditional and loop to process `response.retrieval_info` for source metadata
- Corrects the data source information handling in the response formatting

## Notes
Ensures accurate and consistent source metadata output for improved response clarity.