### PR TITLE
feat: Add batch sync endpoint for user endpoints

### DIFF
--- a/backend/src/syfthub/schemas/endpoint.py
+++ b/backend/src/syfthub/schemas/endpoint.py
@@ -453,6 +453,47 @@ class EndpointPublicResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+# ===========================================
+# SYNC ENDPOINT SCHEMAS
+# ===========================================
+
+
+class SyncValidationError(BaseModel):
+    """Validation error for a specific endpoint in sync batch."""
+
+    index: int = Field(..., ge=0, description="Index of endpoint in batch (0-based)")
+    field: str = Field(..., description="Field that failed validation")
+    error: str = Field(..., description="Error message")
+
+
+class SyncEndpointsRequest(BaseModel):
+    """Request schema for syncing user endpoints.
+
+    This operation replaces ALL user-owned endpoints with the provided list.
+    It is atomic: either all endpoints are synced, or none are (on validation failure).
+
+    Organization endpoints are NOT affected by this operation.
+    """
+
+    endpoints: List[EndpointCreate] = Field(
+        default_factory=list,
+        max_length=100,
+        description="List of endpoint specifications to sync (max 100)",
+    )
+
+
+class SyncEndpointsResponse(BaseModel):
+    """Response schema for sync operation."""
+
+    synced: int = Field(..., ge=0, description="Number of endpoints created")
+    deleted: int = Field(..., ge=0, description="Number of endpoints deleted")
+    endpoints: List[EndpointResponse] = Field(
+        ..., description="Created endpoints with full details"
+    )
+
+    model_config = {"from_attributes": True}
+
+
 def generate_slug_from_name(name: str) -> str:
     """Generate a URL-safe slug from endpoint name."""
     # Convert to lowercase and replace spaces/special chars with hyphens

--- a/sdk/python/src/syfthub_sdk/__init__.py
+++ b/sdk/python/src/syfthub_sdk/__init__.py
@@ -77,6 +77,7 @@ from syfthub_sdk.models import (
     SatelliteTokenResponse,
     SourceInfo,
     SourceStatus,
+    SyncEndpointsResponse,
     TokenUsage,
     Transaction,
     TransactionStatus,
@@ -131,6 +132,8 @@ __all__ = [
     "Transaction",
     "TransactionStatus",
     "CreatorType",
+    # Sync models
+    "SyncEndpointsResponse",
     # Exceptions
     "SyftHubError",
     "AuthenticationError",

--- a/sdk/python/src/syfthub_sdk/models.py
+++ b/sdk/python/src/syfthub_sdk/models.py
@@ -423,3 +423,24 @@ class Message(BaseModel):
     content: str = Field(..., description="Message content")
 
     model_config = {"frozen": True}
+
+
+# =============================================================================
+# Sync Endpoints Models
+# =============================================================================
+
+
+class SyncEndpointsResponse(BaseModel):
+    """Response from the sync endpoints operation.
+
+    Contains details about the sync operation including how many endpoints
+    were deleted, how many were created, and the full list of created endpoints.
+    """
+
+    synced: int = Field(..., ge=0, description="Number of endpoints created")
+    deleted: int = Field(..., ge=0, description="Number of endpoints deleted")
+    endpoints: list[Endpoint] = Field(
+        ..., description="List of created endpoints with full details"
+    )
+
+    model_config = {"frozen": True}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -106,6 +106,7 @@ export type {
   EndpointPublic,
   EndpointCreateInput,
   EndpointUpdateInput,
+  SyncEndpointsResponse,
   // Accounting types
   AccountingUser,
   Transaction,

--- a/sdk/typescript/src/models/endpoint.ts
+++ b/sdk/typescript/src/models/endpoint.ts
@@ -117,3 +117,18 @@ export function getEndpointOwnerType(endpoint: Endpoint): 'user' | 'organization
 export function getEndpointPublicPath(endpoint: EndpointPublic): string {
   return `${endpoint.ownerUsername}/${endpoint.slug}`;
 }
+
+/**
+ * Response from the sync endpoints operation.
+ *
+ * Contains details about the sync operation including how many endpoints
+ * were deleted, how many were created, and the full list of created endpoints.
+ */
+export interface SyncEndpointsResponse {
+  /** Number of endpoints created */
+  readonly synced: number;
+  /** Number of endpoints deleted */
+  readonly deleted: number;
+  /** List of created endpoints with full details */
+  readonly endpoints: readonly Endpoint[];
+}

--- a/sdk/typescript/src/models/index.ts
+++ b/sdk/typescript/src/models/index.ts
@@ -24,6 +24,7 @@ export type {
   EndpointPublic,
   EndpointCreateInput,
   EndpointUpdateInput,
+  SyncEndpointsResponse,
 } from './endpoint.js';
 
 // Endpoint helpers


### PR DESCRIPTION
## Summary
This update introduces a new API endpoint and client method to synchronize a user's endpoints in an atomic operation, replacing all existing user-owned endpoints with a provided list.

## Changes
- Added `/sync` POST endpoint in the API to handle batch synchronization.
- Implemented `sync_user_endpoints` method in `EndpointService` for validation and transaction handling.
- Added `delete_all_user_endpoints` and `bulk_create_endpoints` methods in `EndpointRepository` for atomic database operations.
- Defined new schemas: `SyncEndpointsRequest`, `SyncEndpointsResponse`, and `SyncValidationError`.
- Updated SDK with `SyncEndpointsResponse` model and `sync` method in `MyEndpoints` class.
- Extended TypeScript and Python SDKs to include the new `sync` method and response types.
- Added comprehensive tests covering success, validation, atomicity, max batch size, and edge cases.

**This feature ensures users can reliably replace all their endpoints in one atomic operation, improving efficiency and consistency.**

## Notes
- Validation occurs before any database changes to ensure atomicity.
- Batch size is limited to 100 endpoints.
- Validation errors are returned with detailed information for each invalid endpoint.
- Existing endpoints are fully replaced; stars are reset, and IDs will change.