### PR TITLE
feat: Add default https:// protocol for URL building and domain input

### DIFF
--- a/backend/src/syfthub/core/url_builder.py
+++ b/backend/src/syfthub/core/url_builder.py
@@ -70,6 +70,10 @@ def build_connection_url(
     if not base_url:
         return None
 
+    # Defensive: ensure protocol is present (default to https://)
+    if not base_url.startswith(("http://", "https://", "ws://", "wss://")):
+        base_url = f"https://{base_url}"
+
     # For WebSocket connection types, upgrade protocol
     if connection_type.lower() in _WEBSOCKET_TYPES:
         base_url = base_url.replace("https://", "wss://", 1).replace(

--- a/backend/tests/test_url_builder.py
+++ b/backend/tests/test_url_builder.py
@@ -145,6 +145,21 @@ class TestBuildConnectionUrl:
         result = build_connection_url("https://example.com", "wss", "path")
         assert result == "wss://example.com/path"
 
+    def test_build_url_defaults_to_https_when_no_protocol(self):
+        """Test that bare domain defaults to https:// protocol."""
+        result = build_connection_url("api.example.com", "rest_api", "v1")
+        assert result == "https://api.example.com/v1"
+
+    def test_build_url_bare_domain_with_port_defaults_to_https(self):
+        """Test that bare domain with port defaults to https://."""
+        result = build_connection_url("192.168.1.1:8080", "rest_api", "v1")
+        assert result == "https://192.168.1.1:8080/v1"
+
+    def test_build_url_bare_domain_websocket_defaults_to_wss(self):
+        """Test that bare domain with websocket type gets wss://."""
+        result = build_connection_url("ws.example.com", "websocket", "socket")
+        assert result == "wss://ws.example.com/socket"
+
 
 class TestTransformConnectionUrls:
     """Tests for transform_connection_urls function."""

--- a/frontend/src/components/settings/profile-settings-tab.tsx
+++ b/frontend/src/components/settings/profile-settings-tab.tsx
@@ -213,9 +213,13 @@ export function ProfileSettingsTab() {
       updates.avatar_url = formData.avatar_url.trim();
     }
     if (formData.domain !== (user?.domain ?? '')) {
-      // Strip protocol if user accidentally included it
       let domainValue = formData.domain.trim();
-      domainValue = domainValue.replace(/^https?:\/\//, '');
+      // Ensure protocol is present — default to https:// if omitted
+      if (domainValue && !/^https?:\/\//.test(domainValue)) {
+        domainValue = `https://${domainValue}`;
+      }
+      // Strip trailing slashes
+      domainValue = domainValue.replace(/\/+$/, '');
       updates.domain = domainValue;
     }
 
@@ -468,12 +472,12 @@ export function ProfileSettingsTab() {
               id='domain'
               value={formData.domain}
               onChange={handleInputChange('domain')}
-              placeholder='api.example.com or api.example.com:8080'
+              placeholder='https://api.example.com'
               disabled={isLoading}
             />
             <p className='text-muted-foreground text-xs'>
-              Enter the base domain for your endpoints without the protocol (https:// will be added
-              automatically).
+              Enter the base domain for your endpoints including the protocol (e.g.,
+              https://api.example.com). If omitted, https:// is assumed.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
This update ensures that URLs and domain inputs default to using the https:// protocol when omitted, improving URL handling robustness.

## Changes
- Adds a check in `build_connection_url` to prepend https:// if no protocol is present.
- Enhances domain input handling in the profile settings to automatically add https:// if missing.
- Updates test cases to verify default protocol behavior for URL building.
- Modifies user interface placeholder and instructions to clarify protocol expectations.

## Notes
These improvements help prevent URL misconfigurations and streamline user input for domain fields.