### PR TITLE
feat: Add aggregator_url field to user models and API

### DIFF
--- a/frontend/src/context/auth-context.tsx
+++ b/frontend/src/context/auth-context.tsx
@@ -131,7 +131,8 @@ function mapSdkUserToFrontend(sdkUser: SdkUser): User {
     is_active: sdkUser.isActive,
     created_at: sdkUser.createdAt.toISOString(),
     updated_at: sdkUser.updatedAt?.toISOString() ?? sdkUser.createdAt.toISOString(),
-    domain: sdkUser.domain ?? undefined
+    domain: sdkUser.domain ?? undefined,
+    aggregator_url: sdkUser.aggregatorUrl ?? undefined
   };
 }
 

--- a/frontend/src/lib/sdk-client.ts
+++ b/frontend/src/lib/sdk-client.ts
@@ -240,7 +240,8 @@ export async function updateUserProfileAPI(profileData: UserUpdate): Promise<Fro
     email: profileData.email,
     fullName: profileData.full_name,
     avatarUrl: profileData.avatar_url,
-    domain: profileData.domain
+    domain: profileData.domain,
+    aggregatorUrl: profileData.aggregator_url
   });
 
   // Convert SDK User to frontend User format
@@ -255,7 +256,8 @@ export async function updateUserProfileAPI(profileData: UserUpdate): Promise<Fro
     is_active: sdkUser.isActive,
     created_at: sdkUser.createdAt.toISOString(),
     updated_at: sdkUser.updatedAt?.toISOString() ?? sdkUser.createdAt.toISOString(),
-    domain: sdkUser.domain ?? undefined
+    domain: sdkUser.domain ?? undefined,
+    aggregator_url: sdkUser.aggregatorUrl ?? undefined
   };
 }
 

--- a/sdk/python/src/syfthub_sdk/models.py
+++ b/sdk/python/src/syfthub_sdk/models.py
@@ -53,6 +53,7 @@ class User(BaseModel):
     created_at: datetime
     updated_at: datetime | None = None  # Some endpoints don't return this
     domain: str | None = None  # Domain for endpoint URL construction
+    aggregator_url: str | None = None  # Custom aggregator URL for RAG/chat workflows
 
     model_config = {"frozen": True}
 

--- a/sdk/typescript/src/models/user.ts
+++ b/sdk/typescript/src/models/user.ts
@@ -15,6 +15,8 @@ export interface User {
   readonly updatedAt: Date | null;
   /** Domain for endpoint URL construction (e.g., "api.example.com" or "api.example.com:8080") */
   readonly domain: string | null;
+  /** Custom aggregator URL for RAG/chat workflows */
+  readonly aggregatorUrl: string | null;
 }
 
 /**
@@ -60,6 +62,8 @@ export interface UserUpdateInput {
   avatarUrl?: string;
   /** Domain for endpoint URL construction (no protocol, e.g., "api.example.com:8080") */
   domain?: string;
+  /** Custom aggregator URL for RAG/chat workflows */
+  aggregatorUrl?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
This update introduces the `aggregator_url` field to user models across the frontend, backend, and SDK, enabling support for custom aggregator URLs used in RAG/chat workflows.

## Changes
- Added `aggregator_url` property to the `User` model in Python SDK and TypeScript models.
- Updated user mapping functions in frontend to include `aggregator_url`.
- Extended `updateUserProfileAPI` to handle `aggregator_url` in profile updates.
- Added `aggregatorUrl` field in SDK user data structures for consistent handling.

## Notes
This enhancement facilitates the configuration of custom aggregator URLs for users, improving flexibility for RAG/chat integrations.