### PR TITLE
chore(frontend): hide agent endpoint UI behind TODO flags

### DIFF
--- a/components/frontend/src/app.tsx
+++ b/components/frontend/src/app.tsx
@@ -27,7 +27,8 @@ const AboutPage = lazyWithRetry(() => import('./pages/about'));
 const ProfilePage = lazyWithRetry(() => import('./pages/profile'));
 const EndpointsPage = lazyWithRetry(() => import('./pages/endpoints'));
 const EndpointDetailPage = lazyWithRetry(() => import('./pages/endpoint-detail'));
-const AgentPage = lazyWithRetry(() => import('./pages/agent'));
+// TODO(agent-feature): Uncomment when agent endpoint UI is re-enabled
+// const AgentPage = lazyWithRetry(() => import('./pages/agent'));
 const NotFoundPage = lazyWithRetry(() => import('./pages/not-found'));
 
 /**
@@ -149,7 +150,7 @@ export default function App() {
                         }
                       />
 
-                      {/* Agent session: /agent/:owner/:slug */}
+                      {/* TODO(agent-feature): Uncomment route when agent endpoint UI is re-enabled
                       <Route
                         path='agent/:owner/:slug'
                         element={
@@ -158,6 +159,7 @@ export default function App() {
                           </RouteBoundary>
                         }
                       />
+                      */}
 
                       {/* GitHub-style endpoint URLs: /:username/:slug */}
                       <Route

--- a/components/frontend/src/components/browse-view.tsx
+++ b/components/frontend/src/components/browse-view.tsx
@@ -4,7 +4,8 @@ import type { ChatSource, EndpointType } from '@/lib/types';
 import type { LucideIcon } from 'lucide-react';
 import type { BrowseFilters } from './browse-filters-modal';
 
-import Bot from 'lucide-react/dist/esm/icons/bot';
+// TODO(agent-feature): Uncomment when agent endpoint UI is re-enabled
+// import Bot from 'lucide-react/dist/esm/icons/bot';
 import Calendar from 'lucide-react/dist/esm/icons/calendar';
 import Check from 'lucide-react/dist/esm/icons/check';
 import ChevronRight from 'lucide-react/dist/esm/icons/chevron-right';
@@ -80,7 +81,8 @@ function getTypeIcon(type: EndpointType) {
 // Tab types
 // ============================================================================
 
-type BrowseTab = 'data_sources' | 'models' | 'agents';
+// TODO(agent-feature): Add 'agents' back to BrowseTab and TAB_CONFIG when agent endpoint UI is re-enabled
+type BrowseTab = 'data_sources' | 'models';
 
 const TAB_CONFIG: Record<
   BrowseTab,
@@ -92,8 +94,8 @@ const TAB_CONFIG: Record<
     icon: Database,
     label: 'Data Sources'
   },
-  models: { endpointType: 'model', entityName: 'models', icon: Sparkles, label: 'Models' },
-  agents: { endpointType: 'agent', entityName: 'agents', icon: Bot, label: 'Agents' }
+  models: { endpointType: 'model', entityName: 'models', icon: Sparkles, label: 'Models' }
+  // agents: { endpointType: 'agent', entityName: 'agents', icon: Bot, label: 'Agents' }
 };
 
 // ============================================================================


### PR DESCRIPTION
## Context
Temporarily hides the agent endpoint UI behind TODO flags to keep the UX stable while the feature is paused.

## Changes
- Commented out AgentPage import and route in app.tsx
- Commented out Bot icon import and agent options in browse-view.tsx
- Removed agents tab from BrowseTab and update TAB_CONFIG
- Added TODO comments indicating future re-enable

## Impact
- Agent endpoints are hidden; /agent routes and related UI are unavailable
- Ensure builds pass; no runtime changes unless the TODO flag is toggled
- To re-enable, uncomment lines and restore tab config; update tests accordingly