### PR TITLE
feat(frontend): rename /endpoints to /join; add OS-aware downloads

### DIFF
--- a/components/frontend/src/app.tsx
+++ b/components/frontend/src/app.tsx
@@ -39,7 +39,7 @@ const NotFoundPage = lazyWithRetry(() => import('./pages/not-found'));
  * - /chat : AI chat interface
  * - /build : Developer portal
  * - /profile : User profile (protected)
- * - /endpoints : Endpoint management with onboarding (protected)
+ * - /join : Endpoint management with onboarding (protected)
  * - /:username/:slug : GitHub-style endpoint detail
  * - * : 404 Not Found
  *
@@ -139,7 +139,7 @@ export default function App() {
                         }
                       />
                       <Route
-                        path='endpoints'
+                        path='join'
                         element={
                           <ProtectedRoute>
                             <RouteBoundary>

--- a/components/frontend/src/components/participate-view.tsx
+++ b/components/frontend/src/components/participate-view.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
+import { useQuery } from '@tanstack/react-query';
 import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left';
 import Database from 'lucide-react/dist/esm/icons/database';
 import Download from 'lucide-react/dist/esm/icons/download';
+import ExternalLink from 'lucide-react/dist/esm/icons/external-link';
 import Globe from 'lucide-react/dist/esm/icons/globe';
+import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
 import Shield from 'lucide-react/dist/esm/icons/shield';
 
 import { Button } from './ui/button';
@@ -14,6 +17,183 @@ interface ParticipateViewProperties {
   /** Optional callback to go back */
   onBack?: () => void;
 }
+
+// ─── GitHub release types ────────────────────────────────────────────────────
+
+interface GitHubAsset {
+  name: string;
+  browser_download_url: string;
+}
+
+interface GitHubRelease {
+  tag_name: string;
+  assets: GitHubAsset[];
+}
+
+// ─── OS detection ────────────────────────────────────────────────────────────
+
+type DetectedOS = 'macos' | 'windows' | 'linux' | 'unknown';
+
+function detectOS(): DetectedOS {
+  if (typeof navigator === 'undefined') return 'unknown';
+  const ua = navigator.userAgent;
+  // Exclude iOS/iPadOS — they have "Mac OS X" in UA but can't run the desktop app
+  if (/iPad|iPhone|iPod/.test(ua)) return 'unknown';
+  if (ua.includes('Mac OS X') || ua.includes('Macintosh')) return 'macos';
+  if (ua.includes('Windows NT')) return 'windows';
+  if (ua.includes('Linux') && !ua.includes('Android')) return 'linux';
+  return 'unknown';
+}
+
+// ─── Asset selection ─────────────────────────────────────────────────────────
+
+interface DownloadOption {
+  url: string;
+  label: string;
+  /** true → solid card button; false → ghost/outlined button */
+  primary: boolean;
+}
+
+function selectDownloads(assets: GitHubAsset[], os: DetectedOS): DownloadOption[] {
+  const nonSig = assets.filter((a) => !a.name.endsWith('.sig'));
+
+  if (os === 'macos') {
+    const universal = nonSig.find((a) => a.name.endsWith('.dmg') && a.name.includes('universal'));
+    if (universal) {
+      return [{ url: universal.browser_download_url, label: 'Download for macOS', primary: true }];
+    }
+    const arm = nonSig.find(
+      (a) => a.name.endsWith('.dmg') && (a.name.includes('aarch64') || a.name.includes('arm64'))
+    );
+    const intel = nonSig.find(
+      (a) => a.name.endsWith('.dmg') && (a.name.includes('x64') || a.name.includes('x86_64'))
+    );
+    const opts: DownloadOption[] = [];
+    if (arm) opts.push({ url: arm.browser_download_url, label: 'Apple Silicon', primary: true });
+    if (intel)
+      opts.push({
+        url: intel.browser_download_url,
+        label: 'Intel Mac',
+        primary: opts.length === 0
+      });
+    return opts;
+  }
+
+  if (os === 'windows') {
+    const exe = nonSig.find((a) => a.name.endsWith('.exe'));
+    const msi = nonSig.find((a) => a.name.endsWith('.msi'));
+    const opts: DownloadOption[] = [];
+    if (exe)
+      opts.push({ url: exe.browser_download_url, label: 'Download for Windows', primary: true });
+    if (msi)
+      opts.push({ url: msi.browser_download_url, label: '.msi', primary: opts.length === 0 });
+    return opts;
+  }
+
+  if (os === 'linux') {
+    const deb = nonSig.find((a) => a.name.endsWith('.deb'));
+    const rpm = nonSig.find((a) => a.name.endsWith('.rpm'));
+    const opts: DownloadOption[] = [];
+    if (deb)
+      opts.push({ url: deb.browser_download_url, label: '.deb (Debian / Ubuntu)', primary: true });
+    if (rpm)
+      opts.push({ url: rpm.browser_download_url, label: '.rpm (Fedora / RHEL)', primary: !deb });
+    return opts;
+  }
+
+  return [];
+}
+
+// ─── GitHub API fetch ─────────────────────────────────────────────────────────
+
+const RELEASES_PAGE = 'https://github.com/OpenMined/syft-space/releases';
+
+async function fetchLatestRelease(): Promise<GitHubRelease> {
+  const res = await fetch('https://api.github.com/repos/OpenMined/syft-space/releases/latest', {
+    headers: { Accept: 'application/vnd.github+json' }
+  });
+  if (!res.ok) throw new Error(`GitHub API ${res.status}`);
+  return res.json() as Promise<GitHubRelease>;
+}
+
+// ─── Download section ─────────────────────────────────────────────────────────
+
+function DownloadSection() {
+  const os = useMemo(() => detectOS(), []);
+
+  const { data: release, isLoading } = useQuery({
+    queryKey: ['syft-space-release'],
+    queryFn: fetchLatestRelease,
+    staleTime: 1000 * 60 * 60, // 1 hour — releases don't change often
+    retry: 1
+  });
+
+  const downloads = release ? selectDownloads(release.assets, os) : [];
+  const version = release?.tag_name;
+
+  const primaryBtnClass =
+    'font-inter bg-card text-foreground hover:bg-accent flex items-center gap-2 rounded-lg px-5 py-2.5 text-sm font-medium transition-colors';
+  const ghostBtnClass =
+    'font-inter border border-primary-foreground/30 text-primary-foreground/80 hover:border-primary-foreground/60 hover:text-primary-foreground flex items-center gap-2 rounded-lg px-5 py-2.5 text-sm transition-colors';
+
+  return (
+    <div>
+      <div className='flex flex-wrap items-center gap-3'>
+        {isLoading ? (
+          // Skeleton state — same size as the real button to avoid layout shift
+          <div className={`${primaryBtnClass} pointer-events-none opacity-50`}>
+            <Loader2 className='h-4 w-4 animate-spin' aria-hidden='true' />
+            Checking for latest release…
+          </div>
+        ) : downloads.length === 0 ? (
+          // Fallback: unknown OS or fetch error → link to releases page
+          <a
+            href={RELEASES_PAGE}
+            target='_blank'
+            rel='noopener noreferrer'
+            className={primaryBtnClass}
+          >
+            <ExternalLink className='h-4 w-4' aria-hidden='true' />
+            View all releases
+          </a>
+        ) : (
+          <>
+            {downloads.map((dl) => (
+              <a
+                key={dl.url}
+                href={dl.url}
+                target='_blank'
+                rel='noopener noreferrer'
+                className={dl.primary ? primaryBtnClass : ghostBtnClass}
+              >
+                <Download className='h-4 w-4' aria-hidden='true' />
+                {dl.label}
+              </a>
+            ))}
+
+            {/* Always offer an escape hatch to the full releases page */}
+            <a
+              href={RELEASES_PAGE}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='font-inter text-primary-foreground/50 hover:text-primary-foreground/80 flex items-center gap-1 self-center text-xs transition-colors'
+              aria-label='All releases on GitHub'
+            >
+              <ExternalLink className='h-3 w-3' aria-hidden='true' />
+              All releases
+            </a>
+          </>
+        )}
+      </div>
+
+      <p className='font-inter text-primary-foreground/60 mt-4 text-xs'>
+        {version ? `${version} • ` : ''}Requires Docker Desktop
+      </p>
+    </div>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
 
 export function ParticipateView({
   title = 'Start your first node',
@@ -99,20 +279,7 @@ export function ParticipateView({
                   your knowledge or models, manage permissions, and go live in a few minutes.
                 </p>
 
-                <div className='flex flex-wrap gap-4'>
-                  <a
-                    href='https://github.com/OpenMined/syft-space/releases/download/v0.2.2/Syft.Space_0.2.2_x64.dmg'
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    className='font-inter bg-card text-foreground hover:bg-accent flex items-center gap-2 rounded-lg px-5 py-2.5 text-sm font-medium transition-colors'
-                  >
-                    <Download className='h-4 w-4' aria-hidden='true' />
-                    Download for macOS
-                  </a>
-                </div>
-                <p className='font-inter text-primary-foreground/60 mt-4 text-xs'>
-                  v0.2.2 • Requires Docker Desktop
-                </p>
+                <DownloadSection />
               </div>
 
               {/* Abstract visual */}

--- a/components/frontend/src/components/sidebar.tsx
+++ b/components/frontend/src/components/sidebar.tsx
@@ -24,7 +24,7 @@ interface NavItem {
 const navItems: NavItem[] = [
   { id: 'home', path: '/', label: 'Chat', icon: MessageSquare, protected: false },
   { id: 'browse', path: '/browse', label: 'Browse', icon: Globe, protected: false },
-  { id: 'endpoints', path: '/endpoints', label: 'Participate', icon: UserPlus, protected: true },
+  { id: 'endpoints', path: '/join', label: 'Participate', icon: UserPlus, protected: true },
   { id: 'build', path: '/build', label: 'Build', icon: FileText, protected: false },
   { id: 'about', path: '/about', label: 'About', icon: Info, protected: false }
 ];

--- a/components/frontend/src/pages/home.tsx
+++ b/components/frontend/src/pages/home.tsx
@@ -30,7 +30,7 @@ export default function HomePage() {
   const handleJoinNetwork = () => {
     if (user) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises -- Navigation is fire-and-forget
-      navigate('/endpoints');
+      navigate('/join');
     } else {
       openLogin();
     }


### PR DESCRIPTION
## Context
Renamed the protected endpoints route to /join and added OS-aware downloads to the client. This aligns navigation with the new route and improves installation UX.

## Changes
- Rename /endpoints route to /join in frontend routing and protected navigation.
- Update sidebar and home redirects to point to /join; authenticated users are sent to /join on login.
- Implement OS detection and dynamic GitHub release asset selection for downloads in ParticipateView (DownloadSection).
- Add fallback to releases page and an All releases link; show skeleton state while loading.

## Impact
- Areas to test: /join availability (protected route), navigation highlights, OS-based download options across macOS/Windows/Linux, GitHub API fetch reliability and rate limits. If rate-limited, users are directed to the releases page.