### PR TITLE
feat: Add handling for guest satellite tokens

### DIFF
--- a/backend/src/syfthub/api/endpoints/token.py
+++ b/backend/src/syfthub/api/endpoints/token.py
@@ -500,6 +500,20 @@ async def verify_satellite_token(
             message="Token is missing 'sub' claim.",
         )
 
+    # Handle guest tokens: sub="guest" is a valid guest satellite token
+    # Guest tokens are issued for unauthenticated access to policy-free endpoints
+    if user_id == "guest":
+        return TokenVerifySuccessResponse(
+            valid=True,
+            sub="guest",
+            email="guest",
+            username="guest",
+            role="guest",
+            aud=result.payload.get("aud", authorized_audience),
+            exp=result.payload.get("exp", 0),
+            iat=result.payload.get("iat", 0),
+        )
+
     # Look up user in database
     try:
         user = user_repo.get_by_id(int(user_id))


### PR DESCRIPTION
## Summary
This PR updates the satellite token verification logic to support guest tokens with sub="guest". Guest tokens are now recognized as valid for unauthenticated access to policy-free endpoints.

## Changes
- Added a check for sub="guest" in the verify_satellite_token function
- Returns a successful token verification response with guest role and identifiers when sub="guest"

## Notes
This enhancement allows unauthenticated users to access certain endpoints without requiring a full user authentication.