### PR TITLE
fix: remove stale README.md COPY from Dockerfiles

### DIFF
--- a/components/aggregator/Dockerfile
+++ b/components/aggregator/Dockerfile
@@ -11,8 +11,8 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 # Set working directory
 WORKDIR /app
 
-# Copy dependency files and README (required by hatchling)
-COPY pyproject.toml README.md ./
+# Copy dependency files
+COPY pyproject.toml ./
 
 # Install git (required to fetch git-hosted dependencies)
 RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*

--- a/components/backend/Dockerfile
+++ b/components/backend/Dockerfile
@@ -34,7 +34,6 @@ FROM base AS dependencies
 
 # Copy dependency files
 COPY --chown=syfthub:syfthub pyproject.toml ./
-COPY --chown=syfthub:syfthub README.md ./
 
 # Create src structure for package installation
 RUN mkdir -p src/syfthub && \
@@ -70,7 +69,6 @@ COPY --chown=syfthub:syfthub src src
 COPY --chown=syfthub:syfthub tests tests
 COPY --chown=syfthub:syfthub requirements.txt .
 COPY --chown=syfthub:syfthub uv.lock .
-COPY --chown=syfthub:syfthub README.md .
 COPY --chown=syfthub:syfthub alembic.ini .
 COPY --chown=syfthub:syfthub alembic alembic
 
@@ -105,7 +103,6 @@ COPY --chown=syfthub:syfthub src src
 COPY --chown=syfthub:syfthub tests tests
 COPY --chown=syfthub:syfthub requirements.txt .
 COPY --chown=syfthub:syfthub uv.lock .
-COPY --chown=syfthub:syfthub README.md .
 COPY --chown=syfthub:syfthub alembic.ini .
 COPY --chown=syfthub:syfthub alembic alembic
 


### PR DESCRIPTION
## Summary

- The `docs: consolidate READMEs` commit (e6e6a83) deleted `README.md` from `components/backend/` and `components/aggregator/` and removed the `readme` field from both `pyproject.toml` files
- The Dockerfiles were not updated in that commit, leaving stale `COPY README.md` instructions that cause all Docker builds to fail with: `ERROR: failed to compute cache key: "/README.md": not found`
- This broke **Build backend**, **Build aggregator**, and **e2e** CI jobs on main (and PR #362 which syncs main → dev)

## Changes

- `components/aggregator/Dockerfile`: changed `COPY pyproject.toml README.md ./` → `COPY pyproject.toml ./`
- `components/backend/Dockerfile`: removed 3 `COPY README.md` lines (from `dependencies`, `development`, and `testing` stages)

## Test plan

- [ ] Build backend Docker image passes
- [ ] Build aggregator Docker image passes
- [ ] e2e tests pass