### PR TITLE
feat(xendit): prepaid credits UI polish (OME-242)

### DIFF
--- a/components/backend/src/syfthub/services/endpoint_service.py
+++ b/components/backend/src/syfthub/services/endpoint_service.py
@@ -178,18 +178,18 @@ class EndpointService(BaseService):
         return [uid for uid in unique_ids if uid in active_ids]
 
     @staticmethod
-    def _inject_subscription_tag(tags: list[str], policies: list[Policy]) -> list[str]:
-        """Inject 'subscription' tag if a xendit policy is present.
+    def _inject_prepaid_tag(tags: list[str], policies: list[Policy]) -> list[str]:
+        """Inject 'prepaid' tag if a xendit policy is present.
 
         Silently skips if the tags list already has 10 or more entries and
-        'subscription' is not present (preserves the 10-tag soft limit for
+        'prepaid' is not present (preserves the 10-tag soft limit for
         user-supplied tags without rejecting the request).
         """
-        has_bundle_sub = any(p.type.lower() == "xendit" for p in policies)
-        if has_bundle_sub and "subscription" not in tags:
+        has_xendit_policy = any(p.type.lower() == "xendit" for p in policies)
+        if has_xendit_policy and "prepaid" not in tags:
             if len(tags) >= 10:
                 return tags
-            return [*tags, "subscription"]
+            return [*tags, "prepaid"]
         return tags
 
     def create_endpoint(
@@ -241,8 +241,7 @@ class EndpointService(BaseService):
                     detail="slug already exists - already taken",
                 )
 
-        # Auto-inject 'subscription' tag when a xendit policy is present
-        final_tags = self._inject_subscription_tag(
+        final_tags = self._inject_prepaid_tag(
             endpoint_data.tags, endpoint_data.policies
         )
 
@@ -391,16 +390,13 @@ class EndpointService(BaseService):
                 valid_contributors.append(current_user.id)
             endpoint_data.contributors = valid_contributors
 
-        # Auto-inject 'subscription' tag when a xendit policy is present
         if endpoint_data.policies is not None:
             effective_tags = (
                 endpoint_data.tags
                 if endpoint_data.tags is not None
                 else (endpoint.tags or [])
             )
-            new_tags = self._inject_subscription_tag(
-                effective_tags, endpoint_data.policies
-            )
+            new_tags = self._inject_prepaid_tag(effective_tags, endpoint_data.policies)
             if new_tags != effective_tags:
                 endpoint_data.tags = new_tags
 
@@ -1156,7 +1152,7 @@ class EndpointService(BaseService):
                 valid_contributors.append(current_user.id)
 
             # Prepare the validated endpoint data
-            final_tags = self._inject_subscription_tag(
+            final_tags = self._inject_prepaid_tag(
                 endpoint_data.tags or [], endpoint_data.policies
             )
             validated_endpoint = {

--- a/components/backend/tests/test_endpoints.py
+++ b/components/backend/tests/test_endpoints.py
@@ -1381,10 +1381,10 @@ _XENDIT_POLICY_MINIMAL = {
 }
 
 
-def test_xendit_policy_auto_injects_subscription_tag_on_create(
+def test_xendit_policy_auto_injects_prepaid_tag_on_create(
     client: TestClient, user1_token: str
 ) -> None:
-    """Test that creating an endpoint with xendit policy auto-injects 'subscription' tag."""
+    """Test that creating an endpoint with xendit policy auto-injects 'prepaid' tag."""
     headers = {"Authorization": f"Bearer {user1_token}"}
 
     endpoint_data = {
@@ -1399,15 +1399,15 @@ def test_xendit_policy_auto_injects_subscription_tag_on_create(
     assert response.status_code == 201
 
     data = response.json()
-    assert "subscription" in data["tags"]
+    assert "prepaid" in data["tags"]
     assert "ml" in data["tags"]
     assert "nlp" in data["tags"]
 
 
-def test_xendit_policy_auto_injects_subscription_tag_on_update(
+def test_xendit_policy_auto_injects_prepaid_tag_on_update(
     client: TestClient, user1_token: str
 ) -> None:
-    """Test that updating an endpoint to add xendit policy injects 'subscription' tag."""
+    """Test that updating an endpoint to add xendit policy injects 'prepaid' tag."""
     headers = {"Authorization": f"Bearer {user1_token}"}
 
     # Create endpoint without xendit policy
@@ -1420,7 +1420,7 @@ def test_xendit_policy_auto_injects_subscription_tag_on_update(
     response = client.post("/api/v1/endpoints", json=create_data, headers=headers)
     assert response.status_code == 201
     endpoint_id = response.json()["id"]
-    assert "subscription" not in response.json()["tags"]
+    assert "prepaid" not in response.json()["tags"]
 
     # Update to add xendit policy
     update_data = {"policies": [_XENDIT_POLICY_MINIMAL]}
@@ -1428,7 +1428,7 @@ def test_xendit_policy_auto_injects_subscription_tag_on_update(
         f"/api/v1/endpoints/{endpoint_id}", json=update_data, headers=headers
     )
     assert response.status_code == 200
-    assert "subscription" in response.json()["tags"]
+    assert "prepaid" in response.json()["tags"]
 
 
 def test_xendit_auto_tag_skips_when_tag_limit_reached(
@@ -1451,18 +1451,18 @@ def test_xendit_auto_tag_skips_when_tag_limit_reached(
 
     data = response.json()
     assert len(data["tags"]) == 10
-    assert "subscription" not in data["tags"]
+    assert "prepaid" not in data["tags"]
 
 
 def test_xendit_auto_tag_is_idempotent(client: TestClient, user1_token: str) -> None:
-    """Test that 'subscription' tag is not duplicated if already present."""
+    """Test that 'prepaid' tag is not duplicated if already present."""
     headers = {"Authorization": f"Bearer {user1_token}"}
 
     endpoint_data = {
         "name": "Idempotent Xendit Endpoint",
         "type": "model",
         "visibility": "public",
-        "tags": ["subscription", "ai"],
+        "tags": ["prepaid", "ai"],
         "policies": [_XENDIT_POLICY_MINIMAL],
     }
 
@@ -1470,7 +1470,7 @@ def test_xendit_auto_tag_is_idempotent(client: TestClient, user1_token: str) -> 
     assert response.status_code == 201
 
     data = response.json()
-    assert data["tags"].count("subscription") == 1
+    assert data["tags"].count("prepaid") == 1
 
 
 def test_create_endpoint_with_xendit_policy(
@@ -1507,7 +1507,7 @@ def test_create_endpoint_with_xendit_policy(
         policy["config"]["credits_url"]
         == "https://my-server.example.com/api/v1/payments/gateway/bundles/test-endpoint"
     )
-    assert "subscription" in data["tags"]
+    assert "prepaid" in data["tags"]
 
 
 def test_create_endpoint_with_connections(client: TestClient, user1_token: str) -> None:
@@ -2256,13 +2256,13 @@ def test_create_endpoint_with_xendit_policy_auto_tags(
     assert len(policy["config"]["bundles"]) == 2
 
     # Auto-tag injection
-    assert "subscription" in data["tags"]
+    assert "prepaid" in data["tags"]
 
 
 def test_create_endpoint_xendit_no_duplicate_tag(
     client: TestClient, user1_token: str
 ) -> None:
-    """Test that auto-tag injection does not duplicate 'subscription' if already present."""
+    """Test that auto-tag injection does not duplicate 'prepaid' if already present."""
     headers = {"Authorization": f"Bearer {user1_token}"}
 
     response = client.post(
@@ -2271,7 +2271,7 @@ def test_create_endpoint_xendit_no_duplicate_tag(
             "name": "Already Tagged Xendit Endpoint",
             "type": "model",
             "visibility": "public",
-            "tags": ["subscription", "ml"],
+            "tags": ["prepaid", "ml"],
             "policies": [_XENDIT_POLICY_MINIMAL],
         },
         headers=headers,
@@ -2279,13 +2279,13 @@ def test_create_endpoint_xendit_no_duplicate_tag(
     assert response.status_code == 201
 
     data = response.json()
-    assert data["tags"].count("subscription") == 1
+    assert data["tags"].count("prepaid") == 1
 
 
 def test_update_endpoint_with_xendit_auto_tags(
     client: TestClient, user1_token: str
 ) -> None:
-    """Test that updating an endpoint to add xendit policy injects subscription tag."""
+    """Test that updating an endpoint to add xendit policy injects prepaid tag."""
     headers = {"Authorization": f"Bearer {user1_token}"}
 
     # Create endpoint without policies
@@ -2300,7 +2300,7 @@ def test_update_endpoint_with_xendit_auto_tags(
     )
     assert response.status_code == 201
     endpoint_id = response.json()["id"]
-    assert "subscription" not in response.json()["tags"]
+    assert "prepaid" not in response.json()["tags"]
 
     # Update with xendit policy
     response = client.patch(
@@ -2309,13 +2309,13 @@ def test_update_endpoint_with_xendit_auto_tags(
         headers=headers,
     )
     assert response.status_code == 200
-    assert "subscription" in response.json()["tags"]
+    assert "prepaid" in response.json()["tags"]
 
 
 def test_sync_endpoint_with_xendit_auto_tags(
     client: TestClient, user1_token: str
 ) -> None:
-    """Test that sync with xendit policy injects subscription tag."""
+    """Test that sync with xendit policy injects prepaid tag."""
     headers = {"Authorization": f"Bearer {user1_token}"}
 
     sync_data = {
@@ -2335,7 +2335,7 @@ def test_sync_endpoint_with_xendit_auto_tags(
 
     endpoint = response.json()["endpoints"][0]
     assert "ai" in endpoint["tags"]
-    assert "subscription" in endpoint["tags"]
+    assert "prepaid" in endpoint["tags"]
     assert endpoint["policies"][0]["type"] == "xendit"
     assert endpoint["policies"][0]["config"]["bundles"][0]["name"] == "Starter"
 
@@ -2343,7 +2343,7 @@ def test_sync_endpoint_with_xendit_auto_tags(
 def test_remove_xendit_policy_does_not_remove_tag(
     client: TestClient, user1_token: str
 ) -> None:
-    """Test that removing xendit policies does NOT auto-remove 'subscription' tag."""
+    """Test that removing xendit policies does NOT auto-remove 'prepaid' tag."""
     headers = {"Authorization": f"Bearer {user1_token}"}
 
     # Create with xendit policy
@@ -2359,7 +2359,7 @@ def test_remove_xendit_policy_does_not_remove_tag(
     )
     assert response.status_code == 201
     endpoint_id = response.json()["id"]
-    assert "subscription" in response.json()["tags"]
+    assert "prepaid" in response.json()["tags"]
 
     # Remove all policies
     response = client.patch(
@@ -2369,4 +2369,4 @@ def test_remove_xendit_policy_does_not_remove_tag(
     )
     assert response.status_code == 200
     # Tag should still be present (not auto-removed)
-    assert "subscription" in response.json()["tags"]
+    assert "prepaid" in response.json()["tags"]

--- a/components/frontend/src/components/balance/credits-panel.tsx
+++ b/components/frontend/src/components/balance/credits-panel.tsx
@@ -59,8 +59,8 @@ export function CreditsPanel({
         <SectionHeader
           label={
             subscriptions.length > 0
-              ? `Endpoint subscriptions · ${String(subscriptions.length)}`
-              : 'Endpoint subscriptions'
+              ? `Endpoint credits · ${String(subscriptions.length)}`
+              : 'Endpoint credits'
           }
           onRefresh={() => void subscriptionsQuery.refetch()}
           isRefreshing={subscriptionsQuery.isFetching}
@@ -261,9 +261,7 @@ function SubscriptionRow({
 
   const liveBalance = balance ?? subscription.last_known_balance ?? 0;
   const status = balanceStatus(liveBalance, 0);
-  const label = subscription.endpoint_slug
-    ? `${subscription.endpoint_owner}/${subscription.endpoint_slug}`
-    : subscription.endpoint_owner;
+  const label = subscription.endpoint_owner;
   const targetPath = subscription.endpoint_slug
     ? `/${subscription.endpoint_owner}/${subscription.endpoint_slug}`
     : `/${subscription.endpoint_owner}`;

--- a/components/frontend/src/components/chat/payment-gate.tsx
+++ b/components/frontend/src/components/chat/payment-gate.tsx
@@ -192,6 +192,7 @@ function PaymentGateRow({ pending, liveBalance, isActive, onRemove }: Readonly<R
                 onChange={setSelectedBundleName}
                 disabled={isBusy}
                 triggerClassName='h-8 min-w-[7rem]'
+                pricePerRequest={pending.pricePerRequest}
               />
               <button
                 type='button'

--- a/components/frontend/src/components/endpoint/bundle-picker.tsx
+++ b/components/frontend/src/components/endpoint/bundle-picker.tsx
@@ -12,6 +12,7 @@ import {
   SelectValue
 } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
+import { formatRequestEstimate } from '@/lib/xendit-client';
 
 export interface BundlePickerProperties {
   bundles: MoneyBundle[];
@@ -20,6 +21,19 @@ export interface BundlePickerProperties {
   onChange: (name: string) => void;
   disabled?: boolean;
   triggerClassName?: string;
+  /** When set (>0), each option shows an estimated request count. */
+  pricePerRequest?: number | null;
+}
+
+function RequestEstimate({
+  amount,
+  pricePerRequest
+}: Readonly<{ amount: number; pricePerRequest: number }>) {
+  return (
+    <span className='text-[10px] font-normal opacity-70'>
+      ({formatRequestEstimate(amount, pricePerRequest)})
+    </span>
+  );
 }
 
 export function BundlePicker({
@@ -28,10 +42,13 @@ export function BundlePicker({
   value,
   onChange,
   disabled,
-  triggerClassName
+  triggerClassName,
+  pricePerRequest
 }: Readonly<BundlePickerProperties>) {
   const selected = bundles.find((b) => b.name === value) ?? bundles[0];
   if (!selected) return null;
+
+  const showRequestEstimate = typeof pricePerRequest === 'number' && pricePerRequest > 0;
 
   return (
     <Select value={value} onValueChange={onChange} disabled={disabled}>
@@ -46,10 +63,13 @@ export function BundlePicker({
         )}
       >
         <SelectValue>
-          <span className='flex w-full items-center pr-1'>
+          <span className='flex w-full items-center gap-1.5 pr-1'>
             <span className='font-medium tabular-nums'>
               {currency} {selected.amount.toLocaleString()}
             </span>
+            {showRequestEstimate && (
+              <RequestEstimate amount={selected.amount} pricePerRequest={pricePerRequest} />
+            )}
           </span>
         </SelectValue>
       </SelectTrigger>
@@ -68,8 +88,13 @@ export function BundlePicker({
               'dark:text-violet-200 dark:focus:bg-violet-900/50 dark:focus:text-violet-100'
             )}
           >
-            <span className='font-medium tabular-nums'>
-              {currency} {bundle.amount.toLocaleString()}
+            <span className='flex items-center gap-1.5'>
+              <span className='font-medium tabular-nums'>
+                {currency} {bundle.amount.toLocaleString()}
+              </span>
+              {showRequestEstimate && (
+                <RequestEstimate amount={bundle.amount} pricePerRequest={pricePerRequest} />
+              )}
             </span>
           </SelectItem>
         ))}

--- a/components/frontend/src/components/endpoint/policy-item.tsx
+++ b/components/frontend/src/components/endpoint/policy-item.tsx
@@ -1,11 +1,13 @@
-import React, { memo } from 'react';
+import React, { memo, useMemo, useState } from 'react';
 
 import type { Policy } from '@/lib/types';
 
+import ChevronDown from 'lucide-react/dist/esm/icons/chevron-down';
 import Coins from 'lucide-react/dist/esm/icons/coins';
 import CreditCard from 'lucide-react/dist/esm/icons/credit-card';
 import Gauge from 'lucide-react/dist/esm/icons/gauge';
 import Globe from 'lucide-react/dist/esm/icons/globe';
+import Info from 'lucide-react/dist/esm/icons/info';
 import Key from 'lucide-react/dist/esm/icons/key';
 import Lock from 'lucide-react/dist/esm/icons/lock';
 import MapPin from 'lucide-react/dist/esm/icons/map-pin';
@@ -14,7 +16,9 @@ import ShieldCheck from 'lucide-react/dist/esm/icons/shield-check';
 import Zap from 'lucide-react/dist/esm/icons/zap';
 
 import { Badge } from '@/components/ui/badge';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { cn } from '@/lib/utils';
+import { parseXenditConfig } from '@/lib/xendit-client';
 
 import { GenericPolicyContent } from './generic-policy-content';
 import { formatConfigKey, TransactionPolicyContent } from './transaction-policy-content';
@@ -51,11 +55,11 @@ const POLICY_TYPE_CONFIG: Record<
   },
   xendit: {
     icon: CreditCard,
-    label: 'Xendit Bundle',
+    label: 'Pay-in-advance via Xendit',
     color: 'text-violet-600 dark:text-violet-400',
     bgColor: 'bg-violet-50 dark:bg-violet-950/30',
     borderColor: 'border-violet-200 dark:border-violet-800',
-    description: 'Bundle subscription required to access this endpoint'
+    description: 'Top up credits in advance to use this endpoint'
   },
   // Access control policies
   public: {
@@ -182,6 +186,15 @@ export const PolicyItem = memo(function PolicyItem({
   const rawDescription = policy.description || config.description;
   const description = rawDescription && rawDescription !== displayLabel ? rawDescription : null;
 
+  const xenditParsed = useMemo(
+    () => (isXendit ? parseXenditConfig(policy.config) : null),
+    [isXendit, policy.config]
+  );
+  const xenditPricePerRequest =
+    xenditParsed && xenditParsed.pricePerRequest !== null && xenditParsed.pricePerRequest > 0
+      ? xenditParsed.pricePerRequest
+      : null;
+
   return (
     <div
       className={cn(
@@ -220,17 +233,56 @@ export const PolicyItem = memo(function PolicyItem({
               {policy.enabled ? 'Active' : 'Disabled'}
             </Badge>
           </div>
-          {description && <p className='text-muted-foreground mt-1 text-xs'>{description}</p>}
+          {description && (
+            <p className='text-muted-foreground mt-1 text-xs'>
+              {description}
+              {xenditParsed && xenditPricePerRequest !== null && (
+                <>
+                  {' '}
+                  <span className='font-semibold text-violet-700 tabular-nums dark:text-violet-300'>
+                    ({xenditParsed.currency} {xenditPricePerRequest.toLocaleString()} / request)
+                  </span>
+                </>
+              )}
+            </p>
+          )}
 
           {/* Policy-specific content */}
           {Object.keys(policy.config).length > 0 &&
             renderPolicyContent(policy, isTransaction, isXendit, endpointSlug, endpointOwner)}
 
-          {policy.version ? (
-            <p className='text-muted-foreground mt-2 text-[10px]'>Version {policy.version}</p>
-          ) : null}
+          <div className='mt-2 flex items-center gap-2'>
+            {policy.version ? (
+              <p className='text-muted-foreground text-[10px]'>Version {policy.version}</p>
+            ) : null}
+            {isXendit && <XenditHowItWorks />}
+          </div>
         </div>
       </div>
     </div>
   );
 });
+
+function XenditHowItWorks() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className='text-[10px]'>
+      <CollapsibleTrigger
+        className={cn(
+          'text-muted-foreground hover:text-foreground inline-flex cursor-pointer items-center gap-1',
+          'transition-colors select-none'
+        )}
+      >
+        <Info className='h-3 w-3' />
+        <span>How does this work?</span>
+        <ChevronDown className={cn('h-3 w-3 transition-transform', open && 'rotate-180')} />
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <p className='text-muted-foreground mt-1.5 max-w-prose text-[11px] leading-relaxed'>
+          Purchase credits upfront with a data owner. Your balance is shared across all of their
+          endpoints. Top up anytime — credits are deducted per request until your balance runs out.
+        </p>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/components/frontend/src/components/endpoint/xendit-policy-content.tsx
+++ b/components/frontend/src/components/endpoint/xendit-policy-content.tsx
@@ -12,6 +12,7 @@ import { cn } from '@/lib/utils';
 import {
   createInvoice,
   fetchBalance,
+  fetchPendingInvoice,
   getSatelliteToken,
   openCheckoutWindow,
   parseXenditConfig,
@@ -45,7 +46,7 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
   // Re-parse only when config identity changes — otherwise the bundles array
   // would get a fresh reference each render and re-fire the validation effect.
   const parsed = useMemo(() => parseXenditConfig(config), [config]);
-  const { bundles, currency, paymentUrl, creditsUrl, pricePerRequest } = parsed;
+  const { bundles, currency, paymentUrl, creditsUrl, invoicesUrl, pricePerRequest } = parsed;
 
   const [subscription, setSubscription] = useState<SubscriptionState>({ state: 'loading' });
   const [purchase, setPurchase] = useState<PurchaseState>({ state: 'idle' });
@@ -68,10 +69,11 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
   }, [bundles, selectedBundleName]);
 
   // Shared balance check. `silent=true` skips the loading transition for
-  // background polling. Updates state only when something actually changed,
-  // so unchanged poll ticks don't trigger re-renders downstream.
+  // background polling. `checkPending=true` (used on initial mount) also
+  // queries the gateway for an in-flight pending invoice so the user lands
+  // back on "awaiting payment" after closing the checkout popup.
   const checkBalance = useCallback(
-    async (options: { silent?: boolean; signal?: AbortSignal } = {}) => {
+    async (options: { silent?: boolean; signal?: AbortSignal; checkPending?: boolean } = {}) => {
       const tokens = syftClient.getTokens();
       if (!tokens || !creditsUrl || !endpointOwner) {
         setSubscription((previous) =>
@@ -88,13 +90,25 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
         );
         return;
       }
-      const balance = await fetchBalance(creditsUrl, satelliteToken, options.signal);
+      const [balance, pending] = await Promise.all([
+        fetchBalance(creditsUrl, satelliteToken, options.signal),
+        options.checkPending && invoicesUrl
+          ? fetchPendingInvoice(invoicesUrl, satelliteToken, options.signal)
+          : Promise.resolve(null)
+      ]);
       if (options.signal?.aborted) return;
       if (balance === null || balance <= 0) {
         if (!options.silent) {
           setSubscription((previous) =>
             previous.state === 'inactive' ? previous : { state: 'inactive' }
           );
+        }
+        if (pending) {
+          setPurchase({
+            state: 'awaiting_payment',
+            bundleName: pending.bundleName,
+            checkoutUrl: pending.checkoutUrl
+          });
         }
         return;
       }
@@ -119,16 +133,17 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
         });
       }
     },
-    [creditsUrl, endpointOwner, paymentUrl, endpointSlug, currency, registerOnFunding]
+    [creditsUrl, invoicesUrl, endpointOwner, paymentUrl, endpointSlug, currency, registerOnFunding]
   );
 
   const refreshBalance = useCallback(() => checkBalance(), [checkBalance]);
 
-  // Initial balance load. The same `checkBalance` powers refresh and polling,
-  // and aborts cleanly on unmount.
+  // Initial balance load — also probes for an in-flight pending invoice so a
+  // user returning to the page after closing the checkout popup picks the
+  // flow back up from `awaiting_payment` instead of seeing the Buy button.
   useEffect(() => {
     const controller = new AbortController();
-    void checkBalance({ signal: controller.signal });
+    void checkBalance({ signal: controller.signal, checkPending: true });
     return () => {
       controller.abort();
     };
@@ -214,44 +229,42 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
         </div>
       )}
 
-      {subscription.state !== 'loading' &&
-        purchase.state !== 'awaiting_payment' &&
-        bundles.length > 0 && (
-          <div className='space-y-1.5'>
-            <BundlePicker
-              bundles={bundles}
-              currency={currency}
-              value={selectedBundleName}
-              onChange={setSelectedBundleName}
-              disabled={isCreatingAny}
-              pricePerRequest={pricePerRequest}
-            />
-            <button
-              type='button'
-              disabled={!canPurchase || isCreatingAny}
-              onClick={() => void handleSubscribe(selectedBundleName)}
-              className={cn(
-                'group inline-flex h-8 w-full items-center justify-center gap-1.5 rounded-md text-xs font-medium transition-colors',
-                'border border-violet-300 bg-violet-50 text-violet-700 dark:border-violet-700 dark:bg-violet-950/30 dark:text-violet-300',
-                !canPurchase || isCreatingAny
-                  ? 'cursor-not-allowed opacity-50'
-                  : 'cursor-pointer hover:bg-violet-100 dark:hover:bg-violet-900/40'
-              )}
-            >
-              {isCreatingAny ? (
-                <>
-                  <Loader2 className='h-3 w-3 animate-spin' />
-                  Opening checkout…
-                </>
-              ) : (
-                <>
-                  Buy
-                  <ArrowRight className='h-3 w-3 transition-transform group-hover:translate-x-0.5' />
-                </>
-              )}
-            </button>
-          </div>
-        )}
+      {subscription.state !== 'loading' && bundles.length > 0 && (
+        <div className='space-y-1.5'>
+          <BundlePicker
+            bundles={bundles}
+            currency={currency}
+            value={selectedBundleName}
+            onChange={setSelectedBundleName}
+            disabled={isCreatingAny}
+            pricePerRequest={pricePerRequest}
+          />
+          <button
+            type='button'
+            disabled={!canPurchase || isCreatingAny}
+            onClick={() => void handleSubscribe(selectedBundleName)}
+            className={cn(
+              'group inline-flex h-8 w-full items-center justify-center gap-1.5 rounded-md text-xs font-medium transition-colors',
+              'border border-violet-300 bg-violet-50 text-violet-700 dark:border-violet-700 dark:bg-violet-950/30 dark:text-violet-300',
+              !canPurchase || isCreatingAny
+                ? 'cursor-not-allowed opacity-50'
+                : 'cursor-pointer hover:bg-violet-100 dark:hover:bg-violet-900/40'
+            )}
+          >
+            {isCreatingAny ? (
+              <>
+                <Loader2 className='h-3 w-3 animate-spin' />
+                Opening checkout…
+              </>
+            ) : (
+              <>
+                Buy
+                <ArrowRight className='h-3 w-3 transition-transform group-hover:translate-x-0.5' />
+              </>
+            )}
+          </button>
+        </div>
+      )}
 
       {purchase.state === 'error' && (
         <div className='rounded-md border border-red-200 bg-red-50/70 px-2.5 py-1.5 text-[11px] text-red-700 dark:border-red-900/60 dark:bg-red-950/20 dark:text-red-300'>

--- a/components/frontend/src/components/endpoint/xendit-policy-content.tsx
+++ b/components/frontend/src/components/endpoint/xendit-policy-content.tsx
@@ -45,7 +45,7 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
   // Re-parse only when config identity changes — otherwise the bundles array
   // would get a fresh reference each render and re-fire the validation effect.
   const parsed = useMemo(() => parseXenditConfig(config), [config]);
-  const { bundles, currency, paymentUrl, creditsUrl } = parsed;
+  const { bundles, currency, paymentUrl, creditsUrl, pricePerRequest } = parsed;
 
   const [subscription, setSubscription] = useState<SubscriptionState>({ state: 'loading' });
   const [purchase, setPurchase] = useState<PurchaseState>({ state: 'idle' });
@@ -214,7 +214,7 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
         </div>
       )}
 
-      {subscription.state === 'inactive' &&
+      {subscription.state !== 'loading' &&
         purchase.state !== 'awaiting_payment' &&
         bundles.length > 0 && (
           <div className='space-y-1.5'>
@@ -224,6 +224,7 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
               value={selectedBundleName}
               onChange={setSelectedBundleName}
               disabled={isCreatingAny}
+              pricePerRequest={pricePerRequest}
             />
             <button
               type='button'

--- a/components/frontend/src/lib/xendit-client.ts
+++ b/components/frontend/src/lib/xendit-client.ts
@@ -25,6 +25,7 @@ export interface MoneyBundle {
 export interface ParsedXenditConfig {
   paymentUrl: string | null;
   creditsUrl: string | null;
+  invoicesUrl: string | null;
   bundles: MoneyBundle[];
   currency: string;
   pricePerRequest: number | null;
@@ -61,6 +62,7 @@ function pickConfigValue<T>(
 export function parseXenditConfig(config: Record<string, unknown>): ParsedXenditConfig {
   const paymentUrl = pickConfigValue(config, 'payment_url', 'paymentUrl', isValidUrl);
   const creditsUrl = pickConfigValue(config, 'credits_url', 'creditsUrl', isValidUrl);
+  const invoicesUrl = pickConfigValue(config, 'invoices_url', 'invoicesUrl', isValidUrl);
   const currency = pickConfigValue(config, 'currency', 'currency', isStringValue) ?? 'IDR';
   const country = pickConfigValue(config, 'country', 'country', isStringValue);
   const pricePerRequest = pickConfigValue(
@@ -77,7 +79,7 @@ export function parseXenditConfig(config: Record<string, unknown>): ParsedXendit
       typeof (b as Record<string, unknown>).name === 'string' &&
       typeof (b as Record<string, unknown>).amount === 'number'
   );
-  return { paymentUrl, creditsUrl, bundles, currency, pricePerRequest, country };
+  return { paymentUrl, creditsUrl, invoicesUrl, bundles, currency, pricePerRequest, country };
 }
 
 export function formatRequestEstimate(amount: number, pricePerRequest: number): string {
@@ -118,6 +120,46 @@ export async function fetchBalance(
     if (typeof data !== 'object' || data === null) return null;
     const balance = (data as Record<string, unknown>).balance;
     return typeof balance === 'number' ? balance : 0;
+  } catch {
+    return null;
+  }
+}
+
+export interface PendingInvoice {
+  checkoutUrl: string;
+  bundleName: string;
+}
+
+/**
+ * Look up the caller's most recent pending invoice on a publisher wallet.
+ *
+ * Returns the latest pending invoice (newest first per gateway contract) so
+ * that the policy card can resume an in-flight checkout when the user
+ * revisits the page after closing the popup. Returns null when there is no
+ * pending invoice, the gateway response is malformed, or any error occurs.
+ */
+export async function fetchPendingInvoice(
+  invoicesUrl: string,
+  satelliteToken: string,
+  signal?: AbortSignal
+): Promise<PendingInvoice | null> {
+  try {
+    const url = new URL(invoicesUrl);
+    url.searchParams.set('status', 'pending');
+    const response = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${satelliteToken}` },
+      signal
+    });
+    if (!response.ok) return null;
+    const data: unknown = await response.json();
+    if (!Array.isArray(data) || data.length === 0) return null;
+    const first = data[0];
+    if (typeof first !== 'object' || first === null) return null;
+    const record = first as Record<string, unknown>;
+    const checkoutUrl = record.checkout_url ?? record.checkoutUrl;
+    const bundleName = record.bundle_name ?? record.bundleName;
+    if (typeof checkoutUrl !== 'string' || typeof bundleName !== 'string') return null;
+    return { checkoutUrl, bundleName };
   } catch {
     return null;
   }

--- a/components/frontend/src/lib/xendit-client.ts
+++ b/components/frontend/src/lib/xendit-client.ts
@@ -80,6 +80,11 @@ export function parseXenditConfig(config: Record<string, unknown>): ParsedXendit
   return { paymentUrl, creditsUrl, bundles, currency, pricePerRequest, country };
 }
 
+export function formatRequestEstimate(amount: number, pricePerRequest: number): string {
+  const requests = Math.floor(amount / pricePerRequest);
+  return `~${requests.toLocaleString()} requests`;
+}
+
 export function openCheckoutWindow(url: string): void {
   const width = 800;
   const height = 900;


### PR DESCRIPTION
## Summary

UI/copy polish for the Xendit prepaid credits flow ([OME-242](https://linear.app/openmined/issue/OME-242/last-minute-ui-updates-syft-space)):

- **Wallet dropdown** — show owner-only label (e.g. `junior`) instead of `owner/slug`; rename section header `Endpoint subscriptions` → `Endpoint credits`
- **Endpoint policy card** — rename `Xendit Bundle` → `Pay-in-advance via Xendit`; description now appends highlighted `(IDR 500 / request)`; add collapsible `ⓘ How does this work?` next to Version
- **Bundle picker** — show estimated request count `(~N requests)` next to each amount in trigger and dropdown items
- **Buy flow** — bundle picker + Buy button now render alongside the green `Active · IDR …` balance banner (previously hidden when active)
- **Backend** — auto-injected tag renamed from `subscription` → `prepaid` (`_inject_prepaid_tag`); tests updated

## Test plan
- [x] Wallet dropdown shows owner-only label and "Endpoint credits" header
- [x] Endpoint card with Xendit policy shows new label, price-per-request in description, "How does this work?" expands on click
- [x] Bundle picker dropdown shows `~N requests` per option
- [x] When wallet has active balance: green banner + bundle picker + Buy button all visible
- [x] Creating a Xendit-policy endpoint auto-tags it `prepaid` (not `subscription`)
- [ ] Existing endpoints with old `subscription` tag still display fine (no auto-migration)