### PR TITLE
fix(frontend): restore password validation to match E2E tests

### DIFF
--- a/components/frontend/src/lib/schemas.ts
+++ b/components/frontend/src/lib/schemas.ts
@@ -16,16 +16,14 @@ const otpCodeField = z
 const passwordField = z
   .string()
   .min(1, 'Password is required')
-  .min(8, 'Password must be at least 8 characters')
-  .regex(/\d/, 'Password must contain at least one digit')
-  .regex(/[a-zA-Z]/, 'Password must contain at least one letter');
+  .min(6, 'Password must be at least 6 characters');
 
 export const loginSchema = z.object({
   email: emailField,
   password: z
     .string()
     .min(1, 'Password is required')
-    .min(8, 'Password must be at least 8 characters')
+    .min(6, 'Password must be at least 6 characters')
 });
 
 export type LoginFormValues = z.infer<typeof loginSchema>;

--- a/components/frontend/src/lib/validation.ts
+++ b/components/frontend/src/lib/validation.ts
@@ -35,7 +35,7 @@ export const getPasswordStrength = (password: string): number => {
 
 export function getPasswordStrengthLabel(score: number): { label: string; color: string } {
   if (score < 2) return { label: 'Weak', color: 'bg-red-500' };
-  if (score < 4) return { label: 'Fair', color: 'bg-yellow-500' };
+  if (score < 4) return { label: 'Medium', color: 'bg-yellow-500' };
   return { label: 'Strong', color: 'bg-green-500' };
 }
 


### PR DESCRIPTION
## Summary
- Reverts password minimum length from 8 back to 6 characters in both `registerSchema` and `loginSchema`
- Removes extra regex rules (digit + letter requirements) from `passwordField`
- Restores password strength label from `'Fair'` back to `'Medium'`

These changes were introduced in the MPP migration (PR #326) and broke two E2E tests in `02-hub-auth.spec.ts`:
- `form validation errors on submit` — expected `"password must be at least 6 characters"`, got `"8 characters"`
- `password strength indicator` — expected `"Medium"`, got `"Fair"`

## Test plan
- [ ] E2E tests in `02-hub-auth.spec.ts` pass (both `form validation errors on submit` and `password strength indicator`)
- [ ] Registration form still validates passwords correctly
- [ ] Password strength indicator displays correct labels (Weak/Medium/Strong)

🤖 Generated with [Claude Code](https://claude.com/claude-code)