### PR TITLE
fix(migrations): restore deleted revision and fix migration chain

### DIFF
--- a/components/backend/alembic/versions/20260320_000000_add_wallet_fields_to_users.py
+++ b/components/backend/alembic/versions/20260320_000000_add_wallet_fields_to_users.py
@@ -1,10 +1,12 @@
 """Replace accounting fields with wallet fields on users table.
 
 Adds wallet_address and wallet_private_key columns for MPP / Tempo blockchain
-payments. Drops old accounting_service_url and accounting_password columns.
+payments. Drops old accounting_service_url and accounting_password_encrypted
+columns (accounting_password was already replaced by
+accounting_password_encrypted in migration 008_encrypt_accounting_pw).
 
-Revision ID: 008_wallet_fields
-Revises: 007_endpoint_health
+Revision ID: 009_wallet_fields
+Revises: 008_encrypt_accounting_pw
 Create Date: 2026-03-20 00:00:00.000000+00:00
 """
 
@@ -14,8 +16,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # Revision identifiers, used by Alembic
-revision: str = "008_wallet_fields"
-down_revision: str | None = "007_endpoint_health"
+revision: str = "009_wallet_fields"
+down_revision: str | None = "008_encrypt_accounting_pw"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
@@ -33,13 +35,15 @@ def upgrade() -> None:
     )
 
     # Drop old accounting fields
+    # Note: accounting_password was already dropped and replaced by
+    # accounting_password_encrypted in migration 008_encrypt_accounting_pw
     op.drop_column("users", "accounting_service_url")
-    op.drop_column("users", "accounting_password")
+    op.drop_column("users", "accounting_password_encrypted")
 
 
 def downgrade() -> None:
     """Remove wallet fields, restore accounting fields."""
-    # Restore accounting fields
+    # Restore accounting fields (as they existed after migration 008)
     op.add_column(
         "users",
         sa.Column(
@@ -49,7 +53,9 @@ def downgrade() -> None:
     op.add_column(
         "users",
         sa.Column(
-            "accounting_password", sa.String(), nullable=True, server_default=""
+            "accounting_password_encrypted",
+            sa.String(500),
+            nullable=True,
         ),
     )
 

--- a/components/backend/alembic/versions/20260327_000000_encrypt_accounting_password.py
+++ b/components/backend/alembic/versions/20260327_000000_encrypt_accounting_password.py
@@ -1,0 +1,92 @@
+"""Encrypt accounting_password column in users table.
+
+Security fix: the accounting_password column previously stored plaintext
+credentials for the external accounting service.  This migration:
+
+1. Adds a new ``accounting_password_encrypted`` column (String 500 to fit
+   Fernet tokens which are longer than the original plaintext).
+2. Copies and encrypts existing plaintext values into the new column.
+3. Drops the old ``accounting_password`` column.
+
+Downgrade re-creates the old column but **cannot recover plaintext** for
+rows that were encrypted after the original column was dropped, so it
+sets those values to NULL.
+
+Revision ID: 008_encrypt_accounting_pw
+Revises: 007_endpoint_health
+Create Date: 2026-03-27 00:00:00.000000+00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# Revision identifiers, used by Alembic
+revision: str = "008_encrypt_accounting_pw"
+down_revision: str | None = "007_endpoint_health"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _encrypt_existing_passwords() -> None:
+    """Read all rows with a plaintext accounting_password and encrypt them
+    into the new accounting_password_encrypted column.
+
+    This runs inside the migration transaction so it's atomic.
+    """
+    # Import here to avoid top-level dependency on app code in migrations
+    from syfthub.auth.security import encrypt_field
+
+    connection = op.get_bind()
+    users = sa.table(
+        "users",
+        sa.column("id", sa.Integer),
+        sa.column("accounting_password", sa.String),
+        sa.column("accounting_password_encrypted", sa.String),
+    )
+
+    results = connection.execute(
+        sa.select(users.c.id, users.c.accounting_password).where(
+            users.c.accounting_password.isnot(None),
+            users.c.accounting_password != "",
+        )
+    )
+
+    for row in results:
+        encrypted = encrypt_field(row.accounting_password)
+        connection.execute(
+            users.update()
+            .where(users.c.id == row.id)
+            .values(accounting_password_encrypted=encrypted)
+        )
+
+
+def upgrade() -> None:
+    """Encrypt accounting passwords at rest.
+
+    Steps:
+    1. Add accounting_password_encrypted column (wider to fit Fernet tokens).
+    2. Encrypt existing plaintext values into the new column.
+    3. Drop the old plaintext accounting_password column.
+    """
+    # Step 1: add the new encrypted column
+    op.add_column(
+        "users",
+        sa.Column("accounting_password_encrypted", sa.String(500), nullable=True),
+    )
+
+    # Step 2: encrypt existing plaintext passwords
+    _encrypt_existing_passwords()
+
+    # Step 3: drop the old plaintext column
+    op.drop_column("users", "accounting_password")
+
+
+def downgrade() -> None:
+    """Re-create the plaintext column (values will be NULL for previously encrypted rows)."""
+    op.add_column(
+        "users",
+        sa.Column("accounting_password", sa.String(255), nullable=True),
+    )
+    op.drop_column("users", "accounting_password_encrypted")


### PR DESCRIPTION
## Summary
- Restores the `008_encrypt_accounting_pw` migration that was deleted by the MPP merge (`64dc5bb`). Production's `alembic_version` table references this revision — without it, Alembic crashes with `Can't locate revision identified by '008_encrypt_accounting_pw'`.
- Renumbers `008_wallet_fields` → `009_wallet_fields` with `down_revision = "008_encrypt_accounting_pw"`, fixing the chain: `007 → 008 → 009`.
- Fixes `009_wallet_fields` to drop `accounting_password_encrypted` (the column that actually exists after migration 008) instead of `accounting_password` (already dropped by 008).

## Context
The deploy to production has been failing since `a6dde37` was pushed to main. The first attempt also hit an SSH connectivity issue (unrelated — brute-force attack triggered sshd MaxStartups throttling), but even after re-running, the deploy fails at the database migration step.

## Test plan
- [ ] Verify `alembic history` shows a clean chain: `007_endpoint_health → 008_encrypt_accounting_pw → 009_wallet_fields`
- [ ] Verify `alembic upgrade head` succeeds against a DB currently at `008_encrypt_accounting_pw`
- [ ] Verify CI passes
- [ ] Re-run production deploy after merge