### PR TITLE
feat: Xendit payment flow — credits panel, payment gate, 403 surfacing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup dev stop test test-integration check logs
+.PHONY: help setup dev stop test test-integration check logs sdk-build
 
 # =============================================================================
 # SyftHub Development Commands
@@ -42,7 +42,14 @@ setup:  ## Install dev dependencies (pre-commit, etc.)
 	@echo '  source .venv/bin/activate'
 	@echo ''
 
-dev:  ## Start development environment
+sdk-build:  ## Build the TypeScript SDK (required for frontend dev: bind-mount overlays the container build)
+	@if [ ! -f sdk/typescript/dist/index.js ]; then \
+		echo 'Building TypeScript SDK...'; \
+		npm --prefix sdk/typescript install --silent; \
+		npm --prefix sdk/typescript run build; \
+	fi
+
+dev: sdk-build  ## Start development environment
 	@docker compose -f deploy/docker-compose.dev.yml up -d --build
 	@echo ''
 	@echo '══════════════════════════════════════════'

--- a/components/aggregator/src/aggregator/clients/data_source.py
+++ b/components/aggregator/src/aggregator/clients/data_source.py
@@ -181,7 +181,7 @@ class DataSourceClient:
                 return RetrievalResult(
                     endpoint_path=endpoint_path,
                     documents=[],
-                    status="error",
+                    status="access_denied",
                     error_message=f"Access denied: {error_detail}",
                     latency_ms=latency_ms,
                 )

--- a/components/aggregator/src/aggregator/schemas/internal.py
+++ b/components/aggregator/src/aggregator/schemas/internal.py
@@ -44,7 +44,7 @@ class RetrievalResult(BaseModel):
 
     endpoint_path: str = Field(..., description="Path of the data source")
     documents: list[Document] = Field(default_factory=list, description="Retrieved documents")
-    status: Literal["success", "error", "timeout", "payment_failed"] = Field(
+    status: Literal["success", "error", "timeout", "payment_failed", "access_denied"] = Field(
         ..., description="Query status"
     )
     error_message: str | None = Field(default=None, description="Error message if failed")

--- a/components/aggregator/src/aggregator/schemas/responses.py
+++ b/components/aggregator/src/aggregator/schemas/responses.py
@@ -24,7 +24,9 @@ class SourceInfo(BaseModel):
 
     path: str = Field(..., description="Endpoint path (owner/slug)")
     documents_retrieved: int = Field(..., description="Number of documents retrieved")
-    status: Literal["success", "error", "timeout"] = Field(..., description="Query status")
+    status: Literal["success", "error", "timeout", "payment_failed", "access_denied"] = Field(
+        ..., description="Query status"
+    )
     error_message: str | None = Field(default=None, description="Error message if failed")
 
 

--- a/components/aggregator/src/aggregator/services/orchestrator.py
+++ b/components/aggregator/src/aggregator/services/orchestrator.py
@@ -523,6 +523,29 @@ class Orchestrator:
 
         retrieval_time_ms = int((time.perf_counter() - retrieval_start) * 1000)
 
+        # Hard fail when an explicitly-selected data source refused us. The
+        # user picked these endpoints; degrading silently to model-only would
+        # answer with the wrong context and (worse) charge them for it. Other
+        # statuses (timeout, generic error) keep the existing partial-failure
+        # tolerance — only access_denied (HTTP 403) aborts.
+        denied = [r for r in retrieval_results if r.status == "access_denied"]
+        if denied:
+            paths = ", ".join(r.endpoint_path for r in denied)
+            details = "; ".join(
+                f"{r.endpoint_path}: {r.error_message or 'access denied'}" for r in denied
+            )
+            yield self._sse_event(
+                "error",
+                {
+                    "message": (
+                        f"Data source access denied for: {paths}. "
+                        "Remove these sources or resolve the publisher's policy. "
+                        f"Details — {details}"
+                    )
+                },
+            )
+            return
+
         # Aggregate documents (raw sort as baseline / fallback)
         all_documents = []
         for r in retrieval_results:

--- a/components/backend/alembic/versions/20260429_000000_add_user_xendit_subscriptions.py
+++ b/components/backend/alembic/versions/20260429_000000_add_user_xendit_subscriptions.py
@@ -1,0 +1,66 @@
+"""Add user_xendit_subscriptions table.
+
+Stores the publisher-side wallets (identified by credits_url) that a SyftHub
+user has funded via the Xendit policy flow. Lets the credits panel list every
+wallet a user holds across publishers without scanning endpoint policies.
+
+Revision ID: 011_xendit_subs
+Revises: 010_merge_heads
+Create Date: 2026-04-29 00:00:00.000000+00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "011_xendit_subs"
+down_revision: str | None = "010_merge_heads"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_xendit_subscriptions",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("credits_url", sa.Text(), nullable=False),
+        sa.Column("payment_url", sa.Text(), nullable=False),
+        sa.Column("currency", sa.String(8), nullable=False, server_default="IDR"),
+        sa.Column("endpoint_owner", sa.String(50), nullable=False),
+        sa.Column("endpoint_slug", sa.String(255), nullable=True),
+        sa.Column("last_known_balance", sa.Numeric(18, 4), nullable=True),
+        sa.Column("last_checked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("first_funded_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "user_id", "credits_url", name="uq_user_xendit_subs_user_credits"
+        ),
+    )
+    op.create_index(
+        "idx_user_xendit_subs_user",
+        "user_xendit_subscriptions",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_user_xendit_subs_user", table_name="user_xendit_subscriptions")
+    op.drop_table("user_xendit_subscriptions")

--- a/components/backend/src/syfthub/api/endpoints/wallet.py
+++ b/components/backend/src/syfthub/api/endpoints/wallet.py
@@ -13,9 +13,13 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from syfthub.auth.db_dependencies import get_current_active_user
 from syfthub.core.config import settings
-from syfthub.database.dependencies import get_user_repository
+from syfthub.database.dependencies import (
+    get_user_repository,
+    get_user_xendit_subscription_repository,
+)
 from syfthub.observability.logger import get_logger
 from syfthub.repositories.user import UserRepository
+from syfthub.repositories.xendit_subscription import UserXenditSubscriptionRepository
 from syfthub.schemas.user import (
     CreateWalletResponse,
     ImportWalletRequest,
@@ -25,6 +29,9 @@ from syfthub.schemas.user import (
     WalletBalanceResponse,
     WalletResponse,
     WalletTransaction,
+    XenditSubscriptionListResponse,
+    XenditSubscriptionResponse,
+    XenditSubscriptionUpsertRequest,
 )
 
 logger = get_logger(__name__)
@@ -327,3 +334,85 @@ async def pay(
                     "message": f"Failed to create payment credential: {e}",
                 },
             ) from e
+
+
+# =============================================================================
+# Xendit Subscription Endpoints (publisher-side wallets)
+# =============================================================================
+
+
+@router.get("/subscriptions", response_model=XenditSubscriptionListResponse)
+async def list_xendit_subscriptions(
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    repo: Annotated[
+        UserXenditSubscriptionRepository,
+        Depends(get_user_xendit_subscription_repository),
+    ],
+) -> XenditSubscriptionListResponse:
+    """List every publisher wallet the current user has funded."""
+    rows = repo.list_for_user(current_user.id)
+    return XenditSubscriptionListResponse(
+        subscriptions=[XenditSubscriptionResponse.model_validate(r) for r in rows]
+    )
+
+
+@router.post(
+    "/subscriptions",
+    response_model=XenditSubscriptionResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def upsert_xendit_subscription(
+    request: XenditSubscriptionUpsertRequest,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    repo: Annotated[
+        UserXenditSubscriptionRepository,
+        Depends(get_user_xendit_subscription_repository),
+    ],
+) -> XenditSubscriptionResponse:
+    """Register (or refresh) a publisher wallet for the current user.
+
+    Idempotent on (user_id, credits_url). Called by the frontend whenever a
+    Xendit balance transitions from inactive to active.
+    """
+    row = repo.upsert(
+        user_id=current_user.id,
+        credits_url=request.credits_url,
+        payment_url=request.payment_url,
+        endpoint_owner=request.endpoint_owner,
+        endpoint_slug=request.endpoint_slug,
+        currency=request.currency,
+        last_known_balance=request.last_known_balance,
+    )
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to record xendit subscription",
+        )
+    logger.info(
+        "wallet.xendit_subscription_upserted",
+        user_id=current_user.id,
+        subscription_id=row.id,
+        endpoint_owner=row.endpoint_owner,
+    )
+    return XenditSubscriptionResponse.model_validate(row)
+
+
+@router.delete(
+    "/subscriptions/{subscription_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_xendit_subscription(
+    subscription_id: int,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    repo: Annotated[
+        UserXenditSubscriptionRepository,
+        Depends(get_user_xendit_subscription_repository),
+    ],
+) -> None:
+    """Forget a publisher wallet (no refund — just removes from the panel)."""
+    deleted = repo.delete_for_user(current_user.id, subscription_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Subscription not found",
+        )

--- a/components/backend/src/syfthub/database/dependencies.py
+++ b/components/backend/src/syfthub/database/dependencies.py
@@ -11,6 +11,7 @@ from syfthub.repositories import (
     EndpointRepository,
     OrganizationRepository,
     UserRepository,
+    UserXenditSubscriptionRepository,
 )
 from syfthub.repositories.endpoint import EndpointStarRepository
 from syfthub.repositories.organization import OrganizationMemberRepository
@@ -64,6 +65,13 @@ def get_endpoint_star_repository(
 ) -> EndpointStarRepository:
     """Get EndpointStarRepository dependency."""
     return EndpointStarRepository(session)
+
+
+def get_user_xendit_subscription_repository(
+    session: Annotated[Session, Depends(get_db_session)],
+) -> UserXenditSubscriptionRepository:
+    """Get UserXenditSubscriptionRepository dependency."""
+    return UserXenditSubscriptionRepository(session)
 
 
 # Service dependencies

--- a/components/backend/src/syfthub/models/__init__.py
+++ b/components/backend/src/syfthub/models/__init__.py
@@ -7,6 +7,7 @@ from syfthub.models.organization import OrganizationMemberModel, OrganizationMod
 from syfthub.models.otp import OTPCodeModel
 from syfthub.models.user import UserModel
 from syfthub.models.user_aggregator import UserAggregatorModel
+from syfthub.models.xendit_subscription import UserXenditSubscriptionModel
 from syfthub.observability.models import ErrorLogModel
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     "TimestampMixin",
     "UserAggregatorModel",
     "UserModel",
+    "UserXenditSubscriptionModel",
 ]

--- a/components/backend/src/syfthub/models/xendit_subscription.py
+++ b/components/backend/src/syfthub/models/xendit_subscription.py
@@ -1,0 +1,78 @@
+"""User Xendit subscription database model.
+
+Records the publisher-side wallets that a SyftHub user has funded via the
+Xendit policy flow. SyftHub does not custody the wallet itself; it stores the
+``credits_url`` (which uniquely identifies a wallet on the publisher's
+syft_space) plus enough metadata to render the credits panel and re-mint a
+satellite token to query the live balance.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from syfthub.models.base import BaseModel, TimestampMixin
+
+if TYPE_CHECKING:
+    from syfthub.models.user import UserModel
+
+
+class UserXenditSubscriptionModel(BaseModel, TimestampMixin):
+    """A user's funded Xendit wallet (one per distinct credits_url)."""
+
+    __tablename__ = "user_xendit_subscriptions"
+
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+
+    # Wallet identity on the publisher syft_space.
+    credits_url: Mapped[str] = mapped_column(Text, nullable=False)
+    payment_url: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # Display + auth metadata.
+    currency: Mapped[str] = mapped_column(String(8), nullable=False, default="IDR")
+    endpoint_owner: Mapped[str] = mapped_column(String(50), nullable=False)
+    endpoint_slug: Mapped[Optional[str]] = mapped_column(
+        String(255), nullable=True, default=None
+    )
+
+    # Cached balance for fast initial paint (always re-fetched live).
+    last_known_balance: Mapped[Optional[float]] = mapped_column(
+        Numeric(18, 4), nullable=True, default=None
+    )
+    last_checked_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
+
+    # When the first non-zero balance was detected. Lets the UI show
+    # "subscribed since …".
+    first_funded_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
+
+    user: Mapped["UserModel"] = relationship("UserModel", lazy="joined")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id", "credits_url", name="uq_user_xendit_subs_user_credits"
+        ),
+        Index("idx_user_xendit_subs_user", "user_id"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<UserXenditSubscription(id={self.id}, user_id={self.user_id}, "
+            f"owner='{self.endpoint_owner}')>"
+        )

--- a/components/backend/src/syfthub/repositories/__init__.py
+++ b/components/backend/src/syfthub/repositories/__init__.py
@@ -5,6 +5,7 @@ from syfthub.repositories.base import BaseRepository
 from syfthub.repositories.endpoint import EndpointRepository
 from syfthub.repositories.organization import OrganizationRepository
 from syfthub.repositories.user import UserRepository
+from syfthub.repositories.xendit_subscription import UserXenditSubscriptionRepository
 
 __all__ = [
     "APITokenRepository",
@@ -12,4 +13,5 @@ __all__ = [
     "EndpointRepository",
     "OrganizationRepository",
     "UserRepository",
+    "UserXenditSubscriptionRepository",
 ]

--- a/components/backend/src/syfthub/repositories/xendit_subscription.py
+++ b/components/backend/src/syfthub/repositories/xendit_subscription.py
@@ -1,0 +1,129 @@
+"""Repository for user Xendit subscriptions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, List, Optional
+
+from sqlalchemy import and_, select
+from sqlalchemy.exc import SQLAlchemyError
+
+from syfthub.models.xendit_subscription import UserXenditSubscriptionModel
+from syfthub.repositories.base import BaseRepository
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+class UserXenditSubscriptionRepository(BaseRepository[UserXenditSubscriptionModel]):
+    """Repository for user_xendit_subscriptions CRUD."""
+
+    def __init__(self, session: Session):
+        super().__init__(session, UserXenditSubscriptionModel)
+
+    def list_for_user(self, user_id: int) -> List[UserXenditSubscriptionModel]:
+        """Return all subscriptions for a user, newest first."""
+        try:
+            stmt = (
+                select(self.model)
+                .where(self.model.user_id == user_id)
+                .order_by(self.model.created_at.desc())
+            )
+            return list(self.session.execute(stmt).scalars().all())
+        except SQLAlchemyError:
+            return []
+
+    def get_for_user(
+        self, user_id: int, subscription_id: int
+    ) -> Optional[UserXenditSubscriptionModel]:
+        """Get a single subscription, scoped to the owning user."""
+        try:
+            stmt = select(self.model).where(
+                and_(self.model.id == subscription_id, self.model.user_id == user_id)
+            )
+            return self.session.execute(stmt).scalar_one_or_none()
+        except SQLAlchemyError:
+            return None
+
+    def get_by_credits_url(
+        self, user_id: int, credits_url: str
+    ) -> Optional[UserXenditSubscriptionModel]:
+        """Lookup by the (user_id, credits_url) natural key."""
+        try:
+            stmt = select(self.model).where(
+                and_(
+                    self.model.user_id == user_id,
+                    self.model.credits_url == credits_url,
+                )
+            )
+            return self.session.execute(stmt).scalar_one_or_none()
+        except SQLAlchemyError:
+            return None
+
+    def upsert(
+        self,
+        *,
+        user_id: int,
+        credits_url: str,
+        payment_url: str,
+        endpoint_owner: str,
+        endpoint_slug: Optional[str],
+        currency: str,
+        last_known_balance: Optional[float],
+    ) -> Optional[UserXenditSubscriptionModel]:
+        """Create or refresh a subscription row.
+
+        Existing rows have their balance, mutable metadata, and freshness
+        fields refreshed; ``first_funded_at`` is preserved on first non-zero
+        balance and never overwritten thereafter.
+        """
+        try:
+            now = datetime.now(timezone.utc)
+            existing = self.get_by_credits_url(user_id, credits_url)
+
+            if existing is None:
+                row = UserXenditSubscriptionModel(
+                    user_id=user_id,
+                    credits_url=credits_url,
+                    payment_url=payment_url,
+                    endpoint_owner=endpoint_owner,
+                    endpoint_slug=endpoint_slug,
+                    currency=currency,
+                    last_known_balance=last_known_balance,
+                    last_checked_at=now,
+                    first_funded_at=now if (last_known_balance or 0) > 0 else None,
+                )
+                self.session.add(row)
+            else:
+                existing.payment_url = payment_url
+                existing.endpoint_owner = endpoint_owner
+                # Only adopt a more-specific slug; don't blank one out.
+                if endpoint_slug:
+                    existing.endpoint_slug = endpoint_slug
+                existing.currency = currency
+                if last_known_balance is not None:
+                    existing.last_known_balance = last_known_balance
+                existing.last_checked_at = now
+                if existing.first_funded_at is None and (last_known_balance or 0) > 0:
+                    existing.first_funded_at = now
+                row = existing
+
+            self.session.commit()
+            self.session.refresh(row)
+            return row
+        except SQLAlchemyError:
+            self.session.rollback()
+            return None
+
+    def delete_for_user(self, user_id: int, subscription_id: int) -> bool:
+        """Hard-delete a subscription, scoped to the owning user."""
+        try:
+            row = self.get_for_user(user_id, subscription_id)
+            if row is None:
+                return False
+            self.session.delete(row)
+            self.session.commit()
+            return True
+        except SQLAlchemyError:
+            self.session.rollback()
+            return False

--- a/components/backend/src/syfthub/schemas/user.py
+++ b/components/backend/src/syfthub/schemas/user.py
@@ -484,3 +484,48 @@ class WalletBalanceResponse(BaseModel):
     currency: str = "USD"
     recent_transactions: list[WalletTransaction] = []
     wallet_configured: bool = False
+
+
+# =============================================================================
+# Xendit Subscription Schemas (publisher-side wallets)
+# =============================================================================
+
+
+class XenditSubscriptionUpsertRequest(BaseModel):
+    """Request schema to register / refresh a publisher wallet subscription.
+
+    Called by the frontend when a successful Xendit payment is detected
+    (balance transitions from inactive to active). Idempotent on
+    (user_id, credits_url) — repeat calls only update freshness fields.
+    """
+
+    credits_url: str = Field(..., min_length=1, max_length=2000)
+    payment_url: str = Field(..., min_length=1, max_length=2000)
+    endpoint_owner: str = Field(..., min_length=1, max_length=50)
+    endpoint_slug: Optional[str] = Field(default=None, max_length=255)
+    currency: str = Field(default="IDR", min_length=1, max_length=8)
+    last_known_balance: Optional[float] = Field(default=None, ge=0)
+
+
+class XenditSubscriptionResponse(BaseModel):
+    """Response schema for a single subscription row."""
+
+    id: int
+    credits_url: str
+    payment_url: str
+    currency: str
+    endpoint_owner: str
+    endpoint_slug: Optional[str] = None
+    last_known_balance: Optional[float] = None
+    last_checked_at: Optional[datetime] = None
+    first_funded_at: Optional[datetime] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class XenditSubscriptionListResponse(BaseModel):
+    """Response schema for listing a user's subscriptions."""
+
+    subscriptions: list[XenditSubscriptionResponse] = []

--- a/components/frontend/src/components/__tests__/balance-indicator.test.tsx
+++ b/components/frontend/src/components/__tests__/balance-indicator.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BalanceIndicator } from '@/components/balance/balance-indicator';
@@ -24,26 +25,48 @@ vi.mock('@/stores/settings-modal-store', () => ({
   useSettingsModalStore: () => ({ openSettings: mockOpenSettings })
 }));
 
-// Mock wallet API hooks
-const { mockUseWalletBalance, mockUseWalletTransactions } = vi.hoisted(() => ({
-  mockUseWalletBalance: vi.fn(),
-  mockUseWalletTransactions: vi.fn()
+// Mock wallet balance hook
+const { mockUseWalletBalance } = vi.hoisted(() => ({
+  mockUseWalletBalance: vi.fn()
 }));
 
-vi.mock('@/hooks/use-wallet-api', () => ({
-  useWalletBalance: (): unknown => mockUseWalletBalance(),
-  useWalletTransactions: (...parameters: unknown[]): unknown =>
-    mockUseWalletTransactions(...parameters)
+vi.mock('@/hooks/use-wallet-api', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/hooks/use-wallet-api')>('@/hooks/use-wallet-api');
+  return {
+    ...actual,
+    useWalletBalance: (): unknown => mockUseWalletBalance()
+  };
+});
+
+// Mock xendit subscriptions hooks so the credits panel renders without
+// pulling in auth-context / TanStack Query.
+const { mockUseXenditSubscriptions, mockUseSubscriptionBalance } = vi.hoisted(() => ({
+  mockUseXenditSubscriptions: vi.fn(),
+  mockUseSubscriptionBalance: vi.fn()
 }));
+
+vi.mock('@/hooks/use-xendit-subscriptions', () => ({
+  useXenditSubscriptions: (): unknown => mockUseXenditSubscriptions(),
+  useSubscriptionBalance: (): unknown => mockUseSubscriptionBalance()
+}));
+
+function renderIndicator() {
+  return render(
+    <MemoryRouter>
+      <BalanceIndicator />
+    </MemoryRouter>
+  );
+}
 
 describe('BalanceIndicator', () => {
   let mockRefetch: ReturnType<typeof vi.fn>;
-  let mockRefetchTransactions: ReturnType<typeof vi.fn>;
+  let mockRefetchSubscriptions: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockRefetch = vi.fn().mockResolvedValue(null);
-    mockRefetchTransactions = vi.fn().mockResolvedValue(null);
+    mockRefetchSubscriptions = vi.fn().mockResolvedValue(null);
 
     // Default: configured, loaded, healthy balance
     mockUseWalletContext.mockReturnValue({
@@ -66,11 +89,19 @@ describe('BalanceIndicator', () => {
       refetch: mockRefetch
     });
 
-    mockUseWalletTransactions.mockReturnValue({
-      transactions: [],
+    // Default: no funded Xendit subscriptions.
+    mockUseXenditSubscriptions.mockReturnValue({
+      data: [],
       isLoading: false,
+      isFetching: false,
+      refetch: mockRefetchSubscriptions
+    });
+    mockUseSubscriptionBalance.mockReturnValue({
+      balance: null,
+      isLoading: false,
+      isFetching: false,
       error: null,
-      refetch: mockRefetchTransactions
+      refetch: vi.fn()
     });
   });
 
@@ -80,36 +111,36 @@ describe('BalanceIndicator', () => {
       isLoading: true
     });
 
-    const { container } = render(<BalanceIndicator />);
+    const { container } = renderIndicator();
     expect(container.innerHTML).toBe('');
   });
 
-  it('shows "Set up wallet" when not configured', () => {
+  it('shows "Set up wallet" pill when not configured', () => {
     mockUseWalletContext.mockReturnValue({
       isConfigured: false,
       isLoading: false
     });
 
-    render(<BalanceIndicator />);
+    renderIndicator();
     expect(screen.getByText('Set up wallet')).toBeInTheDocument();
   });
 
-  it('opens wallet settings when "Set up wallet" is clicked', async () => {
+  it('opens dropdown when "Set up wallet" pill is clicked', async () => {
     mockUseWalletContext.mockReturnValue({
       isConfigured: false,
       isLoading: false
     });
 
     const user = userEvent.setup();
-    render(<BalanceIndicator />);
+    renderIndicator();
 
     await user.click(screen.getByText('Set up wallet'));
-    expect(mockOpenSettings).toHaveBeenCalledWith('payment');
+    // Pill toggles dropdown; the actual settings link lives inside the panel.
+    expect(screen.getByText('Wallet settings')).toBeInTheDocument();
   });
 
   it('shows compact balance for healthy balance', () => {
-    render(<BalanceIndicator />);
-    // 500 is below 1000, so it shows formatted with 2 decimals
+    renderIndicator();
     expect(screen.getByText('500.00')).toBeInTheDocument();
   });
 
@@ -126,11 +157,11 @@ describe('BalanceIndicator', () => {
       refetch: mockRefetch
     });
 
-    render(<BalanceIndicator />);
+    renderIndicator();
     expect(screen.getByText('15.0K')).toBeInTheDocument();
   });
 
-  it('shows "Error" text when there is an error', () => {
+  it('shows "Error" text on the pill when there is an error', () => {
     mockUseWalletBalance.mockReturnValue({
       balance: null,
       isLoading: false,
@@ -138,157 +169,72 @@ describe('BalanceIndicator', () => {
       refetch: mockRefetch
     });
 
-    render(<BalanceIndicator />);
+    renderIndicator();
     expect(screen.getByText('Error')).toBeInTheDocument();
   });
 
-  it('disables pill button while loading', () => {
-    mockUseWalletBalance.mockReturnValue({
-      balance: null,
-      isLoading: true,
-      error: null,
-      refetch: mockRefetch
-    });
-
-    render(<BalanceIndicator />);
-    const button = screen.getByRole('button', { name: /account balance/i });
-    expect(button).toBeDisabled();
-  });
-
-  it('opens dropdown on click and shows full balance', async () => {
+  it('opens dropdown on click and renders the credits panel', async () => {
     const user = userEvent.setup();
-    render(<BalanceIndicator />);
+    renderIndicator();
 
     await user.click(screen.getByRole('button', { name: /account balance/i }));
 
-    expect(screen.getByText('Available Credits')).toBeInTheDocument();
-    expect(screen.getByText('credits')).toBeInTheDocument();
+    expect(screen.getByText('Tempo · pathUSD')).toBeInTheDocument();
+    // "Endpoint subscriptions" appears both as a section header and inside
+    // the empty-state copy, so just confirm at least one rendered.
+    expect(screen.getAllByText(/Endpoint subscriptions/i).length).toBeGreaterThan(0);
   });
 
-  it('shows "No recent transactions" when list is empty', async () => {
+  it('shows empty subscriptions message when no Xendit wallets are funded', async () => {
     const user = userEvent.setup();
-    render(<BalanceIndicator />);
+    renderIndicator();
 
     await user.click(screen.getByRole('button', { name: /account balance/i }));
 
-    expect(screen.getByText('No recent transactions')).toBeInTheDocument();
+    expect(screen.getByText(/No endpoint subscriptions yet/i)).toBeInTheDocument();
   });
 
-  it('calls refetch when refresh button is clicked', async () => {
+  it('opens wallet settings from dropdown footer', async () => {
     const user = userEvent.setup();
-    render(<BalanceIndicator />);
+    renderIndicator();
 
-    // Open dropdown
     await user.click(screen.getByRole('button', { name: /account balance/i }));
-
-    // Click refresh
-    await user.click(screen.getByRole('button', { name: /refresh balance/i }));
-
-    expect(mockRefetch).toHaveBeenCalled();
-    expect(mockRefetchTransactions).toHaveBeenCalled();
-  });
-
-  it('opens wallet settings from dropdown', async () => {
-    const user = userEvent.setup();
-    render(<BalanceIndicator />);
-
-    // Open dropdown
-    await user.click(screen.getByRole('button', { name: /account balance/i }));
-
-    // Click Settings button in footer
-    await user.click(screen.getByText('Settings'));
+    await user.click(screen.getByText('Wallet settings'));
 
     expect(mockOpenSettings).toHaveBeenCalledWith('payment');
   });
 
-  it('shows low balance warning when balance is below 100', async () => {
-    mockUseWalletBalance.mockReturnValue({
-      balance: {
-        balance: 50,
-        currency: 'credits',
-        recent_transactions: [],
-        wallet_configured: true
-      },
-      isLoading: false,
-      error: null,
-      refetch: mockRefetch
-    });
-
+  it('opens subscriptions settings from dropdown footer', async () => {
     const user = userEvent.setup();
-    render(<BalanceIndicator />);
+    renderIndicator();
 
     await user.click(screen.getByRole('button', { name: /account balance/i }));
+    await user.click(screen.getByText('Manage all'));
 
-    expect(
-      screen.getByText('Your balance is running low. Consider adding more credits.')
-    ).toBeInTheDocument();
-  });
-
-  it('shows empty balance warning when balance is zero', async () => {
-    mockUseWalletBalance.mockReturnValue({
-      balance: {
-        balance: 0,
-        currency: 'credits',
-        recent_transactions: [],
-        wallet_configured: true
-      },
-      isLoading: false,
-      error: null,
-      refetch: mockRefetch
-    });
-
-    const user = userEvent.setup();
-    render(<BalanceIndicator />);
-
-    await user.click(screen.getByRole('button', { name: /account balance/i }));
-
-    expect(
-      screen.getByText('Your balance is empty. Add credits to continue using services.')
-    ).toBeInTheDocument();
-  });
-
-  it('shows error message in dropdown when error exists', async () => {
-    mockUseWalletBalance.mockReturnValue({
-      balance: null,
-      isLoading: false,
-      error: 'Failed to fetch',
-      refetch: mockRefetch
-    });
-
-    render(<BalanceIndicator />);
-
-    // Open dropdown
-    fireEvent.click(screen.getByRole('button', { name: /account balance/i }));
-
-    expect(screen.getByText('Failed to load balance')).toBeInTheDocument();
+    expect(mockOpenSettings).toHaveBeenCalledWith('subscriptions');
   });
 
   it('closes dropdown on Escape key', async () => {
     const user = userEvent.setup();
-    render(<BalanceIndicator />);
+    renderIndicator();
 
-    // Open dropdown
     await user.click(screen.getByRole('button', { name: /account balance/i }));
-    expect(screen.getByText('Available Credits')).toBeInTheDocument();
+    expect(screen.getByText('Tempo · pathUSD')).toBeInTheDocument();
 
-    // Press Escape
     await user.keyboard('{Escape}');
-
-    expect(screen.queryByText('Available Credits')).not.toBeInTheDocument();
+    expect(screen.queryByText('Tempo · pathUSD')).not.toBeInTheDocument();
   });
 
   it('closes dropdown on click outside', async () => {
-    render(<BalanceIndicator />);
+    renderIndicator();
 
-    // Open dropdown
     fireEvent.click(screen.getByRole('button', { name: /account balance/i }));
-    expect(screen.getByText('Available Credits')).toBeInTheDocument();
+    expect(screen.getByText('Tempo · pathUSD')).toBeInTheDocument();
 
-    // Click outside
     fireEvent.mouseDown(document.body);
 
     await waitFor(() => {
-      expect(screen.queryByText('Available Credits')).not.toBeInTheDocument();
+      expect(screen.queryByText('Tempo · pathUSD')).not.toBeInTheDocument();
     });
   });
 });

--- a/components/frontend/src/components/balance/balance-indicator.tsx
+++ b/components/frontend/src/components/balance/balance-indicator.tsx
@@ -4,56 +4,38 @@ import { AnimatePresence, motion } from 'framer-motion';
 import AlertCircle from 'lucide-react/dist/esm/icons/alert-circle';
 import ChevronDown from 'lucide-react/dist/esm/icons/chevron-down';
 import Coins from 'lucide-react/dist/esm/icons/coins';
-import ExternalLink from 'lucide-react/dist/esm/icons/external-link';
 import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
-import RefreshCw from 'lucide-react/dist/esm/icons/refresh-cw';
-import Settings from 'lucide-react/dist/esm/icons/settings';
 
 import { OnboardingCallout } from '@/components/onboarding';
 import { useWalletContext } from '@/context/wallet-context';
-import { useWalletBalance, useWalletTransactions } from '@/hooks/use-wallet-api';
+import { useWalletBalance } from '@/hooks/use-wallet-api';
 import { cn } from '@/lib/utils';
 import { useSettingsModalStore } from '@/stores/settings-modal-store';
 
 import {
-  BalanceDisplay,
-  formatBalance,
+  formatBalanceCompact,
   getBalanceStatus,
-  getDisplayText,
   statusColors,
   statusRingColors
 } from './balance-display';
-import { TransactionList } from './transaction-list';
+import { CreditsPanel } from './credits-panel';
 
 /**
- * BalanceIndicator - Displays user's credits balance in a compact pill.
+ * BalanceIndicator — top-bar pill that opens the unified Credits Panel.
  *
- * Features:
- * - Shows balance with status indicator (green/yellow/red)
- * - Click to expand dropdown with details
- * - Shows recent transactions
- * - Links to wallet settings
+ * The pill itself stays focused on the MPP wallet balance (the universal
+ * SyftHub wallet); endpoint subscriptions live inside the dropdown so the
+ * nav stays visually quiet.
  */
 export function BalanceIndicator() {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownReference = useRef<HTMLDivElement>(null);
   const buttonReference = useRef<HTMLButtonElement>(null);
 
-  const { isConfigured, isLoading: isLoadingWallet, wallet } = useWalletContext();
-  const {
-    balance: walletBalance,
-    isLoading: isLoadingBalance,
-    error,
-    refetch
-  } = useWalletBalance();
-  const {
-    transactions,
-    isLoading: isLoadingTransactions,
-    refetch: refetchTransactions
-  } = useWalletTransactions({ autoFetch: isConfigured });
+  const { isConfigured, isLoading: isLoadingWallet } = useWalletContext();
+  const { balance: walletBalance, isLoading: isLoadingBalance, error } = useWalletBalance();
   const { openSettings } = useSettingsModalStore();
 
-  // Close dropdown when clicking outside
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (
@@ -74,14 +56,10 @@ export function BalanceIndicator() {
     }
   }, [isOpen]);
 
-  // Close on escape key
   useEffect(() => {
     function handleEscape(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        setIsOpen(false);
-      }
+      if (event.key === 'Escape') setIsOpen(false);
     }
-
     if (isOpen) {
       document.addEventListener('keydown', handleEscape);
       return () => {
@@ -90,58 +68,68 @@ export function BalanceIndicator() {
     }
   }, [isOpen]);
 
-  const handleRefresh = useCallback(async () => {
-    await Promise.all([refetch(), refetchTransactions()]);
-  }, [refetch, refetchTransactions]);
+  const closePanel = useCallback(() => {
+    setIsOpen(false);
+  }, []);
 
-  const handleOpenSettings = useCallback(() => {
+  const handleOpenWalletSettings = useCallback(() => {
     setIsOpen(false);
     openSettings('payment');
+  }, [openSettings]);
+
+  const handleOpenSubscriptionsSettings = useCallback(() => {
+    setIsOpen(false);
+    openSettings('subscriptions');
   }, [openSettings]);
 
   const toggleOpen = useCallback(() => {
     setIsOpen((previous) => !previous);
   }, []);
 
-  // Don't show if not authenticated or wallet info is loading
-  if (isLoadingWallet) {
-    return null;
-  }
+  if (isLoadingWallet) return null;
 
-  // Show setup prompt if not configured
   if (!isConfigured) {
     return (
-      <button
-        onClick={handleOpenSettings}
-        className={cn(
-          'font-inter flex items-center gap-2 rounded-lg border px-3 py-1.5 text-xs transition-colors',
-          'border-amber-200 bg-amber-50 text-amber-700',
-          'hover:border-amber-300 hover:bg-amber-100'
-        )}
-      >
-        <Coins className='h-3.5 w-3.5' aria-hidden='true' />
-        <span>Set up wallet</span>
-      </button>
+      <OnboardingCallout step='balance' position='bottom'>
+        <div className='relative'>
+          <button
+            ref={buttonReference}
+            onClick={toggleOpen}
+            className={cn(
+              'font-inter flex items-center gap-2 rounded-lg border px-3 py-1.5 text-xs transition-colors',
+              'border-amber-200 bg-amber-50 text-amber-700',
+              'hover:border-amber-300 hover:bg-amber-100'
+            )}
+            aria-expanded={isOpen}
+            aria-haspopup='true'
+          >
+            <Coins className='h-3.5 w-3.5' aria-hidden='true' />
+            <span>Set up wallet</span>
+            <ChevronDown className={cn('h-3 w-3 transition-transform', isOpen && 'rotate-180')} />
+          </button>
+          <Dropdown
+            isOpen={isOpen}
+            dropdownReference={dropdownReference}
+            onClose={closePanel}
+            onOpenWalletSettings={handleOpenWalletSettings}
+            onOpenSubscriptionsSettings={handleOpenSubscriptionsSettings}
+          />
+        </div>
+      </OnboardingCallout>
     );
   }
 
-  const isLoading = isLoadingBalance || isLoadingWallet;
+  const isLoading = isLoadingBalance;
   const balance = walletBalance?.balance ?? 0;
   const status = getBalanceStatus(balance);
 
-  // Get recent transactions (last 3)
-  const recentTransactions = transactions.slice(0, 3);
-
-  // Render status icon based on loading/error/success state
   const renderStatusIcon = () => {
     if (isLoading) {
       return <Loader2 className='text-muted-foreground h-3.5 w-3.5 animate-spin' />;
     }
-
     if (error) {
       return <AlertCircle className='h-3.5 w-3.5 text-red-500' />;
     }
-
     return (
       <div className='relative'>
         <div
@@ -161,25 +149,22 @@ export function BalanceIndicator() {
   return (
     <OnboardingCallout step='balance' position='bottom'>
       <div className='relative'>
-        {/* Balance Pill Button */}
         <button
           ref={buttonReference}
           onClick={toggleOpen}
-          disabled={isLoading}
           className={cn(
             'font-inter flex items-center gap-2 rounded-lg border px-3 py-1.5 text-sm transition-colors transition-shadow',
             'border-border bg-muted',
             'hover:border-input hover:shadow-sm',
-            'focus:ring-ring/20 focus:ring-2 focus:outline-none',
-            'disabled:cursor-not-allowed disabled:opacity-50'
+            'focus:ring-ring/20 focus:ring-2 focus:outline-none'
           )}
-          aria-label={`Account balance: ${formatBalance(balance)} credits`}
+          aria-label={`Account balance: ${formatBalanceCompact(balance)}`}
           aria-expanded={isOpen}
           aria-haspopup='true'
         >
           {renderStatusIcon()}
           <span className='text-foreground font-medium tabular-nums'>
-            {getDisplayText(isLoading, error, balance)}
+            {error ? 'Error' : formatBalanceCompact(balance)}
           </span>
           <ChevronDown
             className={cn(
@@ -189,94 +174,55 @@ export function BalanceIndicator() {
           />
         </button>
 
-        {/* Dropdown */}
-        <AnimatePresence>
-          {isOpen ? (
-            <motion.div
-              ref={dropdownReference}
-              initial={{ opacity: 0, y: -8, scale: 0.96 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: -8, scale: 0.96 }}
-              transition={{ duration: 0.15, ease: 'easeOut' }}
-              className={cn(
-                'absolute top-full right-0 z-50 mt-2 w-72',
-                'bg-card border-border rounded-xl border shadow-lg'
-              )}
-            >
-              {/* Header */}
-              <div className='border-border border-b px-4 py-3'>
-                <div className='flex items-center justify-between'>
-                  <span className='font-inter text-muted-foreground text-xs font-medium tracking-wide uppercase'>
-                    Available Credits
-                  </span>
-                  <button
-                    onClick={() => void handleRefresh()}
-                    disabled={isLoading}
-                    className={cn(
-                      'text-muted-foreground rounded-md p-1 transition-colors',
-                      'hover:bg-muted hover:text-foreground',
-                      'disabled:cursor-not-allowed disabled:opacity-50'
-                    )}
-                    aria-label='Refresh balance'
-                  >
-                    <RefreshCw className={cn('h-3.5 w-3.5', isLoading && 'animate-spin')} />
-                  </button>
-                </div>
-
-                <BalanceDisplay
-                  isLoading={isLoading}
-                  error={error}
-                  balance={balance}
-                  status={status}
-                />
-              </div>
-
-              {/* Recent Transactions */}
-              <div className='px-4 py-3'>
-                <div className='mb-2 flex items-center justify-between'>
-                  <span className='font-inter text-muted-foreground text-xs font-medium'>
-                    Recent Activity
-                  </span>
-                </div>
-
-                <TransactionList
-                  isLoading={isLoadingTransactions}
-                  transactions={recentTransactions}
-                  walletAddress={wallet?.address ?? ''}
-                />
-              </div>
-
-              {/* Footer Actions */}
-              <div className='border-border border-t px-4 py-3'>
-                <div className='flex gap-2'>
-                  <button
-                    onClick={handleOpenSettings}
-                    className={cn(
-                      'font-inter flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium transition-colors',
-                      'bg-muted text-foreground',
-                      'hover:bg-border'
-                    )}
-                  >
-                    <Settings className='h-3.5 w-3.5' />
-                    Settings
-                  </button>
-                  <button
-                    onClick={handleOpenSettings}
-                    className={cn(
-                      'font-inter flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium transition-colors',
-                      'bg-primary text-white',
-                      'hover:bg-primary/90'
-                    )}
-                  >
-                    <ExternalLink className='h-3.5 w-3.5' />
-                    View All
-                  </button>
-                </div>
-              </div>
-            </motion.div>
-          ) : null}
-        </AnimatePresence>
+        <Dropdown
+          isOpen={isOpen}
+          dropdownReference={dropdownReference}
+          onClose={closePanel}
+          onOpenWalletSettings={handleOpenWalletSettings}
+          onOpenSubscriptionsSettings={handleOpenSubscriptionsSettings}
+        />
       </div>
     </OnboardingCallout>
+  );
+}
+
+interface DropdownProperties {
+  isOpen: boolean;
+  dropdownReference: React.RefObject<HTMLDivElement | null>;
+  onClose: () => void;
+  onOpenWalletSettings: () => void;
+  onOpenSubscriptionsSettings: () => void;
+}
+
+function Dropdown({
+  isOpen,
+  dropdownReference,
+  onClose,
+  onOpenWalletSettings,
+  onOpenSubscriptionsSettings
+}: Readonly<DropdownProperties>) {
+  return (
+    <AnimatePresence>
+      {isOpen ? (
+        <motion.div
+          ref={dropdownReference}
+          initial={{ opacity: 0, y: -8, scale: 0.96 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: -8, scale: 0.96 }}
+          transition={{ duration: 0.15, ease: 'easeOut' }}
+          className={cn(
+            'absolute top-full right-0 z-50 mt-2 w-[360px]',
+            'bg-card border-border rounded-xl border shadow-lg'
+          )}
+        >
+          <CreditsPanel
+            enabled={isOpen}
+            onClose={onClose}
+            onOpenWalletSettings={onOpenWalletSettings}
+            onOpenSubscriptionsSettings={onOpenSubscriptionsSettings}
+          />
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
   );
 }

--- a/components/frontend/src/components/balance/credits-panel.tsx
+++ b/components/frontend/src/components/balance/credits-panel.tsx
@@ -1,0 +1,457 @@
+/**
+ * CreditsPanel
+ *
+ * Unified panel that lists every credit pool the user holds:
+ *   - the MPP/Tempo wallet (one per user, blockchain-backed)
+ *   - every Xendit subscription (one per publisher wallet they've funded)
+ *
+ * Designed to live inside the BalanceIndicator dropdown. Per-row balance
+ * polling is tied to `enabled` so the panel goes silent when closed.
+ */
+import type { XenditSubscription } from '@/lib/types';
+
+import AlertCircle from 'lucide-react/dist/esm/icons/alert-circle';
+import CheckCircle2 from 'lucide-react/dist/esm/icons/check-circle-2';
+import CircleDot from 'lucide-react/dist/esm/icons/circle-dot';
+import CreditCard from 'lucide-react/dist/esm/icons/credit-card';
+import ExternalLink from 'lucide-react/dist/esm/icons/external-link';
+import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
+import RefreshCw from 'lucide-react/dist/esm/icons/refresh-cw';
+import Wallet from 'lucide-react/dist/esm/icons/wallet';
+import { Link } from 'react-router-dom';
+
+import { useWalletContext } from '@/context/wallet-context';
+import { useWalletBalance } from '@/hooks/use-wallet-api';
+import { useSubscriptionBalance, useXenditSubscriptions } from '@/hooks/use-xendit-subscriptions';
+import { cn } from '@/lib/utils';
+import { openCheckoutWindow, POLL_INTERVAL_MS } from '@/lib/xendit-client';
+
+import { formatBalance } from './balance-display';
+
+export interface CreditsPanelProperties {
+  /** Whether the panel is visible — gates the per-row polling. */
+  enabled: boolean;
+  /** Open the wallet settings tab (closes the panel). */
+  onOpenWalletSettings: () => void;
+  /** Open the subscriptions settings tab (closes the panel). */
+  onOpenSubscriptionsSettings: () => void;
+  /** Close the panel (used after navigation links). */
+  onClose: () => void;
+}
+
+export function CreditsPanel({
+  enabled,
+  onOpenWalletSettings,
+  onOpenSubscriptionsSettings,
+  onClose
+}: Readonly<CreditsPanelProperties>) {
+  const subscriptionsQuery = useXenditSubscriptions({ enabled });
+  const subscriptions = subscriptionsQuery.data ?? [];
+
+  return (
+    <div className='divide-border divide-y'>
+      <div className='px-4 py-3'>
+        <SectionHeader label='MPP Wallet' onRefresh={null} />
+        <MppWalletRow onOpenSettings={onOpenWalletSettings} />
+      </div>
+
+      <div className='px-4 py-3'>
+        <SectionHeader
+          label={
+            subscriptions.length > 0
+              ? `Endpoint subscriptions · ${String(subscriptions.length)}`
+              : 'Endpoint subscriptions'
+          }
+          onRefresh={() => void subscriptionsQuery.refetch()}
+          isRefreshing={subscriptionsQuery.isFetching}
+        />
+        <SubscriptionsBody
+          isLoading={subscriptionsQuery.isLoading}
+          subscriptions={subscriptions}
+          enabled={enabled}
+          onNavigate={onClose}
+        />
+      </div>
+
+      <div className='flex items-center justify-between px-4 py-3'>
+        <button
+          type='button'
+          onClick={onOpenWalletSettings}
+          className={cn(
+            'font-inter text-muted-foreground hover:text-foreground',
+            'text-xs font-medium transition-colors'
+          )}
+        >
+          Wallet settings
+        </button>
+        <button
+          type='button'
+          onClick={onOpenSubscriptionsSettings}
+          className={cn(
+            'font-inter inline-flex items-center gap-1.5',
+            'rounded-md px-2 py-1 text-xs font-medium',
+            'text-foreground hover:bg-muted transition-colors'
+          )}
+        >
+          Manage all
+          <ExternalLink className='h-3 w-3' />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Subscriptions body (loading / empty / list) ───────────────────────────
+
+interface SubscriptionsBodyProperties {
+  isLoading: boolean;
+  subscriptions: XenditSubscription[];
+  enabled: boolean;
+  onNavigate: () => void;
+}
+
+function SubscriptionsBody({
+  isLoading,
+  subscriptions,
+  enabled,
+  onNavigate
+}: Readonly<SubscriptionsBodyProperties>) {
+  if (isLoading) return <SubscriptionsSkeleton />;
+  if (subscriptions.length === 0) return <SubscriptionsEmpty />;
+  return (
+    <div className='space-y-1.5'>
+      {subscriptions.map((sub) => (
+        <SubscriptionRow
+          key={sub.id}
+          subscription={sub}
+          enabled={enabled}
+          onNavigate={onNavigate}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ── Section header ─────────────────────────────────────────────────────────
+
+interface SectionHeaderProperties {
+  label: string;
+  onRefresh: (() => void) | null;
+  isRefreshing?: boolean;
+}
+
+function SectionHeader({
+  label,
+  onRefresh,
+  isRefreshing = false
+}: Readonly<SectionHeaderProperties>) {
+  return (
+    <div className='mb-2 flex items-center justify-between'>
+      <span className='font-inter text-muted-foreground text-[10px] font-semibold tracking-wider uppercase'>
+        {label}
+      </span>
+      {onRefresh && (
+        <button
+          type='button'
+          onClick={onRefresh}
+          disabled={isRefreshing}
+          className={cn(
+            'text-muted-foreground rounded p-1 transition-colors',
+            'hover:bg-muted hover:text-foreground',
+            'disabled:cursor-not-allowed disabled:opacity-50'
+          )}
+          aria-label='Refresh'
+        >
+          <RefreshCw className={cn('h-3 w-3', isRefreshing && 'animate-spin')} />
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── MPP wallet row ─────────────────────────────────────────────────────────
+
+interface MppWalletRowProperties {
+  onOpenSettings: () => void;
+}
+
+function MppWalletRow({ onOpenSettings }: Readonly<MppWalletRowProperties>) {
+  const { isConfigured } = useWalletContext();
+  const { balance, isLoading, error, refetch } = useWalletBalance();
+
+  if (!isConfigured) {
+    return (
+      <button
+        type='button'
+        onClick={onOpenSettings}
+        className={cn(
+          'group flex w-full items-center justify-between gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors',
+          'border-amber-200 bg-amber-50/60 hover:bg-amber-50',
+          'dark:border-amber-900/50 dark:bg-amber-950/15 dark:hover:bg-amber-950/30'
+        )}
+      >
+        <div className='flex min-w-0 items-center gap-2.5'>
+          <WalletChip className='border-amber-200 bg-amber-100 text-amber-700 dark:border-amber-900/60 dark:bg-amber-900/30 dark:text-amber-400'>
+            <Wallet className='h-3.5 w-3.5' />
+          </WalletChip>
+          <div className='min-w-0'>
+            <div className='font-inter text-foreground truncate text-sm font-medium'>
+              MPP Wallet
+            </div>
+            <div className='font-inter text-muted-foreground text-[11px]'>
+              Set up your wallet to pay endpoints
+            </div>
+          </div>
+        </div>
+        <span className='font-inter shrink-0 text-[11px] font-medium text-amber-700 group-hover:underline dark:text-amber-400'>
+          Set up
+        </span>
+      </button>
+    );
+  }
+
+  const displayBalance = balance?.balance ?? 0;
+  const currency = balance?.currency ?? 'USD';
+  const status = balanceStatus(displayBalance, 0);
+
+  return (
+    <div className={cn('rounded-lg border px-3 py-2.5', 'border-border bg-background/40')}>
+      <div className='flex items-center justify-between gap-3'>
+        <div className='flex min-w-0 items-center gap-2.5'>
+          <WalletChip className='border-emerald-200 bg-emerald-100 text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-900/30 dark:text-emerald-400'>
+            <Wallet className='h-3.5 w-3.5' />
+          </WalletChip>
+          <div className='min-w-0'>
+            <div className='font-inter text-foreground truncate text-sm font-medium'>
+              MPP Wallet
+            </div>
+            <div className='font-inter text-muted-foreground text-[11px]'>Tempo · pathUSD</div>
+          </div>
+        </div>
+        <BalanceCell
+          isLoading={isLoading}
+          error={error}
+          balance={displayBalance}
+          currency={currency}
+          status={status}
+          onRefresh={() => void refetch()}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ── Subscription row ───────────────────────────────────────────────────────
+
+interface SubscriptionRowProperties {
+  subscription: XenditSubscription;
+  enabled: boolean;
+  onNavigate: () => void;
+}
+
+function SubscriptionRow({
+  subscription,
+  enabled,
+  onNavigate
+}: Readonly<SubscriptionRowProperties>) {
+  const { balance, isLoading, error, refetch } = useSubscriptionBalance(subscription, {
+    enabled,
+    pollIntervalMs: enabled ? POLL_INTERVAL_MS : undefined
+  });
+
+  const liveBalance = balance ?? subscription.last_known_balance ?? 0;
+  const status = balanceStatus(liveBalance, 0);
+  const label = subscription.endpoint_slug
+    ? `${subscription.endpoint_owner}/${subscription.endpoint_slug}`
+    : subscription.endpoint_owner;
+  const targetPath = subscription.endpoint_slug
+    ? `/${subscription.endpoint_owner}/${subscription.endpoint_slug}`
+    : `/${subscription.endpoint_owner}`;
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border px-3 py-2.5 transition-colors',
+        'border-border bg-background/40 hover:bg-muted/30'
+      )}
+    >
+      <div className='flex items-center justify-between gap-3'>
+        <Link
+          to={targetPath}
+          onClick={onNavigate}
+          className='flex min-w-0 flex-1 items-center gap-2.5'
+        >
+          <WalletChip className='border-violet-200 bg-violet-100 text-violet-700 dark:border-violet-900/60 dark:bg-violet-900/30 dark:text-violet-400'>
+            <CreditCard className='h-3.5 w-3.5' />
+          </WalletChip>
+          <div className='min-w-0'>
+            <div className='font-inter text-foreground truncate text-sm font-medium'>{label}</div>
+            <div className='font-inter text-muted-foreground text-[11px]'>
+              Xendit · {subscription.currency}
+            </div>
+          </div>
+        </Link>
+        <BalanceCell
+          isLoading={isLoading && balance === null}
+          error={error?.message ?? null}
+          balance={liveBalance}
+          currency={subscription.currency}
+          status={status}
+          onRefresh={() => void refetch()}
+          /* Top-up CTA only meaningful for depleted Xendit pools. */
+          onTopUp={
+            status === 'empty'
+              ? () => {
+                  openCheckoutWindow(subscription.payment_url);
+                }
+              : null
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+// ── Balance cell ───────────────────────────────────────────────────────────
+
+interface BalanceCellProperties {
+  isLoading: boolean;
+  error: string | null;
+  balance: number;
+  currency: string;
+  status: BalanceStatus;
+  onRefresh: () => void;
+  onTopUp?: (() => void) | null;
+}
+
+function BalanceCell({
+  isLoading,
+  error,
+  balance,
+  currency,
+  status,
+  onRefresh,
+  onTopUp = null
+}: Readonly<BalanceCellProperties>) {
+  if (isLoading) {
+    return (
+      <span className='text-muted-foreground inline-flex items-center gap-1.5 text-xs'>
+        <Loader2 className='h-3 w-3 animate-spin' />
+      </span>
+    );
+  }
+  if (error) {
+    return (
+      <button
+        type='button'
+        onClick={onRefresh}
+        className='inline-flex items-center gap-1 text-[11px] text-red-600 hover:underline dark:text-red-400'
+      >
+        <AlertCircle className='h-3 w-3' />
+        Retry
+      </button>
+    );
+  }
+  return (
+    <div className='flex shrink-0 items-center gap-1.5'>
+      <StatusChip status={status} />
+      <span className={cn('font-inter text-foreground text-sm font-semibold tabular-nums')}>
+        {formatBalance(balance)}
+      </span>
+      <span className='text-muted-foreground text-[10px]'>{currency}</span>
+      {onTopUp && (
+        <button
+          type='button'
+          onClick={onTopUp}
+          className={cn(
+            'ml-1 inline-flex items-center gap-0.5 rounded px-1.5 py-0.5',
+            'text-[10px] font-medium',
+            'border border-violet-300 bg-violet-50 text-violet-700',
+            'hover:bg-violet-100',
+            'dark:border-violet-700 dark:bg-violet-950/30 dark:text-violet-300',
+            'dark:hover:bg-violet-900/40'
+          )}
+        >
+          Top up
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── Status chip ────────────────────────────────────────────────────────────
+
+type BalanceStatus = 'healthy' | 'low' | 'empty';
+
+function balanceStatus(balance: number, threshold: number): BalanceStatus {
+  if (balance <= threshold) return 'empty';
+  if (balance < (threshold > 0 ? threshold * 10 : 100)) return 'low';
+  return 'healthy';
+}
+
+function StatusChip({ status }: Readonly<{ status: BalanceStatus }>) {
+  if (status === 'healthy') {
+    return (
+      <CheckCircle2
+        aria-label='Healthy balance'
+        className='h-3 w-3 text-emerald-500 dark:text-emerald-400'
+      />
+    );
+  }
+  if (status === 'low') {
+    return (
+      <CircleDot aria-label='Low balance' className='h-3 w-3 text-amber-500 dark:text-amber-400' />
+    );
+  }
+  return (
+    <AlertCircle aria-label='Empty balance' className='h-3 w-3 text-red-500 dark:text-red-400' />
+  );
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function WalletChip({
+  className,
+  children
+}: Readonly<{ className?: string; children: React.ReactNode }>) {
+  return (
+    <div
+      className={cn(
+        'flex h-7 w-7 shrink-0 items-center justify-center rounded-md border',
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function SubscriptionsSkeleton() {
+  return (
+    <div className='space-y-1.5'>
+      {[0, 1].map((index) => (
+        <div
+          key={index}
+          className='border-border bg-background/40 flex animate-pulse items-center gap-3 rounded-lg border px-3 py-2.5'
+        >
+          <div className='bg-muted h-7 w-7 rounded-md' />
+          <div className='flex-1 space-y-1'>
+            <div className='bg-muted h-3 w-32 rounded' />
+            <div className='bg-muted h-2 w-20 rounded' />
+          </div>
+          <div className='bg-muted h-3 w-12 rounded' />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SubscriptionsEmpty() {
+  return (
+    <div className='border-border text-muted-foreground rounded-lg border border-dashed bg-transparent px-3 py-3 text-center text-[11px]'>
+      No endpoint subscriptions yet.
+      <br />
+      Pay for a Xendit endpoint to see it here.
+    </div>
+  );
+}

--- a/components/frontend/src/components/chat/chat-view.tsx
+++ b/components/frontend/src/components/chat/chat-view.tsx
@@ -523,7 +523,16 @@ export function ChatView({
                         setSelectedModel(null);
                       }
                     }
-                    const next = gateState.pending.filter((p) => p.walletKey !== removed.walletKey);
+                    // Each row is uniquely identified by (walletKey, endpoint).
+                    // Multiple rows can share a walletKey when sibling endpoints
+                    // come from the same publisher wallet, so filtering by
+                    // walletKey alone would drop every sibling row at once.
+                    const removedPath = removed.endpoints[0]?.path ?? '';
+                    const next = gateState.pending.filter(
+                      (p) =>
+                        p.walletKey !== removed.walletKey ||
+                        (p.endpoints[0]?.path ?? '') !== removedPath
+                    );
                     // Removing the model invalidates the queued send —
                     // no model left to chat with. Behave like Cancel.
                     if (removedModel) {

--- a/components/frontend/src/components/chat/chat-view.tsx
+++ b/components/frontend/src/components/chat/chat-view.tsx
@@ -8,6 +8,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { ChatHistoryMessage, WorkflowResult } from '@/hooks/use-chat-workflow';
+import type { PendingSubscription } from '@/hooks/use-xendit-precheck';
 import type { SearchableChatSource } from '@/lib/search-service';
 import type { ChatSource } from '@/lib/types';
 import type { SourcesData } from './sources-section';
@@ -29,11 +30,13 @@ import { useChatWorkflow } from '@/hooks/use-chat-workflow';
 import { useDataSources } from '@/hooks/use-data-sources';
 import { useModels } from '@/hooks/use-models';
 import { useSuggestedSources } from '@/hooks/use-suggested-sources';
+import { useXenditPrecheck } from '@/hooks/use-xendit-precheck';
 import { useContextSelectionStore } from '@/stores/context-selection-store';
 import { useOnboardingStore } from '@/stores/onboarding-store';
 
 import { AddSourcesModal } from './add-sources-modal';
 import { MarkdownMessage } from './markdown-message';
+import { PaymentGate } from './payment-gate';
 import { SearchInput } from './search-input';
 import { SourcesSection } from './sources-section';
 import { StatusIndicator } from './status-indicator';
@@ -111,10 +114,8 @@ export function ChatView({
     [selectedSources]
   );
 
-  // Pre-generated ID for the user message seeded by the initialQuery useState initializer.
-  // Must be declared before the messages useState so the lazy initializer can use the same ID.
-  // This ID is later assigned to pendingMessageIdReference in the auto-trigger useEffect so that
-  // onComplete can detect the pre-existing message and skip adding a duplicate.
+  // Stable ID shared with the seeded initial-query message and the auto-trigger
+  // effect, so onComplete recognises the pre-existing bubble and won't duplicate.
   const initialQueryMessageIdReference = useRef<string | null>(
     initialQuery && !initialResult ? crypto.randomUUID() : null
   );
@@ -212,28 +213,9 @@ export function ChatView({
     }
   });
 
-  // Auto-trigger workflow for initial query (when navigated from home page)
-  useEffect(() => {
-    // Only trigger if:
-    // 1. We have an initial query
-    // 2. No initial result (not already processed)
-    // 3. Workflow is idle
-    // 4. Model is selected
-    // 5. Sources have loaded
-    if (
-      initialQuery &&
-      !initialResult &&
-      workflow.phase === 'idle' &&
-      selectedModel &&
-      !isLoadingDataSources
-    ) {
-      // Set pendingMessageIdReference to the pre-seeded user message ID so that onComplete
-      // treats it as an optimistic message and does not add a duplicate.
-      pendingMessageIdReference.current = initialQueryMessageIdReference.current;
-      void workflow.submitQuery(initialQuery);
-    }
-    // Only run once when dependencies are ready, not on every change
-  }, [initialQuery, initialResult, selectedModel, isLoadingDataSources]);
+  // One-shot latch so the home-page initial query doesn't refire after the
+  // gate modal opens (workflow stays in 'idle' until submitQuery actually runs).
+  const autoTriggeredReference = useRef(false);
 
   // Determine if workflow is in a blocking state
   const isWorkflowActive =
@@ -262,32 +244,22 @@ export function ChatView({
     [contextStore]
   );
 
-  // Handle query submission
-  const handleSubmit = useCallback(
-    (query: string) => {
-      // Build conversation history from existing messages (prior turns only)
-      const history: ChatHistoryMessage[] = messages
-        .filter((m): m is Message & { content: string } => !!m.content)
-        .map((m) => ({ role: m.role, content: m.content }));
+  // Gate state holds the pending wallets and the ID of the user-bubble
+  // shown above the gate (so Cancel can pop it). What to run on confirm is
+  // stashed in proceedReference (function-in-state would clash with setState).
+  const [gateState, setGateState] = useState<
+    { open: false } | { open: true; pending: PendingSubscription[]; messageId: string | null }
+  >({ open: false });
+  const proceedReference = useRef<(() => void) | null>(null);
 
-      // Optimistically add user message immediately so it appears before the AI responds
-      const messageId = crypto.randomUUID();
-      pendingMessageIdReference.current = messageId;
-      lastQueryReference.current = query;
-      setMessages((previous) => [
-        ...previous,
-        {
-          id: messageId,
-          role: 'user' as const,
-          content: query,
-          type: 'text' as const
-        }
-      ]);
+  const xenditPrecheck = useXenditPrecheck({
+    model: selectedModel,
+    dataSources: contextStore.getSourcesArray()
+  });
 
-      // Clear suggestions on submit
-      clearSuggestions();
-      setInputText('');
-
+  // Submit the workflow query (without re-adding a user bubble).
+  const submitWorkflow = useCallback(
+    (query: string, history: ChatHistoryMessage[]) => {
       const preSelectedSources = contextStore.getSourcesArray();
       if (preSelectedSources.length > 0) {
         const sourceIds = new Set(preSelectedSources.map((s) => s.id));
@@ -296,8 +268,88 @@ export function ChatView({
         void workflow.submitQuery(query, undefined, history);
       }
     },
-    [workflow, contextStore, messages, clearSuggestions]
+    [workflow, contextStore]
   );
+
+  // Run the Xendit precheck, then either open the inline gate or invoke
+  // `proceed`. The user bubble is added eagerly by the caller so it shows
+  // above the gate while it's open — `messageId` lets Cancel pop it.
+  // A flaky precheck must not block the user — on any error we proceed and
+  // let the server-side policy enforcement be the safety net.
+  const runPrecheckThenProceed = useCallback(
+    (proceed: () => void, messageId: string | null) => {
+      void (async () => {
+        let pending: PendingSubscription[] = [];
+        try {
+          pending = await xenditPrecheck.runPrecheck();
+        } catch {
+          /* swallow — fall through to proceed */
+        }
+        if (pending.length > 0) {
+          proceedReference.current = proceed;
+          setGateState({ open: true, pending, messageId });
+          return;
+        }
+        proceed();
+      })();
+    },
+    [xenditPrecheck]
+  );
+
+  // Handle query submission from the chat input.
+  const handleSubmit = useCallback(
+    (query: string) => {
+      const history: ChatHistoryMessage[] = messages
+        .filter((m): m is Message & { content: string } => !!m.content)
+        .map((m) => ({ role: m.role, content: m.content }));
+
+      // Add user bubble immediately so it shows above the gate (if precheck
+      // blocks) and matches the optimistic-send pattern.
+      const messageId = crypto.randomUUID();
+      pendingMessageIdReference.current = messageId;
+      lastQueryReference.current = query;
+      setMessages((previous) => [
+        ...previous,
+        { id: messageId, role: 'user' as const, content: query, type: 'text' as const }
+      ]);
+      clearSuggestions();
+      setInputText('');
+
+      runPrecheckThenProceed(() => {
+        submitWorkflow(query, history);
+      }, messageId);
+    },
+    [messages, runPrecheckThenProceed, submitWorkflow, clearSuggestions]
+  );
+
+  // Auto-trigger workflow for the initial query (navigated from home page).
+  // The user bubble is already in `messages` from the useState initializer
+  // (id = initialQueryMessageIdReference.current).
+  useEffect(() => {
+    if (
+      autoTriggeredReference.current ||
+      !initialQuery ||
+      initialResult ||
+      workflow.phase !== 'idle' ||
+      !selectedModel ||
+      isLoadingDataSources
+    ) {
+      return;
+    }
+    autoTriggeredReference.current = true;
+    pendingMessageIdReference.current = initialQueryMessageIdReference.current;
+    lastQueryReference.current = initialQuery;
+    runPrecheckThenProceed(() => {
+      void workflow.submitQuery(initialQuery);
+    }, initialQueryMessageIdReference.current);
+  }, [
+    initialQuery,
+    initialResult,
+    selectedModel,
+    isLoadingDataSources,
+    runPrecheckThenProceed,
+    workflow
+  ]);
 
   // Handle modal confirm
   const handleSourceModalConfirm = useCallback(
@@ -436,6 +488,66 @@ export function ChatView({
                     </div>
                   </Message>
                 )
+              )}
+
+              {/* Payment gate — appears below the user bubble when one or
+                  more selected endpoints carry an unfunded Xendit policy. */}
+              {gateState.open && (
+                <PaymentGate
+                  pending={gateState.pending}
+                  onCancel={() => {
+                    // Pop the user bubble that triggered this gate.
+                    const droppedId = gateState.messageId;
+                    if (droppedId) {
+                      setMessages((previous) => previous.filter((m) => m.id !== droppedId));
+                    }
+                    pendingMessageIdReference.current = null;
+                    proceedReference.current = null;
+                    setGateState({ open: false });
+                  }}
+                  onConfirmSend={() => {
+                    setGateState({ open: false });
+                    const proceed = proceedReference.current;
+                    proceedReference.current = null;
+                    proceed?.();
+                  }}
+                  onRemovePending={(removed) => {
+                    // Drop those endpoints from the chat selection. Data
+                    // sources are removed by ID; if the row covers the
+                    // active model, clear the model too.
+                    const removedModel = removed.endpoints.some((ep) => ep.role === 'model');
+                    for (const ep of removed.endpoints) {
+                      if (ep.role === 'data_source') {
+                        contextStore.removeSource(ep.id);
+                      } else if (ep.id === selectedModel?.id) {
+                        setSelectedModel(null);
+                      }
+                    }
+                    const next = gateState.pending.filter((p) => p.walletKey !== removed.walletKey);
+                    // Removing the model invalidates the queued send —
+                    // no model left to chat with. Behave like Cancel.
+                    if (removedModel) {
+                      const droppedId = gateState.messageId;
+                      if (droppedId) {
+                        setMessages((previous) => previous.filter((m) => m.id !== droppedId));
+                      }
+                      pendingMessageIdReference.current = null;
+                      proceedReference.current = null;
+                      setGateState({ open: false });
+                      return;
+                    }
+                    if (next.length === 0) {
+                      // Last data-source blocker removed — fire the
+                      // queued send (model is still selected).
+                      const proceed = proceedReference.current;
+                      proceedReference.current = null;
+                      proceed?.();
+                      setGateState({ open: false });
+                      return;
+                    }
+                    setGateState({ open: true, pending: next, messageId: gateState.messageId });
+                  }}
+                />
               )}
 
               {/* Workflow UI - Processing Status & Streaming */}

--- a/components/frontend/src/components/chat/payment-gate.tsx
+++ b/components/frontend/src/components/chat/payment-gate.tsx
@@ -1,0 +1,431 @@
+/**
+ * PaymentGate
+ *
+ * Inline gate rendered in the chat history (right after the user's bubble)
+ * when one or more selected endpoints carry an unfunded Xendit policy.
+ * Each row drives its own buy flow (popup checkout window); the parent polls
+ * credits_url to detect when each wallet flips active and unlocks Send.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import type { PendingSubscription } from '@/hooks/use-xendit-precheck';
+
+import AlertTriangle from 'lucide-react/dist/esm/icons/alert-triangle';
+import ArrowRight from 'lucide-react/dist/esm/icons/arrow-right';
+import CheckCircle2 from 'lucide-react/dist/esm/icons/check-circle-2';
+import Clock from 'lucide-react/dist/esm/icons/clock';
+import CreditCard from 'lucide-react/dist/esm/icons/credit-card';
+import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
+import X from 'lucide-react/dist/esm/icons/x';
+
+import { BundlePicker } from '@/components/endpoint/bundle-picker';
+import { useRegisterOnFundingDetected } from '@/hooks/use-xendit-subscriptions';
+import { cn } from '@/lib/utils';
+import {
+  createInvoice,
+  fetchBalance,
+  getSatelliteToken,
+  openCheckoutWindow,
+  POLL_INTERVAL_MS
+} from '@/lib/xendit-client';
+
+function distinctOwners(pending: PendingSubscription[]): string[] {
+  const owners = new Set<string>();
+  for (const p of pending) {
+    for (const e of p.endpoints) owners.add(e.owner);
+  }
+  return [...owners];
+}
+
+// ── per-row sub-component ──────────────────────────────────────────────────
+
+type PurchaseState =
+  | { state: 'idle' }
+  | { state: 'creating' }
+  | { state: 'awaiting'; checkoutUrl: string }
+  | { state: 'error'; message: string };
+
+interface RowProperties {
+  pending: PendingSubscription;
+  liveBalance: number;
+  isActive: boolean;
+  onRemove: () => void;
+}
+
+function renderStatusLine(pending: PendingSubscription, isActive: boolean, liveBalance: number) {
+  if (isActive) {
+    return (
+      <span className='inline-flex items-center gap-1 text-emerald-700 dark:text-emerald-400'>
+        <CheckCircle2 className='h-3 w-3' />
+        <span className='tabular-nums'>
+          {pending.currency} {liveBalance.toLocaleString()} remaining
+        </span>
+      </span>
+    );
+  }
+  if (pending.pricePerRequest === null) {
+    return <>Pay-in-advance required</>;
+  }
+  return (
+    <span className='tabular-nums'>
+      {pending.currency} {pending.pricePerRequest.toLocaleString()} per request
+    </span>
+  );
+}
+
+function PaymentGateRow({ pending, liveBalance, isActive, onRemove }: Readonly<RowProperties>) {
+  const [purchase, setPurchase] = useState<PurchaseState>({ state: 'idle' });
+  const [selectedBundleName, setSelectedBundleName] = useState<string>(
+    () => pending.bundles[0]?.name ?? ''
+  );
+
+  // Once the wallet flips active the awaiting/creating chrome would just
+  // confuse the user, so reset it.
+  useEffect(() => {
+    if (isActive && purchase.state !== 'idle') {
+      setPurchase({ state: 'idle' });
+    }
+  }, [isActive, purchase.state]);
+
+  const selectedBundle =
+    pending.bundles.find((b) => b.name === selectedBundleName) ?? pending.bundles[0];
+
+  const primaryEndpoint = pending.endpoints[0];
+  const roleLabel = primaryEndpoint?.role === 'model' ? 'Model' : 'Data source';
+
+  const handleBuy = async () => {
+    if (!selectedBundle || !primaryEndpoint) return;
+    setPurchase({ state: 'creating' });
+    const token = await getSatelliteToken(primaryEndpoint.owner);
+    if (!token) {
+      setPurchase({
+        state: 'error',
+        message: 'Could not authenticate with the endpoint operator.'
+      });
+      return;
+    }
+    const result = await createInvoice(
+      pending.paymentUrl,
+      token,
+      selectedBundle.name,
+      primaryEndpoint.slug
+    );
+    if ('error' in result) {
+      setPurchase({ state: 'error', message: result.error });
+      return;
+    }
+    setPurchase({ state: 'awaiting', checkoutUrl: result.checkoutUrl });
+    openCheckoutWindow(result.checkoutUrl);
+  };
+
+  const isBusy = purchase.state === 'creating';
+  const isAwaiting = purchase.state === 'awaiting';
+
+  let buttonContent: React.ReactNode;
+  if (isBusy) {
+    buttonContent = (
+      <>
+        <Loader2 className='h-3 w-3 animate-spin' />
+        Opening…
+      </>
+    );
+  } else if (isAwaiting) {
+    buttonContent = (
+      <>
+        <Clock className='h-3 w-3' />
+        Reopen
+      </>
+    );
+  } else {
+    buttonContent = (
+      <>
+        Buy
+        <ArrowRight className='h-3 w-3 transition-transform group-hover:translate-x-0.5' />
+      </>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-md border bg-white px-3 py-2.5 transition-colors',
+        'dark:bg-card',
+        isActive
+          ? 'border-emerald-200 dark:border-emerald-900/50'
+          : 'border-amber-200/60 dark:border-amber-900/40'
+      )}
+    >
+      <div className='flex flex-wrap items-center justify-between gap-x-3 gap-y-2'>
+        {/* Left: icon + endpoint + status */}
+        <div className='flex min-w-0 flex-1 items-center gap-2.5'>
+          <div
+            className={cn(
+              'flex h-7 w-7 shrink-0 items-center justify-center rounded-md border',
+              isActive
+                ? 'border-emerald-200 bg-emerald-50 text-emerald-600 dark:border-emerald-900/60 dark:bg-emerald-950/30 dark:text-emerald-400'
+                : 'border-amber-200 bg-amber-50 text-amber-600 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-400'
+            )}
+          >
+            <CreditCard className='h-3.5 w-3.5' />
+          </div>
+          <div className='min-w-0'>
+            <div className='flex items-center gap-1.5'>
+              <span className='text-foreground truncate text-sm font-medium'>
+                {primaryEndpoint?.path ?? 'Unknown endpoint'}
+              </span>
+              <span className='text-muted-foreground text-[11px]'>· {roleLabel}</span>
+            </div>
+            <div className='text-muted-foreground mt-0.5 text-[11px]'>
+              {renderStatusLine(pending, isActive, liveBalance)}
+            </div>
+          </div>
+        </div>
+
+        {/* Right: actions */}
+        <div className='flex shrink-0 items-center gap-1.5'>
+          {!isActive && pending.bundles.length > 0 && selectedBundle && (
+            <>
+              <BundlePicker
+                bundles={pending.bundles}
+                currency={pending.currency}
+                value={selectedBundleName}
+                onChange={setSelectedBundleName}
+                disabled={isBusy}
+                triggerClassName='h-8 min-w-[7rem]'
+              />
+              <button
+                type='button'
+                disabled={isBusy}
+                onClick={() => void handleBuy()}
+                className={cn(
+                  'group inline-flex h-8 items-center justify-center gap-1.5 rounded-md border px-3 text-xs font-medium transition-colors',
+                  'border-violet-300 bg-violet-50 text-violet-700 dark:border-violet-700 dark:bg-violet-950/30 dark:text-violet-300',
+                  isBusy
+                    ? 'cursor-not-allowed opacity-50'
+                    : 'cursor-pointer hover:bg-violet-100 dark:hover:bg-violet-900/40'
+                )}
+              >
+                {buttonContent}
+              </button>
+            </>
+          )}
+          <button
+            type='button'
+            onClick={onRemove}
+            aria-label='Remove from selection'
+            title='Remove from selection'
+            className={cn(
+              'text-muted-foreground hover:text-foreground rounded-md p-1 transition-colors',
+              'hover:bg-muted/60 focus:ring-ring/30 focus:ring-2 focus:outline-none'
+            )}
+          >
+            <X className='h-3.5 w-3.5' />
+          </button>
+        </div>
+      </div>
+
+      {purchase.state === 'awaiting' && !isActive && (
+        <div className='mt-2 text-[11px] text-amber-700 dark:text-amber-400'>
+          Complete payment in the popup window. We'll detect it automatically.
+        </div>
+      )}
+
+      {purchase.state === 'error' && (
+        <div className='mt-2 rounded-md border border-red-200 bg-red-50/70 px-2 py-1 text-[11px] text-red-700 dark:border-red-900/60 dark:bg-red-950/20 dark:text-red-300'>
+          {purchase.message}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── PaymentGate ────────────────────────────────────────────────────────────
+
+export interface PaymentGateProperties {
+  pending: PendingSubscription[];
+  /** User cancels — the queued send is dropped. */
+  onCancel: () => void;
+  /** All wallets active and user clicks Send — fire the queued request. */
+  onConfirmSend: () => void;
+  /** User clicks the × on a row — drop those endpoints from the chat selection. */
+  onRemovePending: (pending: PendingSubscription) => void;
+}
+
+export function PaymentGate({
+  pending,
+  onCancel,
+  onConfirmSend,
+  onRemovePending
+}: Readonly<PaymentGateProperties>) {
+  const seedBalances = useMemo(() => {
+    const map: Record<string, number> = {};
+    for (const p of pending) map[p.walletKey] = p.balance;
+    return map;
+  }, [pending]);
+  const [balances, setBalances] = useState<Record<string, number>>(seedBalances);
+  useEffect(() => {
+    setBalances(seedBalances);
+  }, [seedBalances]);
+
+  // One satellite token per distinct owner, fetched once when the gate mounts.
+  const tokensReference = useRef<Map<string, string>>(new Map());
+  const owners = useMemo(() => distinctOwners(pending), [pending]);
+  useEffect(() => {
+    const controller = new AbortController();
+    void (async () => {
+      const next = new Map<string, string>();
+      await Promise.all(
+        owners.map(async (owner) => {
+          const token = await getSatelliteToken(owner);
+          if (token) next.set(owner, token);
+        })
+      );
+      if (controller.signal.aborted) return;
+      tokensReference.current = next;
+    })();
+    return () => {
+      controller.abort();
+    };
+  }, [owners]);
+
+  const isWalletActive = useCallback(
+    (p: PendingSubscription) => {
+      const balance = balances[p.walletKey] ?? 0;
+      const threshold = p.pricePerRequest ?? 1;
+      return balance >= threshold;
+    },
+    [balances]
+  );
+
+  // Register a subscription on the SyftHub backend the first time we observe
+  // a non-zero balance. Idempotent on the server, but we also dedupe locally
+  // so the mutation only fires once per wallet per gate session.
+  const registerOnFunding = useRegisterOnFundingDetected();
+  const registeredKeysReference = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    for (const p of pending) {
+      const balance = balances[p.walletKey] ?? 0;
+      if (balance <= 0) continue;
+      if (registeredKeysReference.current.has(p.walletKey)) continue;
+      registeredKeysReference.current.add(p.walletKey);
+      const owner = p.endpoints[0]?.owner ?? '';
+      const slug = p.endpoints[0]?.slug ?? null;
+      void registerOnFunding({
+        creditsUrl: p.creditsUrl,
+        paymentUrl: p.paymentUrl,
+        endpointOwner: owner,
+        endpointSlug: slug,
+        currency: p.currency,
+        lastKnownBalance: balance
+      });
+    }
+  }, [balances, pending, registerOnFunding]);
+
+  // Poll once per *wallet* that's still inactive — multiple rows sharing a
+  // credits_url collapse into one fetch, and the result updates every row
+  // bound to that wallet.
+  useEffect(() => {
+    const controller = new AbortController();
+    const tick = async () => {
+      const inactive = new Map<string, PendingSubscription>();
+      for (const p of pending) {
+        if (isWalletActive(p)) continue;
+        if (!inactive.has(p.walletKey)) inactive.set(p.walletKey, p);
+      }
+      if (inactive.size === 0) return;
+      const updates = await Promise.all(
+        [...inactive.values()].map(async (p) => {
+          const owner = p.endpoints[0]?.owner;
+          if (!owner) return null;
+          const token = tokensReference.current.get(owner);
+          if (!token) return null;
+          const balance = await fetchBalance(p.creditsUrl, token, controller.signal);
+          if (balance === null) return null;
+          return [p.walletKey, balance] as const;
+        })
+      );
+      setBalances((previous) => {
+        let next: Record<string, number> | null = null;
+        for (const u of updates) {
+          if (u && previous[u[0]] !== u[1]) {
+            next ??= { ...previous };
+            next[u[0]] = u[1];
+          }
+        }
+        return next ?? previous;
+      });
+    };
+    const intervalId = setInterval(() => void tick(), POLL_INTERVAL_MS);
+    return () => {
+      clearInterval(intervalId);
+      controller.abort();
+    };
+  }, [pending, isWalletActive]);
+
+  if (pending.length === 0) return null;
+
+  const allActive = pending.every((p) => isWalletActive(p));
+
+  return (
+    <div
+      role='region'
+      aria-label='Payment required'
+      className={cn(
+        'max-w-3xl rounded-xl border p-4',
+        'border-amber-200 bg-amber-50/70',
+        'dark:border-amber-900/50 dark:bg-amber-950/20'
+      )}
+    >
+      <div className='flex items-start gap-2.5'>
+        <AlertTriangle className='mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400' />
+        <div className='min-w-0 flex-1'>
+          <h3 className='font-rubik text-sm font-semibold text-amber-900 dark:text-amber-200'>
+            Some endpoints need payment
+          </h3>
+          <p className='font-inter mt-0.5 text-xs text-amber-800/80 dark:text-amber-300/80'>
+            Buy credits for each endpoint to send this message, or remove them from the selection to
+            continue without.
+          </p>
+        </div>
+      </div>
+
+      <div className='mt-3 space-y-1.5'>
+        {pending.map((p) => (
+          <PaymentGateRow
+            key={`${p.walletKey}::${p.endpoints[0]?.path ?? ''}`}
+            pending={p}
+            liveBalance={balances[p.walletKey] ?? 0}
+            isActive={isWalletActive(p)}
+            onRemove={() => {
+              onRemovePending(p);
+            }}
+          />
+        ))}
+      </div>
+
+      <div className='mt-4 flex items-center justify-end gap-2 border-t border-amber-200/60 pt-3 dark:border-amber-900/40'>
+        <button
+          type='button'
+          onClick={onCancel}
+          className='inline-flex h-8 items-center rounded-md px-3 text-xs font-medium text-amber-800 transition-colors hover:bg-amber-100/60 dark:text-amber-300 dark:hover:bg-amber-900/30'
+        >
+          Cancel
+        </button>
+        <button
+          type='button'
+          disabled={!allActive}
+          onClick={onConfirmSend}
+          className={cn(
+            'group inline-flex h-8 items-center gap-1.5 rounded-md px-3.5 text-xs font-medium transition-colors',
+            allActive
+              ? 'bg-primary text-primary-foreground hover:bg-primary/90 cursor-pointer'
+              : 'cursor-not-allowed bg-amber-200/60 text-amber-900/50 dark:bg-amber-900/30 dark:text-amber-300/40'
+          )}
+        >
+          Send message
+          <ArrowRight className='h-3 w-3 transition-transform group-hover:translate-x-0.5' />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/frontend/src/components/endpoint/access-policies-card.tsx
+++ b/components/frontend/src/components/endpoint/access-policies-card.tsx
@@ -8,11 +8,15 @@ import { PolicyItem } from './policy-item';
 
 export interface AccessPoliciesCardProperties {
   policies?: Policy[];
+  endpointSlug?: string;
+  endpointOwner?: string;
 }
 
 // Access Policies Card component - memoized to prevent unnecessary re-renders
 export const AccessPoliciesCard = memo(function AccessPoliciesCard({
-  policies
+  policies,
+  endpointSlug,
+  endpointOwner
 }: Readonly<AccessPoliciesCardProperties>) {
   const validPolicies = policies?.filter((p) => p.type) ?? [];
 
@@ -32,7 +36,12 @@ export const AccessPoliciesCard = memo(function AccessPoliciesCard({
       {validPolicies.length > 0 ? (
         <div className='space-y-3'>
           {validPolicies.map((policy, index) => (
-            <PolicyItem key={`${policy.type}-${String(index)}`} policy={policy} />
+            <PolicyItem
+              key={`${policy.type}-${String(index)}`}
+              policy={policy}
+              endpointSlug={endpointSlug}
+              endpointOwner={endpointOwner}
+            />
           ))}
         </div>
       ) : (

--- a/components/frontend/src/components/endpoint/bundle-picker.tsx
+++ b/components/frontend/src/components/endpoint/bundle-picker.tsx
@@ -1,0 +1,79 @@
+/**
+ * Violet-themed bundle dropdown shared by the Xendit-policy sidebar card
+ * and the chat-flow subscription gate modal.
+ */
+import type { MoneyBundle } from '@/lib/xendit-client';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+
+export interface BundlePickerProperties {
+  bundles: MoneyBundle[];
+  currency: string;
+  value: string;
+  onChange: (name: string) => void;
+  disabled?: boolean;
+  triggerClassName?: string;
+}
+
+export function BundlePicker({
+  bundles,
+  currency,
+  value,
+  onChange,
+  disabled,
+  triggerClassName
+}: Readonly<BundlePickerProperties>) {
+  const selected = bundles.find((b) => b.name === value) ?? bundles[0];
+  if (!selected) return null;
+
+  return (
+    <Select value={value} onValueChange={onChange} disabled={disabled}>
+      <SelectTrigger
+        className={cn(
+          'h-8 text-xs transition-colors',
+          'border-violet-300 bg-violet-50 text-violet-700',
+          'hover:bg-violet-100 focus:ring-violet-400/40',
+          'dark:border-violet-700 dark:bg-violet-950/30 dark:text-violet-300',
+          'dark:hover:bg-violet-900/40 dark:focus:ring-violet-500/30',
+          triggerClassName
+        )}
+      >
+        <SelectValue>
+          <span className='flex w-full items-center pr-1'>
+            <span className='font-medium tabular-nums'>
+              {currency} {selected.amount.toLocaleString()}
+            </span>
+          </span>
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent
+        className={cn(
+          'border-violet-200 bg-violet-50/95 backdrop-blur-sm',
+          'dark:border-violet-800 dark:bg-violet-950/95'
+        )}
+      >
+        {bundles.map((bundle) => (
+          <SelectItem
+            key={bundle.name}
+            value={bundle.name}
+            className={cn(
+              'text-xs text-violet-800 focus:bg-violet-100 focus:text-violet-900',
+              'dark:text-violet-200 dark:focus:bg-violet-900/50 dark:focus:text-violet-100'
+            )}
+          >
+            <span className='font-medium tabular-nums'>
+              {currency} {bundle.amount.toLocaleString()}
+            </span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/components/frontend/src/components/endpoint/endpoint-detail.tsx
+++ b/components/frontend/src/components/endpoint/endpoint-detail.tsx
@@ -388,7 +388,11 @@ export const EndpointDetail = memo(function EndpointDetail({
             ) : null}
 
             {/* Access Policies Card */}
-            <AccessPoliciesCard policies={endpoint.policies} />
+            <AccessPoliciesCard
+              policies={endpoint.policies}
+              endpointSlug={endpoint.full_path ?? endpoint.slug}
+              endpointOwner={endpoint.owner_username}
+            />
           </aside>
         </div>
       </div>

--- a/components/frontend/src/components/endpoint/policy-item.tsx
+++ b/components/frontend/src/components/endpoint/policy-item.tsx
@@ -133,24 +133,39 @@ function getPolicyConfig(type: string) {
 
 export interface PolicyItemProperties {
   policy: Policy;
+  endpointSlug?: string;
+  endpointOwner?: string;
 }
 
 function renderPolicyContent(
   policy: Policy,
   isTransaction: boolean,
-  isXendit: boolean
+  isXendit: boolean,
+  endpointSlug?: string,
+  endpointOwner?: string
 ): React.ReactElement {
   if (isTransaction) {
     return <TransactionPolicyContent config={policy.config} />;
   }
   if (isXendit) {
-    return <XenditPolicyContent config={policy.config} enabled={policy.enabled} />;
+    return (
+      <XenditPolicyContent
+        config={policy.config}
+        enabled={policy.enabled}
+        endpointSlug={endpointSlug}
+        endpointOwner={endpointOwner}
+      />
+    );
   }
   return <GenericPolicyContent config={policy.config} />;
 }
 
 // Single policy item component - memoized to prevent unnecessary re-renders
-export const PolicyItem = memo(function PolicyItem({ policy }: Readonly<PolicyItemProperties>) {
+export const PolicyItem = memo(function PolicyItem({
+  policy,
+  endpointSlug,
+  endpointOwner
+}: Readonly<PolicyItemProperties>) {
   const config = getPolicyConfig(policy.type);
   const Icon = config.icon;
   const policyTypeLower = policy.type.toLowerCase();
@@ -161,6 +176,11 @@ export const PolicyItem = memo(function PolicyItem({ policy }: Readonly<PolicyIt
   const displayLabel = POLICY_TYPE_CONFIG[policy.type.toLowerCase()]
     ? config.label
     : formatConfigKey(policy.type);
+
+  // Avoid printing the description when it just repeats the visible label
+  // (e.g. publisher set policy.name = type label).
+  const rawDescription = policy.description || config.description;
+  const description = rawDescription && rawDescription !== displayLabel ? rawDescription : null;
 
   return (
     <div
@@ -200,13 +220,11 @@ export const PolicyItem = memo(function PolicyItem({ policy }: Readonly<PolicyIt
               {policy.enabled ? 'Active' : 'Disabled'}
             </Badge>
           </div>
-          <p className='text-muted-foreground mt-1 text-xs'>
-            {policy.description || config.description}
-          </p>
+          {description && <p className='text-muted-foreground mt-1 text-xs'>{description}</p>}
 
           {/* Policy-specific content */}
           {Object.keys(policy.config).length > 0 &&
-            renderPolicyContent(policy, isTransaction, isXendit)}
+            renderPolicyContent(policy, isTransaction, isXendit, endpointSlug, endpointOwner)}
 
           {policy.version ? (
             <p className='text-muted-foreground mt-2 text-[10px]'>Version {policy.version}</p>

--- a/components/frontend/src/components/endpoint/xendit-policy-content.tsx
+++ b/components/frontend/src/components/endpoint/xendit-policy-content.tsx
@@ -1,162 +1,327 @@
-import React, { memo, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import ArrowRight from 'lucide-react/dist/esm/icons/arrow-right';
 import CheckCircle2 from 'lucide-react/dist/esm/icons/check-circle-2';
-import ExternalLink from 'lucide-react/dist/esm/icons/external-link';
 import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
+import RefreshCw from 'lucide-react/dist/esm/icons/refresh-cw';
 
-import { Badge } from '@/components/ui/badge';
+import { BundlePicker } from '@/components/endpoint/bundle-picker';
+import { useRegisterOnFundingDetected } from '@/hooks/use-xendit-subscriptions';
 import { syftClient } from '@/lib/sdk-client';
 import { cn } from '@/lib/utils';
-
-interface MoneyBundle {
-  name: string;
-  amount: number;
-}
+import {
+  createInvoice,
+  fetchBalance,
+  getSatelliteToken,
+  openCheckoutWindow,
+  parseXenditConfig,
+  POLL_INTERVAL_MS
+} from '@/lib/xendit-client';
 
 type SubscriptionState =
   | { state: 'loading' }
-  | { state: 'subscribed'; remaining: number | null }
-  | { state: 'not_subscribed' };
+  | { state: 'active'; balance: number }
+  | { state: 'inactive' };
 
-function isValidUrl(value: unknown): value is string {
-  return typeof value === 'string' && (value.startsWith('https://') || value.startsWith('http://'));
-}
-
-// bundleUsageUrl is an external URL owned by the endpoint operator, not a SyftHub API endpoint,
-// so raw fetch is intentional here rather than routing through syftClient.
-async function fetchSubscriptionStatus(
-  bundleUsageUrl: string,
-  accessToken: string
-): Promise<{ remaining: number | null } | null> {
-  try {
-    const response = await fetch(bundleUsageUrl, {
-      headers: { Authorization: `Bearer ${accessToken}` }
-    });
-    if (!response.ok) return null;
-    const data: unknown = await response.json();
-    if (typeof data !== 'object' || data === null) return { remaining: null };
-    const d = data as Record<string, unknown>;
-    const remaining = typeof d.remaining_balance === 'number' ? d.remaining_balance : null;
-    return { remaining };
-  } catch {
-    return null;
-  }
-}
+type PurchaseState =
+  | { state: 'idle' }
+  | { state: 'creating'; bundleName: string }
+  | { state: 'awaiting_payment'; bundleName: string; checkoutUrl: string }
+  | { state: 'error'; message: string };
 
 export interface XenditPolicyContentProperties {
   config: Record<string, unknown>;
   enabled: boolean;
+  endpointSlug?: string;
+  endpointOwner?: string;
 }
 
 export const XenditPolicyContent = memo(function XenditPolicyContent({
   config,
-  enabled
+  enabled,
+  endpointSlug,
+  endpointOwner
 }: Readonly<XenditPolicyContentProperties>) {
-  const currency = typeof config.currency === 'string' ? config.currency : 'IDR';
-  const paymentUrl = isValidUrl(config.payment_url) ? config.payment_url : null;
-  const bundleUsageUrl = isValidUrl(config.credits_url) ? config.credits_url : null;
-  const bundles: MoneyBundle[] = Array.isArray(config.bundles)
-    ? (config.bundles as MoneyBundle[])
-    : [];
+  // Re-parse only when config identity changes — otherwise the bundles array
+  // would get a fresh reference each render and re-fire the validation effect.
+  const parsed = useMemo(() => parseXenditConfig(config), [config]);
+  const { bundles, currency, paymentUrl, creditsUrl } = parsed;
 
-  const [status, setStatus] = useState<SubscriptionState>({ state: 'loading' });
+  const [subscription, setSubscription] = useState<SubscriptionState>({ state: 'loading' });
+  const [purchase, setPurchase] = useState<PurchaseState>({ state: 'idle' });
+  const [selectedBundleName, setSelectedBundleName] = useState<string>(
+    () => bundles[0]?.name ?? ''
+  );
+
+  // Backend registration is best-effort + idempotent; ref-gate so we only
+  // call it once per (component instance, wallet) for the lifetime of the
+  // page. The server upsert covers cross-page re-funding.
+  const registerOnFunding = useRegisterOnFundingDetected();
+  const hasRegisteredReference = useRef(false);
 
   useEffect(() => {
+    const first = bundles[0];
+    if (!first) return;
+    if (!bundles.some((b) => b.name === selectedBundleName)) {
+      setSelectedBundleName(first.name);
+    }
+  }, [bundles, selectedBundleName]);
+
+  // Shared balance check. `silent=true` skips the loading transition for
+  // background polling. Updates state only when something actually changed,
+  // so unchanged poll ticks don't trigger re-renders downstream.
+  const checkBalance = useCallback(
+    async (options: { silent?: boolean; signal?: AbortSignal } = {}) => {
+      const tokens = syftClient.getTokens();
+      if (!tokens || !creditsUrl || !endpointOwner) {
+        setSubscription((previous) =>
+          previous.state === 'inactive' ? previous : { state: 'inactive' }
+        );
+        return;
+      }
+      if (!options.silent) setSubscription({ state: 'loading' });
+      const satelliteToken = await getSatelliteToken(endpointOwner);
+      if (options.signal?.aborted) return;
+      if (!satelliteToken) {
+        setSubscription((previous) =>
+          previous.state === 'inactive' ? previous : { state: 'inactive' }
+        );
+        return;
+      }
+      const balance = await fetchBalance(creditsUrl, satelliteToken, options.signal);
+      if (options.signal?.aborted) return;
+      if (balance === null || balance <= 0) {
+        if (!options.silent) {
+          setSubscription((previous) =>
+            previous.state === 'inactive' ? previous : { state: 'inactive' }
+          );
+        }
+        return;
+      }
+      setSubscription((previous) =>
+        previous.state === 'active' && previous.balance === balance
+          ? previous
+          : { state: 'active', balance }
+      );
+      setPurchase((previous) => (previous.state === 'idle' ? previous : { state: 'idle' }));
+
+      // Active wallet detected — record it on the user's account so the
+      // unified credits panel can list it. Idempotent server-side.
+      if (!hasRegisteredReference.current && paymentUrl && endpointOwner && creditsUrl) {
+        hasRegisteredReference.current = true;
+        void registerOnFunding({
+          creditsUrl,
+          paymentUrl,
+          endpointOwner,
+          endpointSlug: endpointSlug ?? null,
+          currency,
+          lastKnownBalance: balance
+        });
+      }
+    },
+    [creditsUrl, endpointOwner, paymentUrl, endpointSlug, currency, registerOnFunding]
+  );
+
+  const refreshBalance = useCallback(() => checkBalance(), [checkBalance]);
+
+  // Initial balance load. The same `checkBalance` powers refresh and polling,
+  // and aborts cleanly on unmount.
+  useEffect(() => {
+    const controller = new AbortController();
+    void checkBalance({ signal: controller.signal });
+    return () => {
+      controller.abort();
+    };
+  }, [checkBalance]);
+
+  // Background polling while the user completes payment in the popup. The
+  // active-state branch in checkBalance auto-clears purchase to idle, which
+  // tears this interval down — so the loop self-terminates on success.
+  useEffect(() => {
+    if (purchase.state !== 'awaiting_payment') return;
+    const controller = new AbortController();
+    const intervalId = setInterval(() => {
+      void checkBalance({ silent: true, signal: controller.signal });
+    }, POLL_INTERVAL_MS);
+    return () => {
+      clearInterval(intervalId);
+      controller.abort();
+    };
+  }, [purchase.state, checkBalance]);
+
+  const handleSubscribe = async (bundleName: string) => {
+    if (!paymentUrl || !enabled) return;
     const tokens = syftClient.getTokens();
-    if (!tokens || !bundleUsageUrl) {
-      setStatus({ state: 'not_subscribed' });
+    if (!tokens) {
+      setPurchase({ state: 'error', message: 'Sign in to subscribe.' });
       return;
     }
+    if (!endpointOwner) {
+      setPurchase({
+        state: 'error',
+        message: 'Endpoint owner unknown — cannot mint satellite token.'
+      });
+      return;
+    }
+    setPurchase({ state: 'creating', bundleName });
+    const satelliteToken = await getSatelliteToken(endpointOwner);
+    if (!satelliteToken) {
+      setPurchase({ state: 'error', message: 'Failed to get satellite token from SyftHub.' });
+      return;
+    }
+    const result = await createInvoice(paymentUrl, satelliteToken, bundleName, endpointSlug);
+    if ('error' in result) {
+      setPurchase({ state: 'error', message: result.error });
+      return;
+    }
+    setPurchase({ state: 'awaiting_payment', bundleName, checkoutUrl: result.checkoutUrl });
+    openCheckoutWindow(result.checkoutUrl);
+  };
 
-    let cancelled = false;
-    void fetchSubscriptionStatus(bundleUsageUrl, tokens.accessToken).then((result) => {
-      if (cancelled) return;
-      if (result === null) {
-        setStatus({ state: 'not_subscribed' });
-      } else {
-        setStatus({ state: 'subscribed', remaining: result.remaining });
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [bundleUsageUrl]);
+  const canPurchase = Boolean(paymentUrl && enabled);
+  const isCreatingAny = purchase.state === 'creating';
 
   return (
     <div className='mt-3 space-y-2'>
-      <Badge
-        variant='outline'
-        className='border-violet-200 bg-violet-50 text-[10px] font-medium text-violet-700 dark:border-violet-800 dark:bg-violet-950/30 dark:text-violet-400'
-      >
-        Xendit Bundle Required
-      </Badge>
-
-      {status.state === 'loading' && (
-        <div className='text-muted-foreground flex items-center gap-2 text-xs'>
+      {subscription.state === 'loading' && (
+        <div className='text-muted-foreground flex items-center gap-1.5 text-xs'>
           <Loader2 className='h-3 w-3 animate-spin' />
           Checking subscription…
         </div>
       )}
 
-      {status.state === 'subscribed' && (
-        <div className='flex items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 dark:border-emerald-800 dark:bg-emerald-950/30'>
-          <CheckCircle2 className='h-3.5 w-3.5 shrink-0 text-emerald-600 dark:text-emerald-400' />
-          <span className='text-xs font-medium text-emerald-700 dark:text-emerald-400'>
-            Active subscription
-            {status.remaining === null
-              ? ''
-              : ` · ${currency} ${status.remaining.toLocaleString()} remaining`}
-          </span>
+      {subscription.state === 'active' && (
+        <div className='flex items-center justify-between gap-2 rounded-md border border-emerald-200 bg-emerald-50/70 px-2.5 py-1.5 dark:border-emerald-900/60 dark:bg-emerald-950/20'>
+          <div className='flex min-w-0 items-center gap-1.5'>
+            <CheckCircle2 className='h-3.5 w-3.5 shrink-0 text-emerald-600 dark:text-emerald-400' />
+            <span className='truncate text-[11px] font-medium text-emerald-700 dark:text-emerald-400'>
+              Active
+              <span className='mx-1 text-emerald-600/50 dark:text-emerald-500/50'>·</span>
+              <span className='tabular-nums'>
+                {currency} {subscription.balance.toLocaleString()}
+              </span>
+              <span className='ml-1 text-emerald-600/70 dark:text-emerald-500/70'>remaining</span>
+            </span>
+          </div>
+          <button
+            type='button'
+            onClick={() => void refreshBalance()}
+            className='shrink-0 rounded p-0.5 text-emerald-600/70 transition-colors hover:bg-emerald-100/60 hover:text-emerald-700 dark:text-emerald-500/70 dark:hover:bg-emerald-900/30 dark:hover:text-emerald-400'
+            aria-label='Refresh balance'
+          >
+            <RefreshCw className='h-3 w-3' />
+          </button>
         </div>
       )}
 
-      {/* Bundle table + CTA — only when not subscribed */}
-      {status.state === 'not_subscribed' && (
-        <>
-          {bundles.length > 0 && (
-            <div className='bg-card/60 rounded-md border border-violet-200 dark:border-violet-800'>
-              <div className='border-b border-violet-100 px-3 py-1.5 dark:border-violet-800'>
-                <span className='text-[10px] font-semibold tracking-wide text-violet-700 uppercase dark:text-violet-400'>
-                  Available Plans
-                </span>
-              </div>
-              <div className='divide-y divide-violet-100 dark:divide-violet-800'>
-                {bundles.map((bundle) => (
-                  <div key={bundle.name} className='flex items-center justify-between px-3 py-1.5'>
-                    <span className='text-foreground text-xs font-medium'>{bundle.name}</span>
-                    <span className='text-foreground font-mono text-xs font-medium'>
-                      {currency} {bundle.amount.toLocaleString()}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
+      {subscription.state === 'inactive' &&
+        purchase.state !== 'awaiting_payment' &&
+        bundles.length > 0 && (
+          <div className='space-y-1.5'>
+            <BundlePicker
+              bundles={bundles}
+              currency={currency}
+              value={selectedBundleName}
+              onChange={setSelectedBundleName}
+              disabled={isCreatingAny}
+            />
+            <button
+              type='button'
+              disabled={!canPurchase || isCreatingAny}
+              onClick={() => void handleSubscribe(selectedBundleName)}
+              className={cn(
+                'group inline-flex h-8 w-full items-center justify-center gap-1.5 rounded-md text-xs font-medium transition-colors',
+                'border border-violet-300 bg-violet-50 text-violet-700 dark:border-violet-700 dark:bg-violet-950/30 dark:text-violet-300',
+                !canPurchase || isCreatingAny
+                  ? 'cursor-not-allowed opacity-50'
+                  : 'cursor-pointer hover:bg-violet-100 dark:hover:bg-violet-900/40'
+              )}
+            >
+              {isCreatingAny ? (
+                <>
+                  <Loader2 className='h-3 w-3 animate-spin' />
+                  Opening checkout…
+                </>
+              ) : (
+                <>
+                  Buy
+                  <ArrowRight className='h-3 w-3 transition-transform group-hover:translate-x-0.5' />
+                </>
+              )}
+            </button>
+          </div>
+        )}
 
-          {(() => {
-            const active = Boolean(paymentUrl && enabled);
-            return (
-              <a
-                href={active ? (paymentUrl ?? undefined) : undefined}
-                target={active ? '_blank' : undefined}
-                rel={active ? 'noopener noreferrer' : undefined}
-                aria-disabled={!active}
-                className={cn(
-                  'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
-                  'border border-violet-300 bg-violet-50 text-violet-700 dark:border-violet-700 dark:bg-violet-950/30 dark:text-violet-300',
-                  active
-                    ? 'cursor-pointer hover:bg-violet-100 dark:hover:bg-violet-900/40'
-                    : 'cursor-not-allowed opacity-50'
-                )}
-              >
-                <ExternalLink className='h-3 w-3' />
-                Subscribe
-              </a>
-            );
-          })()}
-        </>
+      {purchase.state === 'error' && (
+        <div className='rounded-md border border-red-200 bg-red-50/70 px-2.5 py-1.5 text-[11px] text-red-700 dark:border-red-900/60 dark:bg-red-950/20 dark:text-red-300'>
+          {purchase.message}
+        </div>
+      )}
+
+      {purchase.state === 'awaiting_payment' && subscription.state !== 'active' && (
+        <AwaitingPaymentBanner
+          checkoutUrl={purchase.checkoutUrl}
+          onCancel={() => {
+            setPurchase({ state: 'idle' });
+          }}
+        />
       )}
     </div>
   );
 });
+
+interface AwaitingPaymentBannerProperties {
+  checkoutUrl: string;
+  onCancel: () => void;
+}
+
+function AwaitingPaymentBanner({
+  checkoutUrl,
+  onCancel
+}: Readonly<AwaitingPaymentBannerProperties>) {
+  return (
+    <div
+      role='status'
+      aria-live='polite'
+      className={cn(
+        'flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50/70 px-2.5 py-2',
+        'dark:border-amber-900/60 dark:bg-amber-950/20'
+      )}
+    >
+      <Loader2 className='mt-0.5 h-3 w-3 shrink-0 animate-spin text-amber-600 dark:text-amber-400' />
+      <div className='min-w-0 flex-1 space-y-1'>
+        <div className='text-[11px] font-medium text-amber-800 dark:text-amber-300'>
+          Awaiting payment…
+        </div>
+        <div className='text-[11px] text-amber-700/80 dark:text-amber-400/70'>
+          We'll detect it automatically once the popup completes.
+        </div>
+        <div className='flex items-center gap-2 pt-0.5'>
+          <button
+            type='button'
+            onClick={() => {
+              openCheckoutWindow(checkoutUrl);
+            }}
+            className={cn(
+              'text-[11px] font-medium text-amber-800 underline-offset-2 hover:underline',
+              'dark:text-amber-300'
+            )}
+          >
+            Reopen checkout
+          </button>
+          <span className='text-amber-600/40 dark:text-amber-500/40'>·</span>
+          <button
+            type='button'
+            onClick={onCancel}
+            className={cn(
+              'text-[11px] text-amber-700/70 underline-offset-2 hover:underline',
+              'dark:text-amber-400/70'
+            )}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/frontend/src/components/settings/settings-modal.tsx
+++ b/components/frontend/src/components/settings/settings-modal.tsx
@@ -4,6 +4,7 @@ import type { SettingsTab } from '@/stores/settings-modal-store';
 
 import { AnimatePresence, motion } from 'framer-motion';
 import AlertTriangle from 'lucide-react/dist/esm/icons/alert-triangle';
+import CreditCard from 'lucide-react/dist/esm/icons/credit-card';
 import Key from 'lucide-react/dist/esm/icons/key';
 import Lock from 'lucide-react/dist/esm/icons/lock';
 import Server from 'lucide-react/dist/esm/icons/server';
@@ -22,6 +23,7 @@ import { DangerZoneTab } from './danger-zone-tab';
 import { PaymentSettingsTab } from './payment-settings-tab';
 import { ProfileSettingsTab } from './profile-settings-tab';
 import { SecuritySettingsTab } from './security-settings-tab';
+import { SubscriptionsSettingsTab } from './subscriptions-settings-tab';
 
 interface TabItem {
   id: SettingsTab;
@@ -44,6 +46,11 @@ const TABS: TabItem[] = [
     icon: <WalletIcon className='h-4 w-4' aria-hidden='true' />
   },
   {
+    id: 'subscriptions',
+    label: 'Subscriptions',
+    icon: <CreditCard className='h-4 w-4' aria-hidden='true' />
+  },
+  {
     id: 'aggregator',
     label: 'Aggregator',
     icon: <Server className='h-4 w-4' aria-hidden='true' />
@@ -61,6 +68,7 @@ const TAB_CONTENT: Record<SettingsTab, React.ComponentType> = {
   security: SecuritySettingsTab,
   'api-tokens': APITokensSettingsTab,
   payment: PaymentSettingsTab,
+  subscriptions: SubscriptionsSettingsTab,
   aggregator: AggregatorSettingsTab,
   'danger-zone': DangerZoneTab
 };

--- a/components/frontend/src/components/settings/subscriptions-settings-tab.tsx
+++ b/components/frontend/src/components/settings/subscriptions-settings-tab.tsx
@@ -1,0 +1,304 @@
+/**
+ * Subscriptions settings tab — manages publisher (Xendit) wallets the user
+ * has funded. Each row shows the live balance fetched from the publisher
+ * with a satellite token, plus Top-up and Forget actions.
+ */
+import { useCallback, useState } from 'react';
+
+import type { XenditSubscription } from '@/lib/types';
+
+import AlertCircle from 'lucide-react/dist/esm/icons/alert-circle';
+import CreditCard from 'lucide-react/dist/esm/icons/credit-card';
+import ExternalLink from 'lucide-react/dist/esm/icons/external-link';
+import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
+import RefreshCw from 'lucide-react/dist/esm/icons/refresh-cw';
+import Trash2 from 'lucide-react/dist/esm/icons/trash-2';
+import { Link } from 'react-router-dom';
+
+import { formatBalance } from '@/components/balance/balance-display';
+import { Button } from '@/components/ui/button';
+import {
+  useDeleteXenditSubscription,
+  useSubscriptionBalance,
+  useXenditSubscriptions
+} from '@/hooks/use-xendit-subscriptions';
+import { cn } from '@/lib/utils';
+import { openCheckoutWindow } from '@/lib/xendit-client';
+
+export function SubscriptionsSettingsTab() {
+  const subscriptionsQuery = useXenditSubscriptions();
+  const subscriptions = subscriptionsQuery.data ?? [];
+
+  return (
+    <div className='space-y-4'>
+      <div>
+        <h2 className='text-foreground text-lg font-semibold'>Endpoint subscriptions</h2>
+        <p className='text-muted-foreground mt-1 text-sm'>
+          Publisher-side wallets you've funded via Xendit. Balances are fetched live from each
+          publisher.
+        </p>
+      </div>
+
+      <div className='flex items-center justify-between'>
+        <span className='text-muted-foreground text-xs'>
+          {subscriptions.length} subscription{subscriptions.length === 1 ? '' : 's'}
+        </span>
+        <Button
+          variant='ghost'
+          size='sm'
+          disabled={subscriptionsQuery.isFetching}
+          onClick={() => void subscriptionsQuery.refetch()}
+          className='gap-1.5'
+        >
+          <RefreshCw
+            className={cn('h-3.5 w-3.5', subscriptionsQuery.isFetching && 'animate-spin')}
+          />
+          Refresh
+        </Button>
+      </div>
+
+      {renderBody({
+        isLoading: subscriptionsQuery.isLoading,
+        error: subscriptionsQuery.error,
+        subscriptions,
+        onRetry: () => void subscriptionsQuery.refetch()
+      })}
+    </div>
+  );
+}
+
+interface RenderBodyArguments {
+  isLoading: boolean;
+  error: Error | null;
+  subscriptions: XenditSubscription[];
+  onRetry: () => void;
+}
+
+function renderBody({ isLoading, error, subscriptions, onRetry }: RenderBodyArguments) {
+  if (isLoading) {
+    return (
+      <div className='text-muted-foreground flex items-center gap-2 py-8 text-sm'>
+        <Loader2 className='h-4 w-4 animate-spin' />
+        Loading subscriptions…
+      </div>
+    );
+  }
+  if (error) return <ErrorState message={error.message} onRetry={onRetry} />;
+  if (subscriptions.length === 0) return <EmptyState />;
+  return (
+    <div className='space-y-2'>
+      {subscriptions.map((sub) => (
+        <SubscriptionCard key={sub.id} subscription={sub} />
+      ))}
+    </div>
+  );
+}
+
+// ── per-row card ───────────────────────────────────────────────────────────
+
+function SubscriptionCard({ subscription }: Readonly<{ subscription: XenditSubscription }>) {
+  const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
+  const deleteMutation = useDeleteXenditSubscription();
+  const { balance, isLoading, error, refetch } = useSubscriptionBalance(subscription, {
+    enabled: true,
+    pollIntervalMs: 30_000
+  });
+
+  const liveBalance = balance ?? subscription.last_known_balance ?? 0;
+  const label = subscription.endpoint_slug
+    ? `${subscription.endpoint_owner}/${subscription.endpoint_slug}`
+    : subscription.endpoint_owner;
+  const targetPath = subscription.endpoint_slug
+    ? `/${subscription.endpoint_owner}/${subscription.endpoint_slug}`
+    : `/${subscription.endpoint_owner}`;
+
+  const handleTopUp = useCallback(() => {
+    openCheckoutWindow(subscription.payment_url);
+  }, [subscription.payment_url]);
+
+  const handleForget = useCallback(async () => {
+    await deleteMutation.mutateAsync(subscription.id);
+  }, [deleteMutation, subscription.id]);
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border p-4',
+        'border-border bg-card',
+        'transition-shadow hover:shadow-sm'
+      )}
+    >
+      <div className='flex items-start justify-between gap-3'>
+        <div className='flex min-w-0 items-start gap-3'>
+          <div
+            className={cn(
+              'flex h-9 w-9 shrink-0 items-center justify-center rounded-md border',
+              'border-violet-200 bg-violet-100 text-violet-700',
+              'dark:border-violet-900/60 dark:bg-violet-900/30 dark:text-violet-400'
+            )}
+          >
+            <CreditCard className='h-4 w-4' />
+          </div>
+          <div className='min-w-0'>
+            <Link
+              to={targetPath}
+              className='text-foreground inline-flex items-center gap-1 text-sm font-medium hover:underline'
+            >
+              {label}
+              <ExternalLink className='h-3 w-3 opacity-60' />
+            </Link>
+            <div className='text-muted-foreground mt-0.5 text-xs'>
+              Xendit · {subscription.currency}
+              {subscription.first_funded_at && (
+                <>
+                  {' · '}
+                  Active since {new Date(subscription.first_funded_at).toLocaleDateString()}
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+        <div className='shrink-0 text-right'>
+          <BalanceCell
+            isLoading={isLoading && balance === null}
+            error={error}
+            liveBalance={liveBalance}
+            currency={subscription.currency}
+            isCached={subscription.last_checked_at !== null && balance === null}
+            onRetry={() => void refetch()}
+          />
+        </div>
+      </div>
+
+      <div className='mt-3 flex items-center justify-end gap-2 border-t pt-3'>
+        {isConfirmingDelete ? (
+          <div className='flex w-full items-center justify-between gap-2'>
+            <span className='text-muted-foreground text-xs'>
+              Forget this subscription? You can re-add it by paying again.
+            </span>
+            <div className='flex shrink-0 gap-2'>
+              <Button
+                variant='ghost'
+                size='sm'
+                onClick={() => {
+                  setIsConfirmingDelete(false);
+                }}
+                disabled={deleteMutation.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant='destructive'
+                size='sm'
+                onClick={() => void handleForget()}
+                disabled={deleteMutation.isPending}
+              >
+                {deleteMutation.isPending ? (
+                  <Loader2 className='h-3.5 w-3.5 animate-spin' />
+                ) : (
+                  'Forget'
+                )}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <Button variant='ghost' size='sm' onClick={handleTopUp} className='gap-1.5'>
+              <ExternalLink className='h-3.5 w-3.5' />
+              Top up
+            </Button>
+            <Button
+              variant='ghost'
+              size='sm'
+              onClick={() => {
+                setIsConfirmingDelete(true);
+              }}
+              className='text-muted-foreground hover:text-destructive gap-1.5'
+            >
+              <Trash2 className='h-3.5 w-3.5' />
+              Forget
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── balance cell ───────────────────────────────────────────────────────────
+
+interface BalanceCellProperties {
+  isLoading: boolean;
+  error: Error | null;
+  liveBalance: number;
+  currency: string;
+  isCached: boolean;
+  onRetry: () => void;
+}
+
+function BalanceCell({
+  isLoading,
+  error,
+  liveBalance,
+  currency,
+  isCached,
+  onRetry
+}: Readonly<BalanceCellProperties>) {
+  if (isLoading) {
+    return <Loader2 className='text-muted-foreground h-4 w-4 animate-spin' />;
+  }
+  if (error) {
+    return (
+      <button
+        type='button'
+        onClick={onRetry}
+        className='inline-flex items-center gap-1 text-xs text-red-600 hover:underline dark:text-red-400'
+      >
+        <AlertCircle className='h-3 w-3' />
+        Retry
+      </button>
+    );
+  }
+  return (
+    <>
+      <div className='text-foreground text-base font-semibold tabular-nums'>
+        {formatBalance(liveBalance)}
+      </div>
+      <div className='text-muted-foreground text-[10px]'>
+        {currency}
+        {isCached && <> · cached</>}
+      </div>
+    </>
+  );
+}
+
+// ── states ─────────────────────────────────────────────────────────────────
+
+function EmptyState() {
+  return (
+    <div className='border-border text-muted-foreground rounded-lg border border-dashed bg-transparent px-6 py-10 text-center text-sm'>
+      <CreditCard className='mx-auto mb-2 h-6 w-6 opacity-40' />
+      You haven't funded any endpoint subscriptions yet.
+      <br />
+      <span className='text-xs'>Pay for any Xendit-gated endpoint and it will appear here.</span>
+    </div>
+  );
+}
+
+function ErrorState({ message, onRetry }: Readonly<{ message: string; onRetry: () => void }>) {
+  return (
+    <div className='rounded-lg border border-red-200 bg-red-50/60 p-4 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/20 dark:text-red-300'>
+      <div className='flex items-start gap-2'>
+        <AlertCircle className='mt-0.5 h-4 w-4 shrink-0' />
+        <div className='min-w-0 flex-1'>
+          <div className='font-medium'>Failed to load subscriptions</div>
+          <div className='mt-0.5 text-xs opacity-80'>{message}</div>
+          <Button variant='ghost' size='sm' onClick={onRetry} className='mt-2 gap-1.5'>
+            <RefreshCw className='h-3.5 w-3.5' />
+            Retry
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/frontend/src/hooks/use-wallet-api.ts
+++ b/components/frontend/src/hooks/use-wallet-api.ts
@@ -20,7 +20,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import type { WalletBalance, WalletInfo, WalletTransaction } from '@/lib/types';
+import type { WalletBalance, WalletInfo, WalletTransaction, XenditSubscription } from '@/lib/types';
 
 import { useWalletContext } from '@/context/wallet-context';
 import { syftClient } from '@/lib/sdk-client';
@@ -229,6 +229,25 @@ export class WalletAPIClient {
     return this.request<{ address: string }>('POST', '/import', {
       body: { private_key: privateKey }
     });
+  }
+
+  async listXenditSubscriptions(): Promise<{ subscriptions: XenditSubscription[] }> {
+    return this.request<{ subscriptions: XenditSubscription[] }>('GET', '/subscriptions');
+  }
+
+  async upsertXenditSubscription(payload: {
+    credits_url: string;
+    payment_url: string;
+    endpoint_owner: string;
+    endpoint_slug?: string | null;
+    currency: string;
+    last_known_balance?: number | null;
+  }): Promise<XenditSubscription> {
+    return this.request<XenditSubscription>('POST', '/subscriptions', { body: payload });
+  }
+
+  async deleteXenditSubscription(id: number): Promise<void> {
+    await this.request<unknown>('DELETE', `/subscriptions/${String(id)}`);
   }
 }
 

--- a/components/frontend/src/hooks/use-xendit-precheck.ts
+++ b/components/frontend/src/hooks/use-xendit-precheck.ts
@@ -1,0 +1,186 @@
+/**
+ * useXenditPrecheck
+ *
+ * Pre-flight subscription check run before a chat message is sent.
+ * Inspects the model + selected data sources for Xendit-policy gates,
+ * dedupes by credits_url (one wallet may back multiple endpoints), and
+ * fetches each balance via a satellite token. Returns the rows that
+ * still need a paid subscription so the chat view can open the gate
+ * modal — or an empty array when the user is clear to send.
+ */
+import { useCallback } from 'react';
+
+import type { ChatSource, Policy } from '@/lib/types';
+import type { MoneyBundle, ParsedXenditConfig } from '@/lib/xendit-client';
+
+import { syftClient } from '@/lib/sdk-client';
+import { fetchBalance, getSatelliteToken, parseXenditConfig } from '@/lib/xendit-client';
+
+export type EndpointRole = 'model' | 'data_source';
+
+export interface EndpointReference {
+  /** ChatSource ID — needed to remove the source from the chat selection. */
+  id: string;
+  /** owner/slug as displayed in the UI */
+  path: string;
+  owner: string;
+  slug: string;
+  name: string;
+  role: EndpointRole;
+}
+
+export interface PendingSubscription {
+  /** Stable identity (the credits_url, which uniquely names a wallet). */
+  walletKey: string;
+  /** All endpoints covered by this single wallet subscription. */
+  endpoints: EndpointReference[];
+  paymentUrl: string;
+  creditsUrl: string;
+  bundles: MoneyBundle[];
+  currency: string;
+  pricePerRequest: number | null;
+  /** Last balance reading (0 when unsubscribed). */
+  balance: number;
+}
+
+interface ResolvedXenditPolicy {
+  paymentUrl: string;
+  creditsUrl: string;
+  bundles: MoneyBundle[];
+  currency: string;
+  pricePerRequest: number | null;
+}
+
+function resolveXenditPolicy(policy: Policy): ResolvedXenditPolicy | null {
+  if (!policy.enabled) return null;
+  if (policy.type.toLowerCase() !== 'xendit') return null;
+  const parsed: ParsedXenditConfig = parseXenditConfig(policy.config);
+  if (!parsed.paymentUrl || !parsed.creditsUrl) return null;
+  return {
+    paymentUrl: parsed.paymentUrl,
+    creditsUrl: parsed.creditsUrl,
+    bundles: parsed.bundles,
+    currency: parsed.currency,
+    pricePerRequest: parsed.pricePerRequest
+  };
+}
+
+function endpointReferenceFor(source: ChatSource, role: EndpointRole): EndpointReference | null {
+  if (!source.owner_username || !source.full_path) return null;
+  return {
+    id: source.id,
+    path: source.full_path,
+    owner: source.owner_username,
+    slug: source.slug,
+    name: source.name,
+    role
+  };
+}
+
+interface XenditCandidate {
+  endpoint: EndpointReference;
+  policy: ResolvedXenditPolicy;
+}
+
+function candidatesFromSource(source: ChatSource, role: EndpointRole): XenditCandidate[] {
+  if (!source.policies) return [];
+  const ref = endpointReferenceFor(source, role);
+  if (!ref) return [];
+  const out: XenditCandidate[] = [];
+  for (const policy of source.policies) {
+    const resolved = resolveXenditPolicy(policy);
+    if (resolved) out.push({ endpoint: ref, policy: resolved });
+  }
+  return out;
+}
+
+function collectXenditCandidates(
+  model: ChatSource | null,
+  dataSources: ChatSource[]
+): XenditCandidate[] {
+  const out: XenditCandidate[] = [];
+  if (model) out.push(...candidatesFromSource(model, 'model'));
+  for (const ds of dataSources) out.push(...candidatesFromSource(ds, 'data_source'));
+  return out;
+}
+
+export interface UseXenditPrecheckOptions {
+  model: ChatSource | null;
+  dataSources: ChatSource[];
+}
+
+export interface UseXenditPrecheckReturn {
+  /**
+   * Resolve the precheck. Returns the wallets that still need funding.
+   * On any unrecoverable error (no satellite token, network), the affected
+   * wallet is *omitted* — the user gets the post-error path as a fallback
+   * rather than being blocked by a flaky precheck.
+   */
+  runPrecheck: (signal?: AbortSignal) => Promise<PendingSubscription[]>;
+}
+
+export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditPrecheckReturn {
+  const { model, dataSources } = options;
+
+  const runPrecheck = useCallback(
+    async (signal?: AbortSignal): Promise<PendingSubscription[]> => {
+      const candidates = collectXenditCandidates(model, dataSources);
+      if (candidates.length === 0) return [];
+      if (!syftClient.getTokens()) return [];
+
+      // One satellite token per distinct owner — multiple wallets owned by
+      // the same publisher reuse the token.
+      const owners = [...new Set(candidates.map((c) => c.endpoint.owner))];
+      const tokenByOwner = new Map<string, string>();
+      await Promise.all(
+        owners.map(async (owner) => {
+          const token = await getSatelliteToken(owner);
+          if (token) tokenByOwner.set(owner, token);
+        })
+      );
+
+      // One balance fetch per distinct credits_url. Multiple endpoints can
+      // share a wallet — paying once funds them all — but the gate UI lists
+      // each endpoint separately, so we need to know each row's status
+      // without re-hitting the same credits_url.
+      const distinctCreditsUrls = [...new Set(candidates.map((c) => c.policy.creditsUrl))];
+      const balanceByCreditsUrl = new Map<string, number | null>();
+      await Promise.all(
+        distinctCreditsUrls.map(async (creditsUrl) => {
+          const sample = candidates.find((c) => c.policy.creditsUrl === creditsUrl);
+          if (!sample) return;
+          const token = tokenByOwner.get(sample.endpoint.owner);
+          if (!token) return;
+          const balance = await fetchBalance(creditsUrl, token, signal);
+          balanceByCreditsUrl.set(creditsUrl, balance);
+        })
+      );
+
+      // One PendingSubscription per endpoint. Rows that share a wallet keep
+      // the same `walletKey` (= credits_url) so the gate's polling loop and
+      // auto-registration can dedupe by wallet, and a single payment flips
+      // every sibling row to active at once.
+      const out: PendingSubscription[] = [];
+      for (const c of candidates) {
+        const balance = balanceByCreditsUrl.get(c.policy.creditsUrl);
+        if (balance === null || balance === undefined) continue;
+        const threshold = c.policy.pricePerRequest ?? 1;
+        if (balance >= threshold) continue;
+        out.push({
+          walletKey: c.policy.creditsUrl,
+          endpoints: [c.endpoint],
+          paymentUrl: c.policy.paymentUrl,
+          creditsUrl: c.policy.creditsUrl,
+          bundles: c.policy.bundles,
+          currency: c.policy.currency,
+          pricePerRequest: c.policy.pricePerRequest,
+          balance
+        });
+      }
+      return out;
+    },
+    [model, dataSources]
+  );
+
+  return { runPrecheck };
+}

--- a/components/frontend/src/hooks/use-xendit-subscriptions.ts
+++ b/components/frontend/src/hooks/use-xendit-subscriptions.ts
@@ -1,0 +1,164 @@
+/**
+ * Xendit subscription hooks.
+ *
+ * Surfaces the publisher-side wallets a user has funded. Subscription rows
+ * live on the SyftHub backend (just metadata + last-known balance), but the
+ * authoritative balance is always fetched live from the publisher's
+ * `credits_url` with a per-publisher satellite token.
+ */
+
+import { useCallback } from 'react';
+
+import type { XenditSubscription } from '@/lib/types';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { useAuth } from '@/context/auth-context';
+import { WalletAPIClient } from '@/hooks/use-wallet-api';
+import { walletKeys } from '@/lib/query-keys';
+import { fetchBalance, getSatelliteToken } from '@/lib/xendit-client';
+
+let walletClientInstance: WalletAPIClient | null = null;
+
+function getWalletClient(): WalletAPIClient {
+  walletClientInstance ??= new WalletAPIClient();
+  return walletClientInstance;
+}
+
+export interface RegisterXenditSubscriptionInput {
+  creditsUrl: string;
+  paymentUrl: string;
+  endpointOwner: string;
+  endpointSlug?: string | null;
+  currency: string;
+  lastKnownBalance?: number | null;
+}
+
+export function useXenditSubscriptions(options: { enabled?: boolean } = {}) {
+  const { user } = useAuth();
+  const isAuthenticated = user !== null;
+  const enabled = (options.enabled ?? true) && isAuthenticated;
+
+  return useQuery({
+    queryKey: walletKeys.subscriptions(),
+    queryFn: async () => {
+      const result = await getWalletClient().listXenditSubscriptions();
+      return result.subscriptions;
+    },
+    enabled,
+    staleTime: 30_000
+  });
+}
+
+export function useRegisterXenditSubscription() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: RegisterXenditSubscriptionInput) => {
+      return getWalletClient().upsertXenditSubscription({
+        credits_url: input.creditsUrl,
+        payment_url: input.paymentUrl,
+        endpoint_owner: input.endpointOwner,
+        endpoint_slug: input.endpointSlug ?? null,
+        currency: input.currency,
+        last_known_balance: input.lastKnownBalance ?? null
+      });
+    },
+    onSuccess: (row) => {
+      queryClient.setQueryData<XenditSubscription[] | undefined>(
+        walletKeys.subscriptions(),
+        (previous) => {
+          if (!previous) return [row];
+          const index = previous.findIndex((p) => p.credits_url === row.credits_url);
+          if (index === -1) return [row, ...previous];
+          const next = [...previous];
+          next[index] = row;
+          return next;
+        }
+      );
+    }
+  });
+}
+
+export function useDeleteXenditSubscription() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: number) => {
+      await getWalletClient().deleteXenditSubscription(id);
+      return id;
+    },
+    onSuccess: (id) => {
+      queryClient.setQueryData<XenditSubscription[] | undefined>(
+        walletKeys.subscriptions(),
+        (previous) => previous?.filter((p) => p.id !== id) ?? []
+      );
+    }
+  });
+}
+
+export interface SubscriptionBalanceResult {
+  balance: number | null;
+  isLoading: boolean;
+  isFetching: boolean;
+  error: Error | null;
+  refetch: () => Promise<unknown>;
+}
+
+/**
+ * Live-fetch a subscription's balance from its publisher.
+ *
+ * Mints a satellite token for the endpoint owner and queries credits_url.
+ * Polls every `pollIntervalMs` while `enabled` is true (typically while the
+ * credits panel is open). Returns `null` balance when fetching fails.
+ */
+export function useSubscriptionBalance(
+  subscription: Pick<XenditSubscription, 'credits_url' | 'endpoint_owner'>,
+  options: { enabled?: boolean; pollIntervalMs?: number } = {}
+): SubscriptionBalanceResult {
+  const { enabled = true, pollIntervalMs } = options;
+
+  const query = useQuery({
+    queryKey: walletKeys.subscriptionBalance(subscription.credits_url),
+    queryFn: async ({ signal }) => {
+      const token = await getSatelliteToken(subscription.endpoint_owner);
+      if (!token) throw new Error('Failed to mint satellite token');
+      const balance = await fetchBalance(subscription.credits_url, token, signal);
+      return balance;
+    },
+    enabled,
+    refetchInterval: pollIntervalMs,
+    refetchIntervalInBackground: false,
+    staleTime: 5000
+  });
+
+  return {
+    balance: query.data ?? null,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: query.error,
+    refetch: query.refetch
+  };
+}
+
+/**
+ * Imperative helper for the auto-registration sites (xendit-policy-content,
+ * subscription-gate-modal). Wraps the mutation in a stable callback that
+ * silently swallows errors — registration is best-effort and shouldn't block
+ * payment confirmation.
+ */
+export function useRegisterOnFundingDetected() {
+  const { mutateAsync } = useRegisterXenditSubscription();
+
+  return useCallback(
+    async (input: RegisterXenditSubscriptionInput) => {
+      try {
+        await mutateAsync(input);
+      } catch {
+        // Best-effort: a failed registration here is not fatal. The next
+        // balance check will retry.
+      }
+    },
+    [mutateAsync]
+  );
+}

--- a/components/frontend/src/lib/query-keys.ts
+++ b/components/frontend/src/lib/query-keys.ts
@@ -34,5 +34,8 @@ export const walletKeys = {
   all: ['wallet'] as const,
   info: () => [...walletKeys.all, 'info'] as const,
   balance: () => [...walletKeys.all, 'balance'] as const,
-  transactions: () => [...walletKeys.all, 'transactions'] as const
+  transactions: () => [...walletKeys.all, 'transactions'] as const,
+  subscriptions: () => [...walletKeys.all, 'subscriptions'] as const,
+  subscriptionBalance: (creditsUrl: string) =>
+    [...walletKeys.all, 'subscriptions', 'balance', creditsUrl] as const
 };

--- a/components/frontend/src/lib/types.ts
+++ b/components/frontend/src/lib/types.ts
@@ -390,3 +390,23 @@ export interface WalletTransaction {
   app_name?: string;
   app_ep_path?: string;
 }
+
+/**
+ * A publisher-side Xendit subscription stored on the user account.
+ * One row per distinct credits_url. Identifies a wallet on a publisher's
+ * syft_space that the user has funded; balance is fetched live from the
+ * publisher with a satellite token, last_known_balance is just for fast paint.
+ */
+export interface XenditSubscription {
+  id: number;
+  credits_url: string;
+  payment_url: string;
+  currency: string;
+  endpoint_owner: string;
+  endpoint_slug: string | null;
+  last_known_balance: number | null;
+  last_checked_at: string | null;
+  first_funded_at: string | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/components/frontend/src/lib/xendit-client.ts
+++ b/components/frontend/src/lib/xendit-client.ts
@@ -1,0 +1,169 @@
+/**
+ * Xendit client — shared helpers for talking to a publisher's syft_space
+ * payment gateway. The Xendit-policy sidebar card, the chat-precheck hook,
+ * and the subscription gate modal all need the same primitives:
+ *
+ * - Mint a satellite token for the endpoint owner (SyftHub SDK).
+ * - GET the user's per-wallet balance against credits_url.
+ * - POST a bundle purchase against payment_url, returning the checkout URL.
+ * - Open the checkout in a centred popup window.
+ * - Parse a Xendit policy.config dict into a typed shape.
+ *
+ * The hub returns policy.config through two code paths: a raw-fetch path
+ * that preserves snake_case, and the SDK browse/trending path that
+ * recursively camelCases every key. parseXenditConfig accepts either.
+ */
+import { syftClient } from '@/lib/sdk-client';
+
+export const POLL_INTERVAL_MS = 3000;
+
+export interface MoneyBundle {
+  name: string;
+  amount: number;
+}
+
+export interface ParsedXenditConfig {
+  paymentUrl: string | null;
+  creditsUrl: string | null;
+  bundles: MoneyBundle[];
+  currency: string;
+  pricePerRequest: number | null;
+  country: string | null;
+}
+
+export function isValidUrl(value: unknown): value is string {
+  return typeof value === 'string' && (value.startsWith('https://') || value.startsWith('http://'));
+}
+
+function isStringValue(v: unknown): v is string {
+  return typeof v === 'string';
+}
+function isNumberValue(v: unknown): v is number {
+  return typeof v === 'number';
+}
+function isUnknownArray(v: unknown): v is unknown[] {
+  return Array.isArray(v);
+}
+
+function pickConfigValue<T>(
+  config: Record<string, unknown>,
+  snake: string,
+  camel: string,
+  guard: (v: unknown) => v is T
+): T | null {
+  const snakeValue = config[snake];
+  if (guard(snakeValue)) return snakeValue;
+  const camelValue = config[camel];
+  if (guard(camelValue)) return camelValue;
+  return null;
+}
+
+export function parseXenditConfig(config: Record<string, unknown>): ParsedXenditConfig {
+  const paymentUrl = pickConfigValue(config, 'payment_url', 'paymentUrl', isValidUrl);
+  const creditsUrl = pickConfigValue(config, 'credits_url', 'creditsUrl', isValidUrl);
+  const currency = pickConfigValue(config, 'currency', 'currency', isStringValue) ?? 'IDR';
+  const country = pickConfigValue(config, 'country', 'country', isStringValue);
+  const pricePerRequest = pickConfigValue(
+    config,
+    'price_per_request',
+    'pricePerRequest',
+    isNumberValue
+  );
+  const rawBundles = pickConfigValue(config, 'bundles', 'bundles', isUnknownArray) ?? [];
+  const bundles: MoneyBundle[] = rawBundles.filter(
+    (b): b is MoneyBundle =>
+      typeof b === 'object' &&
+      b !== null &&
+      typeof (b as Record<string, unknown>).name === 'string' &&
+      typeof (b as Record<string, unknown>).amount === 'number'
+  );
+  return { paymentUrl, creditsUrl, bundles, currency, pricePerRequest, country };
+}
+
+export function openCheckoutWindow(url: string): void {
+  const width = 800;
+  const height = 900;
+  const left = Math.max(0, Math.round((window.screen.availWidth - width) / 2));
+  const top = Math.max(0, Math.round((window.screen.availHeight - height) / 2));
+  const features = `popup=yes,width=${String(width)},height=${String(height)},left=${String(left)},top=${String(top)},noopener,noreferrer`;
+  window.open(url, 'xendit-checkout', features);
+}
+
+export async function getSatelliteToken(audience: string): Promise<string | null> {
+  try {
+    const response = await syftClient.auth.getSatelliteToken(audience);
+    return response.targetToken;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchBalance(
+  creditsUrl: string,
+  satelliteToken: string,
+  signal?: AbortSignal
+): Promise<number | null> {
+  try {
+    const response = await fetch(creditsUrl, {
+      headers: { Authorization: `Bearer ${satelliteToken}` },
+      signal
+    });
+    if (!response.ok) return null;
+    const data: unknown = await response.json();
+    if (typeof data !== 'object' || data === null) return null;
+    const balance = (data as Record<string, unknown>).balance;
+    return typeof balance === 'number' ? balance : 0;
+  } catch {
+    return null;
+  }
+}
+
+export interface CreateInvoiceResult {
+  checkoutUrl: string;
+}
+
+export async function createInvoice(
+  paymentUrl: string,
+  satelliteToken: string,
+  bundleName: string,
+  endpointSlug?: string,
+  signal?: AbortSignal
+): Promise<CreateInvoiceResult | { error: string }> {
+  try {
+    const body: Record<string, string> = { bundle_name: bundleName };
+    if (endpointSlug) body.endpoint_slug = endpointSlug;
+    const response = await fetch(paymentUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${satelliteToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(body),
+      signal
+    });
+    if (!response.ok) {
+      let message = `Failed to create invoice (${String(response.status)})`;
+      try {
+        const errorData: unknown = await response.json();
+        if (typeof errorData === 'object' && errorData !== null) {
+          const detail = (errorData as Record<string, unknown>).detail;
+          if (typeof detail === 'string') message = detail;
+        }
+      } catch {
+        /* keep default */
+      }
+      return { error: message };
+    }
+    const data: unknown = await response.json();
+    if (typeof data !== 'object' || data === null) {
+      return { error: 'Invalid invoice response (missing checkout_url)' };
+    }
+    const checkoutUrl = (data as Record<string, unknown>).checkout_url;
+    if (typeof checkoutUrl !== 'string') {
+      return { error: 'Invalid invoice response (missing checkout_url)' };
+    }
+    return { checkoutUrl };
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : 'Network error' };
+  }
+}

--- a/components/frontend/src/stores/settings-modal-store.ts
+++ b/components/frontend/src/stores/settings-modal-store.ts
@@ -5,6 +5,7 @@ export type SettingsTab =
   | 'security'
   | 'api-tokens'
   | 'payment'
+  | 'subscriptions'
   | 'aggregator'
   | 'danger-zone';
 


### PR DESCRIPTION
## Summary

Adds the user-facing flow for Xendit-paid endpoints end-to-end:

1. **Persistent record of funded publisher wallets** so SyftHub can list them in a unified credits panel without re-scanning every endpoint policy. The wallet itself stays publisher-owned; SyftHub only stores `credits_url`/`payment_url`/currency/last-known-balance and always fetches live balances from the publisher with a satellite token.
2. **Unified credits panel** in the top-bar dropdown listing the MPP/Tempo wallet alongside every funded publisher wallet, each polling its own `credits_url` while the panel is open. New **Subscriptions** settings tab manages the funded wallets (Top up / Forget).
3. **Inline payment gate** in the chat history when one or more selected endpoints carry an unfunded Xendit policy. One row per endpoint, each with Bundle picker, Buy, and × to remove. Removing the model row cancels the queued send; removing the last data-source blocker auto-fires the queued send.
4. **Endpoint sidebar Xendit policy card** gets a real Buy flow with auto-polling for "active" without manual refresh.
5. **Aggregator 403 fix** — when a publisher's policy refuses a data-source query, the aggregator no longer silently degrades to model-only and charges the user for the wrong answer; it surfaces the access-denial via SSE error and aborts the stream.

## Commits

- `feat(backend)`: persist user-funded Xendit subscriptions (table + repo + 3 endpoints under existing wallet router)
- `fix(aggregator)`: surface upstream 403s instead of silently degrading
- `feat(frontend)`: unified credits panel + Xendit subscriptions tab (foundation: shared `xendit-client` lib + `bundle-picker`)
- `feat(frontend)`: inline payment gate and Xendit purchase UI
- `chore`: add Makefile sdk-build target (avoids the bind-mount overlay erasing the SDK build)

## Test plan

- [ ] Backend migration applies cleanly: `alembic upgrade head` creates `user_xendit_subscriptions`
- [ ] `GET /api/v1/wallet/subscriptions` returns `[]` for a fresh user
- [ ] Pay an unfunded Xendit endpoint via the sidebar; row flips to "Active" without manual refresh
- [ ] Open the credits panel — the funded wallet appears as a row alongside the MPP wallet
- [ ] In **Settings → Subscriptions**, Top up opens the publisher checkout; Forget removes the row (no refund)
- [ ] Try chat with an unfunded paid endpoint selected: gate appears below the user bubble; Send disabled until all rows go active
- [ ] Click the × on a data-source row: that endpoint is dropped from the chat selection; if it was the only blocker, the queued send fires
- [ ] Click the × on the model row: queued send is cancelled and the user bubble is popped
- [ ] When a publisher refuses a selected data source (HTTP 403), the chat surfaces an error listing the offending paths instead of returning a degraded model-only answer