### PR TITLE
feat: Add PostgreSQL advisory lock for multi-worker health checks

### DIFF
--- a/backend/src/syfthub/jobs/__init__.py
+++ b/backend/src/syfthub/jobs/__init__.py
@@ -7,6 +7,6 @@ Jobs:
 - health_monitor: Periodic endpoint health checking
 """
 
-from syfthub.jobs.health_monitor import EndpointHealthMonitor
+from syfthub.jobs.health_monitor import HEALTH_MONITOR_LOCK_ID, EndpointHealthMonitor
 
-__all__ = ["EndpointHealthMonitor"]
+__all__ = ["HEALTH_MONITOR_LOCK_ID", "EndpointHealthMonitor"]


### PR DESCRIPTION
## Summary
This update introduces a PostgreSQL advisory lock mechanism to ensure that in multi-worker deployments only one worker performs the health check cycle at a time, preventing redundant checks and flapping.

## Changes
- Added `_try_acquire_cycle_lock` method to `EndpointHealthMonitor` to acquire a PostgreSQL advisory lock.
- Integrated lock acquisition into `run_health_check_cycle` to skip the cycle if another worker holds the lock.
- Updated documentation to explain multi-worker safety with advisory locks.
- Extended tests to cover lock acquisition logic, including PostgreSQL-specific behavior, error handling, and lock ID usage.

## Notes
This implementation ensures safe concurrent execution of health checks across multiple workers by leveraging PostgreSQL's `pg_try_advisory_lock`. It gracefully skips the cycle if the lock cannot be acquired, and the lock is released automatically when the session ends.