### PR TITLE
fix: Update MCP installation command in build view

### DIFF
--- a/frontend/src/components/build-view.tsx
+++ b/frontend/src/components/build-view.tsx
@@ -299,11 +299,11 @@ for await (const ep of client.myEndpoints.list()) {
 
                 <Section
                   title='Claude Code MCP Installation'
-                  description='Install SyftHub MCP server for Claude Code CLI.'
+                  description='Add SyftHub MCP server to Claude Code CLI.'
                   icon={<Terminal className='h-5 w-5' />}
                 >
                   <CodeBlock
-                    code={`claude mcp install https://syfthub.openmined.org/mcp`}
+                    code={`claude mcp add --transport http syfthub https://syfthub.openmined.org/mcp`}
                     language='bash'
                   />
                 </Section>


### PR DESCRIPTION
## Summary
This PR updates the MCP installation instructions in the build view component to reflect the correct command syntax for adding the SyftHub MCP server.

## Changes
- Changed the description text for MCP installation to improve clarity.
- Updated the code snippet to use the correct command: `claude mcp add --transport http syfthub https://syfthub.openmined.org/mcp`.

## Notes
These changes ensure users follow the correct procedure for integrating the MCP server with Claude Code CLI.