### PR TITLE
fix: resolve alembic multiple heads blocking production deploy

### DIFF
--- a/components/backend/alembic/versions/20260428_000000_merge_wallet_and_archived_heads.py
+++ b/components/backend/alembic/versions/20260428_000000_merge_wallet_and_archived_heads.py
@@ -1,0 +1,25 @@
+"""Merge the 009_wallet_fields and 009_add_archived branch heads.
+
+Both migrations descended from 008_encrypt_accounting_pw independently,
+creating two alembic heads. This merge migration unifies the graph so that
+'alembic upgrade head' resolves to a single target.
+
+Revision ID: 010_merge_heads
+Revises: 009_wallet_fields, 009_add_archived
+Create Date: 2026-04-28 00:00:00.000000+00:00
+"""
+
+from collections.abc import Sequence
+
+revision: str = "010_merge_heads"
+down_revision: tuple[str, str] = ("009_wallet_fields", "009_add_archived")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/components/backend/src/syfthub/main.py
+++ b/components/backend/src/syfthub/main.py
@@ -623,9 +623,9 @@ async def get_owner_endpoint(
             readme_html = sanitize_readme_html(raw_html)
 
         return templates.TemplateResponse(
+            request,
             "endpoint.html",
             {
-                "request": request,
                 "endpoint": endpoint,
                 "owner_name": owner_name,
                 "owner_slug": owner_slug,


### PR DESCRIPTION
## Summary

- **Root cause**: `009_wallet_fields` and `009_add_archived` both descended from `008_encrypt_accounting_pw` independently (merged via separate PRs), creating two Alembic branch heads. `alembic upgrade head` fails with _"Multiple head revisions are present"_, which breaks `deploy.sh` and blocks every push to main.
- **Fix 1**: Add merge migration `010_merge_heads` (`20260428_000000_merge_wallet_and_archived_heads.py`) with `down_revision = ("009_wallet_fields", "009_add_archived")`. No schema changes — it only unifies the graph so there is a single `head`.
- **Fix 2**: Fix a pre-existing mypy error in `get_owner_endpoint` (`main.py:625`): Starlette 0.36+ requires `TemplateResponse(request, name, context)` — `request` moves out of the context dict.

## Migration graph after this fix

```
001 → 002 → 003 → 004 → 005 → 006 → 007 → 008 → 009_wallet_fields ──┐
                                                → 009_add_archived  ──┴─→ 010_merge_heads (HEAD)
```

## Test plan

- [ ] CI pipeline passes (deploy step no longer fails on alembic multi-head error)
- [ ] `alembic upgrade head` on prod applies `009_add_archived` + `010_merge_heads` cleanly (prod is currently at `009_wallet_fields`)
- [ ] Endpoint detail page (`/{owner}/{slug}`) still renders correctly (TemplateResponse change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)