### PR TITLE
feat: Add configurable aggregator URL for RAG/chat workflows

### DIFF
--- a/backend/src/syfthub/models/user.py
+++ b/backend/src/syfthub/models/user.py
@@ -39,6 +39,11 @@ class UserModel(BaseModel, TimestampMixin):
         String(253), nullable=True, default=None
     )
 
+    # Custom aggregator URL for RAG/chat workflows
+    aggregator_url: Mapped[Optional[str]] = mapped_column(
+        String(500), nullable=True, default=None
+    )
+
     # Relationships
     endpoints: Mapped[List["EndpointModel"]] = relationship(
         "EndpointModel", back_populates="user", cascade="all, delete-orphan"

--- a/backend/src/syfthub/repositories/user.py
+++ b/backend/src/syfthub/repositories/user.py
@@ -110,6 +110,9 @@ class UserRepository(BaseRepository[UserModel]):
                 user_model.accounting_password = user_data.accounting_password
             if user_data.domain is not None:
                 user_model.domain = user_data.domain
+            # Aggregator URL
+            if user_data.aggregator_url is not None:
+                user_model.aggregator_url = user_data.aggregator_url
 
             self.session.commit()
             self.session.refresh(user_model)

--- a/backend/src/syfthub/schemas/user.py
+++ b/backend/src/syfthub/schemas/user.py
@@ -51,6 +51,10 @@ class User(UserBase):
     domain: Optional[str] = Field(
         None, max_length=253, description="Domain for endpoint URL construction"
     )
+    # Custom aggregator URL for RAG/chat workflows
+    aggregator_url: Optional[str] = Field(
+        None, description="Custom aggregator URL for RAG/chat workflows"
+    )
 
     model_config = {"from_attributes": True}
 
@@ -74,6 +78,10 @@ class UserResponse(BaseModel):
     # Domain for dynamic endpoint URL construction
     domain: Optional[str] = Field(
         None, description="Domain for endpoint URL construction"
+    )
+    # Custom aggregator URL for RAG/chat workflows
+    aggregator_url: Optional[str] = Field(
+        None, description="Custom aggregator URL for RAG/chat workflows"
     )
 
     model_config = {"from_attributes": True}
@@ -105,6 +113,12 @@ class UserUpdate(BaseModel):
         None,
         max_length=253,
         description="Domain for endpoint URL construction (no protocol)",
+    )
+    # Custom aggregator URL for RAG/chat workflows
+    aggregator_url: Optional[str] = Field(
+        None,
+        max_length=500,
+        description="Custom aggregator URL for RAG/chat workflows",
     )
 
 

--- a/frontend/src/components/chat-view.tsx
+++ b/frontend/src/components/chat-view.tsx
@@ -972,10 +972,12 @@ export function ChatView({ initialQuery }: Readonly<ChatViewProperties>) {
         let accumulatedContent = '';
 
         // Use SDK for streaming - SDK resolves paths internally
+        // Pass custom aggregator URL if user has configured one
         for await (const event of syftClient.chat.stream({
           prompt: inputValue,
           model: modelPath,
           dataSources: dataSourcePaths.length > 0 ? dataSourcePaths : undefined,
+          aggregatorUrl: user?.aggregator_url || undefined,
           signal: abortControllerReference.current.signal
         })) {
           // Update processing status from event

--- a/frontend/src/components/settings/aggregator-settings-tab.tsx
+++ b/frontend/src/components/settings/aggregator-settings-tab.tsx
@@ -1,0 +1,386 @@
+/**
+ * Aggregator Settings Tab
+ *
+ * Allows users to configure a custom aggregator URL for RAG/chat workflows.
+ * If not configured, the default aggregator is used.
+ */
+
+import React, { useCallback, useState } from 'react';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import AlertCircle from 'lucide-react/dist/esm/icons/alert-circle';
+import Check from 'lucide-react/dist/esm/icons/check';
+import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
+import Save from 'lucide-react/dist/esm/icons/save';
+import Server from 'lucide-react/dist/esm/icons/server';
+import Trash2 from 'lucide-react/dist/esm/icons/trash-2';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useAuth } from '@/context/auth-context';
+import { syftClient } from '@/lib/sdk-client';
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+function validateUrl(url: string): string | null {
+  if (!url.trim()) return null; // Empty is valid (means use default)
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return 'URL must use http:// or https://';
+    }
+    return null;
+  } catch {
+    return 'Please enter a valid URL (e.g., https://aggregator.example.com)';
+  }
+}
+
+// =============================================================================
+// Main Component
+// =============================================================================
+
+export function AggregatorSettingsTab() {
+  const { user, updateUser } = useAuth();
+
+  const [formUrl, setFormUrl] = useState('');
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+
+  const currentUrl = user?.aggregator_url;
+  const isConfigured = Boolean(currentUrl);
+
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormUrl(e.target.value);
+    setLocalError(null);
+    setSuccess(false);
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLocalError(null);
+    setSuccess(false);
+
+    // Validate URL (empty is allowed - means clear/use default)
+    const trimmedUrl = formUrl.trim();
+    if (trimmedUrl) {
+      const urlError = validateUrl(trimmedUrl);
+      if (urlError) {
+        setLocalError(urlError);
+        return;
+      }
+    }
+
+    setIsLoading(true);
+
+    try {
+      // Get token from SDK client
+      const tokens = syftClient.getTokens();
+      const accessToken = tokens?.accessToken ?? '';
+
+      const response = await fetch('/api/v1/users/me', {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          aggregator_url: trimmedUrl || null // null to clear
+        })
+      });
+
+      if (!response.ok) {
+        const errorData = (await response.json().catch(() => ({}))) as { detail?: string };
+        throw new Error(errorData.detail ?? 'Failed to update aggregator settings');
+      }
+
+      const updatedUser = (await response.json()) as { aggregator_url?: string | null };
+
+      // Update local user state
+      if (updateUser && user) {
+        updateUser({
+          ...user,
+          aggregator_url: updatedUser.aggregator_url ?? undefined
+        });
+      }
+
+      setSuccess(true);
+      setIsEditing(false);
+      setFormUrl('');
+    } catch (error_) {
+      setLocalError(error_ instanceof Error ? error_.message : 'An unknown error occurred');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleClear = async () => {
+    setLocalError(null);
+    setSuccess(false);
+    setIsLoading(true);
+
+    try {
+      const tokens = syftClient.getTokens();
+      const accessToken = tokens?.accessToken ?? '';
+
+      const response = await fetch('/api/v1/users/me', {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          aggregator_url: null
+        })
+      });
+
+      if (!response.ok) {
+        const errorData = (await response.json().catch(() => ({}))) as { detail?: string };
+        throw new Error(errorData.detail ?? 'Failed to clear aggregator settings');
+      }
+
+      // Update local user state
+      if (updateUser && user) {
+        updateUser({
+          ...user,
+          aggregator_url: undefined
+        });
+      }
+
+      setSuccess(true);
+    } catch (error_) {
+      setLocalError(error_ instanceof Error ? error_.message : 'An unknown error occurred');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleStartEditing = () => {
+    setIsEditing(true);
+    setFormUrl(currentUrl ?? '');
+    setSuccess(false);
+  };
+
+  const handleCancelEditing = () => {
+    setIsEditing(false);
+    setFormUrl('');
+    setLocalError(null);
+  };
+
+  // If configured and not editing, show view mode
+  if (isConfigured && !isEditing) {
+    return (
+      <div className='space-y-6'>
+        {/* Header */}
+        <div>
+          <h3 className='text-lg font-semibold text-gray-900'>Aggregator Settings</h3>
+          <p className='mt-1 text-sm text-gray-500'>
+            You have a custom aggregator configured for chat operations.
+          </p>
+        </div>
+
+        {/* Success Message */}
+        <AnimatePresence>
+          {success ? (
+            <motion.div
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+              className='flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3'
+            >
+              <Check className='h-4 w-4 text-green-600' />
+              <span className='text-sm text-green-800'>Settings updated successfully!</span>
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+
+        {/* Error Message */}
+        <AnimatePresence>
+          {localError ? (
+            <motion.div
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+              className='flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3'
+            >
+              <AlertCircle className='h-4 w-4 text-red-600' />
+              <span className='text-sm text-red-800'>{localError}</span>
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+
+        {/* Current Configuration Display */}
+        <div className='space-y-4' data-testid='aggregator-view'>
+          <div className='flex items-center gap-2 border-b border-gray-200 pb-3'>
+            <Server className='h-4 w-4 text-gray-500' />
+            <h4 className='font-medium text-gray-900'>Custom Aggregator</h4>
+          </div>
+
+          {/* URL */}
+          <div className='space-y-1'>
+            <Label className='text-xs text-gray-500'>Aggregator URL</Label>
+            <div className='rounded-md bg-gray-50 px-3 py-2'>
+              <span className='text-sm break-all text-gray-900'>{currentUrl}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Action Buttons */}
+        <div className='flex items-center justify-between border-t border-gray-200 pt-4'>
+          <Button
+            type='button'
+            variant='outline'
+            onClick={handleClear}
+            disabled={isLoading}
+            className='flex items-center gap-2 text-red-600 hover:bg-red-50 hover:text-red-700'
+          >
+            {isLoading ? (
+              <Loader2 className='h-4 w-4 animate-spin' />
+            ) : (
+              <Trash2 className='h-4 w-4' />
+            )}
+            Use Default
+          </Button>
+          <Button
+            type='button'
+            variant='outline'
+            onClick={handleStartEditing}
+            className='flex items-center gap-2'
+          >
+            Update URL
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Setup or Edit form
+  return (
+    <div className='space-y-6'>
+      {/* Header */}
+      <div>
+        <h3 className='text-lg font-semibold text-gray-900'>Aggregator Settings</h3>
+        <p className='mt-1 text-sm text-gray-500'>
+          {isEditing
+            ? 'Update your custom aggregator URL.'
+            : 'Configure a custom aggregator for chat operations.'}
+        </p>
+      </div>
+
+      {/* Info Banner */}
+      {isEditing ? null : (
+        <div className='rounded-lg border border-blue-200 bg-blue-50 p-4'>
+          <div className='flex items-start gap-3'>
+            <Server className='mt-0.5 h-5 w-5 flex-shrink-0 text-blue-600' />
+            <div>
+              <h4 className='text-sm font-medium text-blue-900'>Optional Configuration</h4>
+              <p className='mt-1 text-xs text-blue-700'>
+                By default, SyftHub uses its built-in aggregator for chat operations. You can
+                configure a custom aggregator if you want to use your own RAG orchestration service.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Success Message */}
+      <AnimatePresence>
+        {success ? (
+          <motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            className='flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3'
+          >
+            <Check className='h-4 w-4 text-green-600' />
+            <span className='text-sm text-green-800'>Settings updated successfully!</span>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+
+      {/* Error Message */}
+      <AnimatePresence>
+        {localError ? (
+          <motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            className='flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3'
+          >
+            <AlertCircle className='h-4 w-4 text-red-600' />
+            <span className='text-sm text-red-800'>{localError}</span>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+
+      {/* Setup/Edit Form */}
+      <form onSubmit={handleSubmit} className='space-y-5'>
+        <div className='flex items-center gap-2 border-b border-gray-200 pb-3'>
+          <Server className='h-4 w-4 text-gray-500' />
+          <h4 className='font-medium text-gray-900'>Aggregator Service</h4>
+        </div>
+
+        {/* URL */}
+        <div className='space-y-2'>
+          <Label htmlFor='aggregator-url'>Aggregator URL</Label>
+          <Input
+            id='aggregator-url'
+            name='aggregator_url'
+            type='url'
+            value={formUrl}
+            onChange={handleInputChange}
+            placeholder='https://aggregator.example.com/api/v1'
+            autoComplete='url'
+            disabled={isLoading}
+            data-testid='aggregator-url'
+          />
+          <p className='text-xs text-gray-500'>
+            The base URL of your aggregator service API. Leave empty to use the default.
+          </p>
+        </div>
+
+        {/* Warning */}
+        <div className='rounded-lg border border-amber-200 bg-amber-50 p-3'>
+          <div className='flex items-start gap-2'>
+            <AlertCircle className='mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600' />
+            <p className='text-xs text-amber-800'>
+              Using a custom aggregator means your chat queries will be sent to that service. Make
+              sure you trust the aggregator you configure.
+            </p>
+          </div>
+        </div>
+
+        {/* Submit Buttons */}
+        <div className='flex items-center justify-end gap-2 pt-2'>
+          {isEditing ? (
+            <Button type='button' variant='outline' onClick={handleCancelEditing}>
+              Cancel
+            </Button>
+          ) : null}
+          <Button
+            type='submit'
+            disabled={isLoading}
+            className='flex items-center gap-2'
+            data-testid='save-aggregator'
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className='h-4 w-4 animate-spin' />
+                Saving…
+              </>
+            ) : (
+              <>
+                <Save className='h-4 w-4' aria-hidden='true' />
+                {isEditing ? 'Update URL' : 'Save Settings'}
+              </>
+            )}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/settings-modal.tsx
+++ b/frontend/src/components/settings/settings-modal.tsx
@@ -6,6 +6,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import AlertTriangle from 'lucide-react/dist/esm/icons/alert-triangle';
 import CreditCard from 'lucide-react/dist/esm/icons/credit-card';
 import Lock from 'lucide-react/dist/esm/icons/lock';
+import Server from 'lucide-react/dist/esm/icons/server';
 import User from 'lucide-react/dist/esm/icons/user';
 import X from 'lucide-react/dist/esm/icons/x';
 
@@ -13,6 +14,7 @@ import { Button } from '@/components/ui/button';
 import { useSettingsModal } from '@/context/settings-modal-context';
 import { cn } from '@/lib/utils';
 
+import { AggregatorSettingsTab } from './aggregator-settings-tab';
 import { DangerZoneTab } from './danger-zone-tab';
 import { PaymentSettingsTab } from './payment-settings-tab';
 import { ProfileSettingsTab } from './profile-settings-tab';
@@ -29,6 +31,11 @@ const TABS: TabItem[] = [
   { id: 'profile', label: 'Profile', icon: <User className='h-4 w-4' aria-hidden='true' /> },
   { id: 'security', label: 'Security', icon: <Lock className='h-4 w-4' aria-hidden='true' /> },
   { id: 'payment', label: 'Payment', icon: <CreditCard className='h-4 w-4' aria-hidden='true' /> },
+  {
+    id: 'aggregator',
+    label: 'Aggregator',
+    icon: <Server className='h-4 w-4' aria-hidden='true' />
+  },
   {
     id: 'danger-zone',
     label: 'Danger Zone',
@@ -120,6 +127,9 @@ export function SettingsModal() {
       }
       case 'payment': {
         return <PaymentSettingsTab />;
+      }
+      case 'aggregator': {
+        return <AggregatorSettingsTab />;
       }
       case 'danger-zone': {
         return <DangerZoneTab />;

--- a/frontend/src/context/settings-modal-context.tsx
+++ b/frontend/src/context/settings-modal-context.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useCallback, useContext, useState } from 'react';
 
-export type SettingsTab = 'profile' | 'security' | 'payment' | 'danger-zone';
+export type SettingsTab = 'profile' | 'security' | 'payment' | 'aggregator' | 'danger-zone';
 
 interface SettingsModalContextType {
   isOpen: boolean;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -45,6 +45,8 @@ export interface User {
   updated_at: string;
   /** Domain for endpoint URL construction (e.g., "api.example.com:8080") */
   domain?: string;
+  /** Custom aggregator URL for RAG/chat workflows */
+  aggregator_url?: string;
 }
 
 // Authentication request schemas
@@ -95,6 +97,8 @@ export interface UserUpdate {
   avatar_url?: string;
   /** Domain for endpoint URL construction (no protocol) */
   domain?: string;
+  /** Custom aggregator URL for RAG/chat workflows */
+  aggregator_url?: string;
 }
 
 // Availability check responses

--- a/sdk/python/src/syfthub_sdk/chat.py
+++ b/sdk/python/src/syfthub_sdk/chat.py
@@ -490,6 +490,7 @@ class ChatResource:
         max_tokens: int = 1024,
         temperature: float = 0.7,
         similarity_threshold: float = 0.5,
+        aggregator_url: str | None = None,
     ) -> ChatResponse:
         """Send a chat request and get the complete response.
 
@@ -506,6 +507,7 @@ class ChatResource:
             max_tokens: Maximum tokens to generate (default: 1024)
             temperature: Generation temperature (default: 0.7)
             similarity_threshold: Minimum similarity for retrieved docs (default: 0.5)
+            aggregator_url: Custom aggregator URL (optional, uses default if not provided)
 
         Returns:
             ChatResponse with response text, sources, and metadata
@@ -524,6 +526,9 @@ class ChatResource:
             print(response.response)
             print(f"Used {len(response.sources)} sources")
         """
+        # Use custom aggregator URL if provided, otherwise use default
+        effective_aggregator_url = (aggregator_url or self._aggregator_url).rstrip("/")
+
         model_ref = self._resolve_endpoint_ref(model, expected_type="model")
 
         ds_refs = []
@@ -550,7 +555,7 @@ class ChatResource:
 
         try:
             response = self._agg_client.post(
-                f"{self._aggregator_url}/chat",
+                f"{effective_aggregator_url}/chat",
                 json=request_body,
                 headers={"Content-Type": "application/json"},
             )
@@ -624,6 +629,7 @@ class ChatResource:
         max_tokens: int = 1024,
         temperature: float = 0.7,
         similarity_threshold: float = 0.5,
+        aggregator_url: str | None = None,
     ) -> Iterator[ChatStreamEvent]:
         """Send a chat request and stream response events.
 
@@ -640,6 +646,7 @@ class ChatResource:
             max_tokens: Maximum tokens to generate (default: 1024)
             temperature: Generation temperature (default: 0.7)
             similarity_threshold: Minimum similarity for retrieved docs (default: 0.5)
+            aggregator_url: Custom aggregator URL (optional, uses default if not provided)
 
         Yields:
             ChatStreamEvent objects as they arrive
@@ -663,6 +670,9 @@ class ChatResource:
                 elif event.type == "done":
                     print(f"\\nCompleted in {event.metadata.total_time_ms}ms")
         """
+        # Use custom aggregator URL if provided, otherwise use default
+        effective_aggregator_url = (aggregator_url or self._aggregator_url).rstrip("/")
+
         model_ref = self._resolve_endpoint_ref(model, expected_type="model")
 
         ds_refs = []
@@ -690,7 +700,7 @@ class ChatResource:
         try:
             with self._agg_client.stream(
                 "POST",
-                f"{self._aggregator_url}/chat/stream",
+                f"{effective_aggregator_url}/chat/stream",
                 json=request_body,
                 headers={
                     "Content-Type": "application/json",

--- a/sdk/typescript/src/models/chat.ts
+++ b/sdk/typescript/src/models/chat.ts
@@ -143,6 +143,8 @@ export interface ChatOptions {
   similarityThreshold?: number;
   /** AbortSignal for request cancellation */
   signal?: AbortSignal;
+  /** Custom aggregator URL to use instead of the default */
+  aggregatorUrl?: string;
 }
 
 /**

--- a/sdk/typescript/src/resources/chat.ts
+++ b/sdk/typescript/src/resources/chat.ts
@@ -394,7 +394,9 @@ export class ChatResource {
       }
     );
 
-    const url = `${this.aggregatorUrl}/chat`;
+    // Use custom aggregator URL if provided, otherwise use default
+    const effectiveAggregatorUrl = (options.aggregatorUrl ?? this.aggregatorUrl).replace(/\/+$/, '');
+    const url = `${effectiveAggregatorUrl}/chat`;
 
     const response = await fetch(url, {
       method: 'POST',
@@ -483,7 +485,9 @@ export class ChatResource {
       }
     );
 
-    const url = `${this.aggregatorUrl}/chat/stream`;
+    // Use custom aggregator URL if provided, otherwise use default
+    const effectiveAggregatorUrl = (options.aggregatorUrl ?? this.aggregatorUrl).replace(/\/+$/, '');
+    const url = `${effectiveAggregatorUrl}/chat/stream`;
 
     const response = await fetch(url, {
       method: 'POST',


### PR DESCRIPTION
## Summary
This PR introduces support for a custom aggregator URL in user profiles, SDK, and frontend, enabling users to specify their own RAG/chat orchestration endpoints.

## Changes
- Added `aggregator_url` field to User model, schemas, and API.
- Updated repository to handle `aggregator_url` updates.
- Enhanced SDK's ChatResource to accept an optional `aggregator_url` parameter, overriding the default.
- Modified frontend components to configure, display, and manage custom aggregator URLs.
- Updated chat streaming and request endpoints to utilize the custom URL if provided.
- Added new "Aggregator" tab in user settings modal for easy configuration.

## Notes
- Defaults to the built-in aggregator if no custom URL is provided.
- Ensures backward compatibility with existing setups.
- Frontend and SDK modifications ensure flexible deployment for custom RAG services.