### PR TITLE
feat: Add onboarding overlay and store

### DIFF
--- a/frontend/src/components/auth/register-modal.tsx
+++ b/frontend/src/components/auth/register-modal.tsx
@@ -16,6 +16,7 @@ import { useAuth } from '@/context/auth-context';
 import { registerSchema } from '@/lib/schemas';
 import { AccountingAccountExistsError } from '@/lib/sdk-client';
 import { getPasswordStrength } from '@/lib/validation';
+import { useOnboardingStore } from '@/stores/onboarding-store';
 
 import { AuthErrorAlert, AuthLoadingOverlay } from './auth-utils';
 
@@ -70,6 +71,7 @@ export function RegisterModal({
         accountingPassword: data.accountingPassword || undefined
       });
       onClose();
+      useOnboardingStore.getState().startOnboarding();
     } catch (error_) {
       if (error_ instanceof AccountingAccountExistsError) {
         setRequiresAccountingPassword(true);

--- a/frontend/src/components/balance/balance-indicator.tsx
+++ b/frontend/src/components/balance/balance-indicator.tsx
@@ -12,6 +12,7 @@ import Settings from 'lucide-react/dist/esm/icons/settings';
 import { useAccountingContext } from '@/context/accounting-context';
 import { useAccountingUser, useTransactions } from '@/hooks/use-accounting-api';
 import { cn } from '@/lib/utils';
+import { useOnboardingStore } from '@/stores/onboarding-store';
 import { useSettingsModalStore } from '@/stores/settings-modal-store';
 
 import {
@@ -46,6 +47,21 @@ export function BalanceIndicator() {
     refetch: refetchTransactions
   } = useTransactions({ pageSize: 5, autoFetch: isConfigured });
   const { openSettings } = useSettingsModalStore();
+  const { hasCompletedOnboarding, hasCompletedFirstQuery } = useOnboardingStore();
+  const [showCallout, setShowCallout] = useState(false);
+
+  // Show callout when onboarding is completed but first query hasn't been done
+  useEffect(() => {
+    if (hasCompletedOnboarding && !hasCompletedFirstQuery && isConfigured) {
+      setShowCallout(true);
+      const timer = setTimeout(() => {
+        setShowCallout(false);
+      }, 5000);
+      return () => {
+        clearTimeout(timer);
+      };
+    }
+  }, [hasCompletedOnboarding, hasCompletedFirstQuery, isConfigured]);
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -181,6 +197,26 @@ export function BalanceIndicator() {
           )}
         />
       </button>
+
+      {/* Onboarding Callout Tooltip */}
+      <AnimatePresence>
+        {showCallout && !isOpen ? (
+          <motion.div
+            initial={{ opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.2 }}
+            className={cn(
+              'absolute top-full left-1/2 z-50 mt-2 -translate-x-1/2 whitespace-nowrap',
+              'bg-primary text-primary-foreground rounded-lg px-3 py-2 text-xs font-medium shadow-lg'
+            )}
+            role='tooltip'
+          >
+            <div className='bg-primary absolute -top-1 left-1/2 h-2 w-2 -translate-x-1/2 rotate-45' />
+            Your credit balance lives here
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
 
       {/* Dropdown */}
       <AnimatePresence>

--- a/frontend/src/components/build/code-block.tsx
+++ b/frontend/src/components/build/code-block.tsx
@@ -1,0 +1,121 @@
+import React, { memo, Suspense, useCallback, useState } from 'react';
+
+import Check from 'lucide-react/dist/esm/icons/check';
+import Copy from 'lucide-react/dist/esm/icons/copy';
+import { PrismLight as SyntaxHighlighterBase } from 'react-syntax-highlighter';
+import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash';
+import json from 'react-syntax-highlighter/dist/esm/languages/prism/json';
+import python from 'react-syntax-highlighter/dist/esm/languages/prism/python';
+import typescript from 'react-syntax-highlighter/dist/esm/languages/prism/typescript';
+
+import { Button } from '@/components/ui/button';
+
+// Register languages for syntax highlighting (prism-light requires explicit registration)
+SyntaxHighlighterBase.registerLanguage('bash', bash);
+SyntaxHighlighterBase.registerLanguage('python', python);
+SyntaxHighlighterBase.registerLanguage('typescript', typescript);
+SyntaxHighlighterBase.registerLanguage('json', json);
+
+// Wrap in lazy for code-splitting (the component itself is small, languages are registered above)
+const SyntaxHighlighter = React.lazy(() => Promise.resolve({ default: SyntaxHighlighterBase }));
+
+// Lazy load the style - will be loaded alongside SyntaxHighlighter
+const loadStyle = () =>
+  import('react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus').then(
+    (module_) => module_.default
+  );
+
+export interface CodeBlockProps {
+  code: string;
+  language: string;
+}
+
+// Memoized CodeBlock component with lazy-loaded syntax highlighter
+export const CodeBlock = memo(function CodeBlock({ code, language }: Readonly<CodeBlockProps>) {
+  const [copied, setCopied] = useState(false);
+  const [style, setStyle] = useState<Record<string, React.CSSProperties> | null>(null);
+
+  // Load style on mount using lazy initialization
+  React.useEffect(() => {
+    let mounted = true;
+    void loadStyle().then((loadedStyle) => {
+      if (mounted) setStyle(loadedStyle);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const copyToClipboard = useCallback(() => {
+    void navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  }, [code]);
+
+  // Custom style to match the existing dark theme
+  const customStyle = React.useMemo(() => {
+    if (!style) return {};
+    return {
+      ...style,
+      'pre[class*="language-"]': {
+        ...(style['pre[class*="language-"]'] as React.CSSProperties | undefined),
+        background: 'transparent',
+        margin: 0,
+        padding: 0,
+        fontSize: '14px',
+        lineHeight: '1.5'
+      },
+      'code[class*="language-"]': {
+        ...(style['code[class*="language-"]'] as React.CSSProperties | undefined),
+        background: 'transparent',
+        fontSize: '14px',
+        lineHeight: '1.5'
+      }
+    };
+  }, [style]);
+
+  return (
+    <div className='group border-border relative overflow-hidden rounded-xl border bg-[#1a1923]'>
+      <div className='absolute top-2 right-2 opacity-0 transition-opacity group-hover:opacity-100'>
+        <Button
+          variant='ghost'
+          size='icon'
+          className='text-muted-foreground h-8 w-8 hover:bg-white/10 hover:text-white'
+          onClick={copyToClipboard}
+        >
+          {copied ? <Check className='h-4 w-4' /> : <Copy className='h-4 w-4' />}
+        </Button>
+      </div>
+      <div className='flex items-center justify-between border-b border-white/5 bg-[#131219] px-4 py-2'>
+        <span className='text-muted-foreground font-mono text-xs'>{language}</span>
+      </div>
+      <div className='overflow-x-auto p-4'>
+        <Suspense fallback={<pre className='text-muted-foreground font-mono text-sm'>{code}</pre>}>
+          {style ? (
+            <SyntaxHighlighter
+              language={language}
+              style={customStyle}
+              customStyle={{
+                background: 'transparent',
+                padding: 0,
+                margin: 0
+              }}
+              codeTagProps={{
+                style: {
+                  fontSize: '14px',
+                  lineHeight: '1.5'
+                }
+              }}
+            >
+              {code}
+            </SyntaxHighlighter>
+          ) : (
+            <pre className='text-muted-foreground font-mono text-sm'>{code}</pre>
+          )}
+        </Suspense>
+      </div>
+    </div>
+  );
+});

--- a/frontend/src/components/build/info-card.tsx
+++ b/frontend/src/components/build/info-card.tsx
@@ -1,0 +1,31 @@
+import { memo } from 'react';
+
+import Check from 'lucide-react/dist/esm/icons/check';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export interface InfoCardProps {
+  title: string;
+  items: string[];
+}
+
+// Memoized InfoCard component
+export const InfoCard = memo(function InfoCard({ title, items }: Readonly<InfoCardProps>) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className='text-sm font-medium'>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className='space-y-2'>
+          {items.map((item, index) => (
+            <li key={index} className='text-muted-foreground flex items-center gap-2 text-sm'>
+              <Check className='h-4 w-4 text-green-500' />
+              {item}
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+});

--- a/frontend/src/components/build/resource-link.tsx
+++ b/frontend/src/components/build/resource-link.tsx
@@ -1,0 +1,26 @@
+import { memo } from 'react';
+
+import ArrowRight from 'lucide-react/dist/esm/icons/arrow-right';
+
+export interface ResourceLinkProps {
+  label: string;
+  href: string;
+}
+
+// Memoized ResourceLink component
+export const ResourceLink = memo(function ResourceLink({
+  label,
+  href
+}: Readonly<ResourceLinkProps>) {
+  return (
+    <a
+      href={href}
+      target='_blank'
+      rel='noopener noreferrer'
+      className='text-muted-foreground hover:bg-muted hover:text-foreground flex items-center justify-between rounded p-2 text-sm transition-colors'
+    >
+      {label}
+      <ArrowRight className='h-4 w-4 opacity-50' />
+    </a>
+  );
+});

--- a/frontend/src/components/build/section.tsx
+++ b/frontend/src/components/build/section.tsx
@@ -1,0 +1,29 @@
+import React, { memo } from 'react';
+
+export interface SectionProps {
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}
+
+// Memoized Section component to prevent unnecessary re-renders
+export const Section = memo(function Section({
+  title,
+  description,
+  icon,
+  children
+}: Readonly<SectionProps>) {
+  return (
+    <div className='space-y-4'>
+      <div className='flex items-start gap-3'>
+        <div className='border-border text-foreground bg-card rounded-lg border p-2'>{icon}</div>
+        <div>
+          <h3 className='text-foreground text-lg font-medium'>{title}</h3>
+          <p className='text-muted-foreground text-sm'>{description}</p>
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+});

--- a/frontend/src/components/onboarding/chat-empty-state.tsx
+++ b/frontend/src/components/onboarding/chat-empty-state.tsx
@@ -1,0 +1,123 @@
+import { motion } from 'framer-motion';
+import Database from 'lucide-react/dist/esm/icons/database';
+import Search from 'lucide-react/dist/esm/icons/search';
+import Send from 'lucide-react/dist/esm/icons/send';
+import Shield from 'lucide-react/dist/esm/icons/shield';
+
+import { cn } from '@/lib/utils';
+
+const SUGGESTIONS = [
+  {
+    label: 'What datasets are available?',
+    icon: Database
+  },
+  {
+    label: 'Search for health statistics in the US',
+    icon: Search
+  },
+  {
+    label: 'Find population data by country',
+    icon: Search
+  },
+  {
+    label: 'How does privacy-preserving querying work?',
+    icon: Shield
+  }
+];
+
+const STEPS = [
+  { number: '1', title: 'Ask a question', description: 'Type any query in the input below.' },
+  {
+    number: '2',
+    title: 'Sources are matched',
+    description: 'SyftHub finds the best data sources for your query.'
+  },
+  {
+    number: '3',
+    title: 'Get your answer',
+    description: 'Results are aggregated and returned to you privately.'
+  }
+];
+
+interface ChatEmptyStateProperties {
+  onSuggestionClick: (query: string) => void;
+}
+
+export function ChatEmptyState({ onSuggestionClick }: Readonly<ChatEmptyStateProperties>) {
+  return (
+    <div className='flex flex-col items-center justify-center px-4 py-12'>
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+        className='w-full max-w-2xl space-y-10'
+      >
+        {/* Heading */}
+        <div className='text-center'>
+          <h2 className='font-rubik text-foreground text-2xl font-semibold'>Ask Anything</h2>
+          <p className='font-inter text-muted-foreground mt-2 text-sm'>
+            Query multiple privacy-preserving data sources with a single question.
+          </p>
+        </div>
+
+        {/* Suggestion Cards - 2x2 grid */}
+        <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
+          {SUGGESTIONS.map((suggestion, index) => {
+            const Icon = suggestion.icon;
+            return (
+              <motion.button
+                key={suggestion.label}
+                type='button'
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.1 + index * 0.05, duration: 0.25 }}
+                onClick={() => {
+                  onSuggestionClick(suggestion.label);
+                }}
+                className={cn(
+                  'group flex items-start gap-3 rounded-xl border p-4 text-left transition-colors',
+                  'border-border bg-muted/40 hover:bg-muted hover:border-input',
+                  'dark:bg-muted/20 dark:hover:bg-muted/40',
+                  'focus:ring-ring/20 focus:ring-2 focus:outline-none'
+                )}
+              >
+                <div className='bg-primary/10 group-hover:bg-primary/20 mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors'>
+                  <Icon className='text-primary h-4 w-4' aria-hidden='true' />
+                </div>
+                <div className='flex items-center gap-2'>
+                  <span className='font-inter text-foreground text-sm leading-snug'>
+                    {suggestion.label}
+                  </span>
+                  <Send
+                    className='text-muted-foreground h-3 w-3 shrink-0 opacity-0 transition-opacity group-hover:opacity-100'
+                    aria-hidden='true'
+                  />
+                </div>
+              </motion.button>
+            );
+          })}
+        </div>
+
+        {/* How it works */}
+        <div className='space-y-4'>
+          <h3 className='font-rubik text-muted-foreground text-center text-xs font-medium tracking-wide uppercase'>
+            How it works
+          </h3>
+          <div className='grid grid-cols-1 gap-4 sm:grid-cols-3'>
+            {STEPS.map((step) => (
+              <div key={step.number} className='flex flex-col items-center text-center'>
+                <div className='bg-primary text-primary-foreground font-rubik mb-2 flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold'>
+                  {step.number}
+                </div>
+                <span className='font-rubik text-foreground text-sm font-medium'>{step.title}</span>
+                <span className='font-inter text-muted-foreground mt-1 text-xs leading-relaxed'>
+                  {step.description}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/frontend/src/components/onboarding/index.ts
+++ b/frontend/src/components/onboarding/index.ts
@@ -1,0 +1,2 @@
+export { ChatEmptyState } from './chat-empty-state';
+export { WelcomeOverlay } from './welcome-overlay';

--- a/frontend/src/components/onboarding/welcome-overlay.tsx
+++ b/frontend/src/components/onboarding/welcome-overlay.tsx
@@ -1,0 +1,93 @@
+import { motion } from 'framer-motion';
+import Coins from 'lucide-react/dist/esm/icons/coins';
+import MessageSquare from 'lucide-react/dist/esm/icons/message-square';
+
+import { Button } from '@/components/ui/button';
+import { Modal } from '@/components/ui/modal';
+import { useAccountingUser } from '@/hooks/use-accounting-api';
+import { cn } from '@/lib/utils';
+import { useOnboardingStore } from '@/stores/onboarding-store';
+
+import { formatBalance } from '../balance/balance-display';
+
+export function WelcomeOverlay() {
+  const { isVisible, completeOnboarding, skipOnboarding } = useOnboardingStore();
+  const { user } = useAccountingUser();
+
+  const balance = user?.balance ?? null;
+
+  return (
+    <Modal
+      isOpen={isVisible}
+      onClose={skipOnboarding}
+      title='Welcome to SyftHub'
+      description='Get started in seconds — here is everything you need to know.'
+      size='xl'
+    >
+      <div className='space-y-6'>
+        {/* Two-card layout */}
+        <div className='grid grid-cols-1 gap-4 sm:grid-cols-2'>
+          {/* Ask Questions Card */}
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.1, duration: 0.3 }}
+            className={cn('rounded-xl border p-5', 'border-border bg-muted/50', 'dark:bg-muted/30')}
+          >
+            <div className='bg-primary/10 mb-3 flex h-10 w-10 items-center justify-center rounded-lg'>
+              <MessageSquare className='text-primary h-5 w-5' aria-hidden='true' />
+            </div>
+            <h3 className='font-rubik text-foreground text-base font-medium'>Ask Questions</h3>
+            <p className='font-inter text-muted-foreground mt-1 text-sm leading-relaxed'>
+              Navigate to the chat and type any question. SyftHub queries multiple
+              privacy-preserving data sources and returns a unified answer.
+            </p>
+          </motion.div>
+
+          {/* Your Credits Card */}
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.2, duration: 0.3 }}
+            className={cn('rounded-xl border p-5', 'border-border bg-muted/50', 'dark:bg-muted/30')}
+          >
+            <div className='mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-amber-500/10'>
+              <Coins className='h-5 w-5 text-amber-600 dark:text-amber-400' aria-hidden='true' />
+            </div>
+            <h3 className='font-rubik text-foreground text-base font-medium'>Your Credits</h3>
+            <p className='font-inter text-muted-foreground mt-1 text-sm leading-relaxed'>
+              {balance === null ? (
+                <>
+                  Your credit balance appears in the top-right corner. Set up billing in Settings to
+                  start querying.
+                </>
+              ) : (
+                <>
+                  You have{' '}
+                  <span className='text-foreground font-semibold'>
+                    {formatBalance(balance)} credits
+                  </span>
+                  . Each query costs a small amount — check the balance pill in the top right.
+                </>
+              )}
+            </p>
+          </motion.div>
+        </div>
+
+        {/* CTA */}
+        <div className='flex items-center justify-between'>
+          <button
+            type='button'
+            onClick={skipOnboarding}
+            className='font-inter text-muted-foreground hover:text-foreground text-sm underline transition-colors'
+          >
+            Skip
+          </button>
+          <Button size='lg' className='font-inter' onClick={completeOnboarding}>
+            Start Exploring
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/layouts/main-layout.tsx
+++ b/frontend/src/layouts/main-layout.tsx
@@ -5,6 +5,7 @@ import { Link, Outlet } from 'react-router-dom';
 
 import { AuthModals } from '@/components/auth/auth-modals';
 import { BalanceIndicator } from '@/components/balance';
+import { WelcomeOverlay } from '@/components/onboarding';
 import { SettingsModal } from '@/components/settings/settings-modal';
 import { Sidebar } from '@/components/sidebar';
 import { Button } from '@/components/ui/button';
@@ -127,6 +128,9 @@ export function MainLayout() {
 
       {/* Settings Modal */}
       <SettingsModal />
+
+      {/* Onboarding Welcome Overlay */}
+      <WelcomeOverlay />
     </div>
   );
 }

--- a/frontend/src/stores/onboarding-store.ts
+++ b/frontend/src/stores/onboarding-store.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface OnboardingState {
+  isVisible: boolean;
+  hasCompletedOnboarding: boolean;
+  hasCompletedFirstQuery: boolean;
+  startOnboarding: () => void;
+  completeOnboarding: () => void;
+  skipOnboarding: () => void;
+  markFirstQueryComplete: () => void;
+}
+
+export const useOnboardingStore = create<OnboardingState>()(
+  persist(
+    (set) => ({
+      isVisible: false,
+      hasCompletedOnboarding: false,
+      hasCompletedFirstQuery: false,
+      startOnboarding: () => {
+        set({ isVisible: true });
+      },
+      completeOnboarding: () => {
+        set({ isVisible: false, hasCompletedOnboarding: true });
+      },
+      skipOnboarding: () => {
+        set({ isVisible: false, hasCompletedOnboarding: true });
+      },
+      markFirstQueryComplete: () => {
+        set({ hasCompletedFirstQuery: true });
+      }
+    }),
+    {
+      name: 'syfthub-onboarding',
+      partialize: (state) => ({
+        hasCompletedOnboarding: state.hasCompletedOnboarding,
+        hasCompletedFirstQuery: state.hasCompletedFirstQuery
+      })
+    }
+  )
+);


### PR DESCRIPTION
## Summary
This update introduces a new onboarding overlay to guide new users, and a persistent store to manage onboarding state across sessions.

## Changes
- Added `WelcomeOverlay` component with introductory cards and call-to-action buttons
- Implemented `useOnboardingStore` for managing onboarding visibility and completion status
- Integrated onboarding overlay into `MainLayout` to display on app start
- Updated `balance-indicator` to show a tooltip callout when onboarding is completed but first query hasn't been made
- Added `chat-empty-state` component to suggest questions during onboarding

## Notes
The onboarding flow is designed to enhance user onboarding experience, with state persisted across sessions. The overlay can be skipped or completed to proceed into the app.