### PR TITLE
feat: Improve no-match handling with relevance threshold filtering

### DIFF
--- a/frontend/src/components/chat/no-match-message.tsx
+++ b/frontend/src/components/chat/no-match-message.tsx
@@ -1,153 +1,33 @@
 /**
  * NoMatchMessage - AI assistant response for no relevant search results
  *
- * Displays a helpful message when semantic search doesn't find
- * highly relevant data sources for the user's query.
+ * Displays a clean AI assistant-style message when semantic search doesn't find
+ * any data sources with similarity score >= 0.5 for the user's query.
  */
 
-import type { ChatSource } from '@/lib/types';
-
 import { motion } from 'framer-motion';
-import AlertCircle from 'lucide-react/dist/esm/icons/alert-circle';
 import Compass from 'lucide-react/dist/esm/icons/compass';
-import Lightbulb from 'lucide-react/dist/esm/icons/lightbulb';
+import MessageSquare from 'lucide-react/dist/esm/icons/message-square';
 import Plus from 'lucide-react/dist/esm/icons/plus';
-import RefreshCw from 'lucide-react/dist/esm/icons/refresh-cw';
-
-import { Badge } from '@/components/ui/badge';
 
 interface NoMatchMessageProps {
   /** The original search query */
   query: string;
-  /** Loosely related sources (relevance 0.3-0.5) to show as secondary options */
-  looseMatches?: ChatSource[];
-  /** Callback when user selects a loose match */
-  onSelectLooseMatch?: (source: ChatSource) => void;
   /** Callback when user wants to browse catalog */
   onBrowseCatalog?: () => void;
   /** Callback when user wants to add custom source */
   onAddCustomSource?: () => void;
-  /** Callback when user wants to refine query */
-  onRefineQuery?: () => void;
-}
-
-interface SuggestionAction {
-  icon: React.ReactNode;
-  label: string;
-  description: string;
-  onClick?: () => void;
 }
 
 /**
- * Action button for suggested actions.
- */
-function ActionButton({
-  icon,
-  label,
-  description,
-  onClick
-}: Readonly<SuggestionAction & { onClick?: () => void }>) {
-  return (
-    <button
-      type='button'
-      onClick={onClick}
-      className='border-border bg-card hover:bg-accent group flex w-full items-start gap-3 rounded-lg border p-3 text-left transition-colors'
-    >
-      <div className='bg-muted group-hover:bg-primary/10 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors'>
-        {icon}
-      </div>
-      <div className='min-w-0 flex-1'>
-        <span className='font-inter text-foreground block text-sm font-medium'>{label}</span>
-        <span className='font-inter text-muted-foreground text-xs'>{description}</span>
-      </div>
-    </button>
-  );
-}
-
-/**
- * Compact source card for loose matches.
- */
-function LooseMatchCard({
-  source,
-  onSelect
-}: Readonly<{ source: ChatSource; onSelect: () => void }>) {
-  const relevanceScore = (source as ChatSource & { relevance_score?: number }).relevance_score;
-
-  return (
-    <button
-      type='button'
-      onClick={onSelect}
-      className='border-border bg-card hover:border-primary/50 hover:bg-accent/50 flex w-full items-center gap-3 rounded-lg border p-3 text-left transition-colors'
-    >
-      <div className='bg-muted flex h-8 w-8 shrink-0 items-center justify-center rounded-lg'>
-        <span className='font-inter text-muted-foreground text-xs font-medium'>
-          {source.name.slice(0, 2).toUpperCase()}
-        </span>
-      </div>
-      <div className='min-w-0 flex-1'>
-        <span className='font-inter text-foreground block truncate text-sm font-medium'>
-          {source.name}
-        </span>
-        <span className='font-inter text-muted-foreground block truncate text-xs'>
-          {source.description.slice(0, 60)}
-          {source.description.length > 60 ? '...' : ''}
-        </span>
-      </div>
-      {relevanceScore !== undefined && (
-        <Badge variant='secondary' className='font-inter h-5 shrink-0 px-2 text-[10px] font-normal'>
-          {Math.round(relevanceScore * 100)}% match
-        </Badge>
-      )}
-    </button>
-  );
-}
-
-/**
- * Main component for displaying "no match" message.
+ * Main component for displaying "no match" message as an AI assistant response.
  */
 export function NoMatchMessage({
   query,
-  looseMatches = [],
-  onSelectLooseMatch,
   onBrowseCatalog,
-  onAddCustomSource,
-  onRefineQuery
+  onAddCustomSource
 }: Readonly<NoMatchMessageProps>) {
-  const hasLooseMatches = looseMatches.length > 0;
-  const truncatedQuery = query.length > 50 ? `${query.slice(0, 50)}...` : query;
-
-  const actions: SuggestionAction[] = [
-    ...(onBrowseCatalog
-      ? [
-          {
-            icon: <Compass className='text-muted-foreground h-4 w-4' />,
-            label: 'Browse catalog',
-            description: 'Explore all available data sources',
-            onClick: onBrowseCatalog
-          }
-        ]
-      : []),
-    ...(onAddCustomSource
-      ? [
-          {
-            icon: <Plus className='text-muted-foreground h-4 w-4' />,
-            label: 'Add custom source',
-            description: 'Enter an endpoint path directly',
-            onClick: onAddCustomSource
-          }
-        ]
-      : []),
-    ...(onRefineQuery
-      ? [
-          {
-            icon: <RefreshCw className='text-muted-foreground h-4 w-4' />,
-            label: 'Refine your query',
-            description: 'Try different keywords or be more specific',
-            onClick: onRefineQuery
-          }
-        ]
-      : [])
-  ];
+  const truncatedQuery = query.length > 60 ? `${query.slice(0, 60)}...` : query;
 
   return (
     <motion.div
@@ -157,62 +37,48 @@ export function NoMatchMessage({
       transition={{ duration: 0.2 }}
       className='my-4 w-full max-w-3xl'
     >
-      {/* Main message card */}
+      {/* AI Assistant style message card */}
       <div className='border-border bg-muted/30 overflow-hidden rounded-xl border'>
-        {/* Header */}
-        <div className='border-border flex items-start gap-3 border-b px-4 py-3'>
-          <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-amber-100 dark:bg-amber-900/30'>
-            <AlertCircle className='h-4 w-4 text-amber-600 dark:text-amber-400' />
+        {/* Message header with assistant icon */}
+        <div className='flex items-start gap-3 px-4 py-4'>
+          <div className='bg-primary/10 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg'>
+            <MessageSquare className='text-primary h-4 w-4' />
           </div>
           <div className='min-w-0 flex-1'>
-            <h3 className='font-inter text-foreground text-sm font-medium'>
-              No relevant endpoints found
-            </h3>
-            <p className='font-inter text-muted-foreground mt-0.5 text-xs'>
-              We couldn&apos;t find any data sources related to &ldquo;{truncatedQuery}&rdquo;.
+            <p className='font-inter text-foreground text-sm leading-relaxed'>
+              I couldn&apos;t find any relevant data sources for your query about &ldquo;
+              {truncatedQuery}&rdquo;.
+            </p>
+            <p className='font-inter text-muted-foreground mt-2 text-sm'>
+              You can browse our catalog to discover available endpoints, or add a custom source
+              directly.
             </p>
           </div>
         </div>
 
-        {/* Suggestions */}
-        <div className='p-4'>
-          <div className='mb-3 flex items-center gap-2'>
-            <Lightbulb className='text-muted-foreground h-3.5 w-3.5' />
-            <span className='font-inter text-muted-foreground text-xs font-medium'>
-              Here&apos;s what you can do:
-            </span>
-          </div>
-
-          <div className='grid gap-2'>
-            {actions.map((action) => (
-              <ActionButton
-                key={action.label}
-                icon={action.icon}
-                label={action.label}
-                description={action.description}
-                onClick={action.onClick}
-              />
-            ))}
-          </div>
-        </div>
-
-        {/* Loose matches section (if available) */}
-        {hasLooseMatches ? (
-          <div className='border-border border-t px-4 py-3'>
-            <div className='mb-3'>
-              <span className='font-inter text-muted-foreground text-xs font-medium'>
-                Loosely related sources ({looseMatches.length}):
-              </span>
-            </div>
-            <div className='grid gap-2'>
-              {looseMatches.slice(0, 3).map((source) => (
-                <LooseMatchCard
-                  key={source.id}
-                  source={source}
-                  onSelect={() => onSelectLooseMatch?.(source)}
-                />
-              ))}
-            </div>
+        {/* Action buttons */}
+        {(onBrowseCatalog ?? onAddCustomSource) ? (
+          <div className='border-border flex gap-2 border-t px-4 py-3'>
+            {onBrowseCatalog ? (
+              <button
+                type='button'
+                onClick={onBrowseCatalog}
+                className='border-border bg-background hover:bg-accent inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition-colors'
+              >
+                <Compass className='h-4 w-4' />
+                Browse catalog
+              </button>
+            ) : null}
+            {onAddCustomSource ? (
+              <button
+                type='button'
+                onClick={onAddCustomSource}
+                className='border-border bg-background hover:bg-accent inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition-colors'
+              >
+                <Plus className='h-4 w-4' />
+                Add custom source
+              </button>
+            ) : null}
           </div>
         ) : null}
       </div>
@@ -223,10 +89,7 @@ export function NoMatchMessage({
 /**
  * Simplified message variant for inline display.
  */
-export function NoMatchMessageInline({
-  query,
-  onRefineQuery
-}: Readonly<{ query: string; onRefineQuery?: () => void }>) {
+export function NoMatchMessageInline({ query }: Readonly<{ query: string }>) {
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -234,16 +97,11 @@ export function NoMatchMessageInline({
       exit={{ opacity: 0 }}
       className='font-inter text-muted-foreground flex items-center gap-2 py-2 text-sm'
     >
-      <AlertCircle className='h-4 w-4 text-amber-500' />
+      <MessageSquare className='text-primary h-4 w-4' />
       <span>
         No relevant endpoints found for &ldquo;{query.slice(0, 30)}
         {query.length > 30 ? '...' : ''}&rdquo;
       </span>
-      {onRefineQuery ? (
-        <button type='button' onClick={onRefineQuery} className='text-primary hover:underline'>
-          Try again
-        </button>
-      ) : null}
     </motion.div>
   );
 }

--- a/frontend/src/lib/search-service.ts
+++ b/frontend/src/lib/search-service.ts
@@ -65,11 +65,8 @@ export interface SearchOptions {
 // Constants
 // ============================================================================
 
-/** Minimum relevance score for "high confidence" results */
+/** Minimum relevance score for results to be shown (0.5 threshold) */
 export const HIGH_RELEVANCE_THRESHOLD = 0.5;
-
-/** Minimum relevance score for "loose match" results */
-export const LOOSE_RELEVANCE_THRESHOLD = 0.3;
 
 /** Minimum query length to trigger search */
 export const MIN_QUERY_LENGTH = 3;
@@ -204,27 +201,23 @@ export function filterByRelevance(
 }
 
 /**
- * Categorize search results into high/loose relevance groups.
+ * Filter search results to only include high relevance matches (>= 0.5 threshold).
+ *
+ * Results below the threshold are filtered out completely - they are not shown
+ * to the user. If no results meet the threshold, the UI should show a "no match"
+ * message instead.
  *
  * @param results - Search results with relevance scores
- * @returns Object with high and loose relevance result arrays
+ * @returns Object with high relevance result array (only results >= 0.5)
  */
 export function categorizeResults(results: SearchableChatSource[]): {
   highRelevance: SearchableChatSource[];
-  looseRelevance: SearchableChatSource[];
 } {
-  const highRelevance: SearchableChatSource[] = [];
-  const looseRelevance: SearchableChatSource[] = [];
+  const highRelevance = results.filter(
+    (result) => result.relevance_score >= HIGH_RELEVANCE_THRESHOLD
+  );
 
-  for (const result of results) {
-    if (result.relevance_score >= HIGH_RELEVANCE_THRESHOLD) {
-      highRelevance.push(result);
-    } else if (result.relevance_score >= LOOSE_RELEVANCE_THRESHOLD) {
-      looseRelevance.push(result);
-    }
-  }
-
-  return { highRelevance, looseRelevance };
+  return { highRelevance };
 }
 
 /**


### PR DESCRIPTION
## Summary
Refactored the no-match message logic to filter search results by a relevance score threshold of 0.5, ensuring only highly relevant results are considered. Results below this threshold are now excluded from no-match scenarios, simplifying the UI flow and emphasizing high-confidence matches.

## Changes
- Removed `looseMatches` property from `Message` interface and related code.
- Updated `categorizeResults` to only include high relevance results (>= 0.5).
- Modified `ChatView` to use the filtered results for no-match messages.
- Changed `NoMatchMessage` component to no longer handle loose matches.
- Updated `search-service.ts` to filter results based on relevance threshold.

## Notes
This change enhances the clarity of no-match messaging by focusing on results with a relevance score of at least 0.5, reducing user confusion from loosely related results.