### PR TITLE
feat(wallet): replace top-bar balance pill with wallet icon (OME-247)

### DIFF
--- a/components/frontend/src/components/__tests__/balance-indicator.test.tsx
+++ b/components/frontend/src/components/__tests__/balance-indicator.test.tsx
@@ -25,7 +25,7 @@ vi.mock('@/stores/settings-modal-store', () => ({
   useSettingsModalStore: () => ({ openSettings: mockOpenSettings })
 }));
 
-// Mock wallet balance hook
+// CreditsPanel internally uses useWalletBalance for the MPP wallet row.
 const { mockUseWalletBalance } = vi.hoisted(() => ({
   mockUseWalletBalance: vi.fn()
 }));
@@ -115,81 +115,42 @@ describe('BalanceIndicator', () => {
     expect(container.innerHTML).toBe('');
   });
 
-  it('shows "Set up wallet" pill when not configured', () => {
-    mockUseWalletContext.mockReturnValue({
-      isConfigured: false,
-      isLoading: false
-    });
-
+  it('renders an icon-only wallet trigger', () => {
     renderIndicator();
-    expect(screen.getByText('Set up wallet')).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: /wallet/i });
+    expect(button).toBeInTheDocument();
+    // No balance text on the trigger itself.
+    expect(screen.queryByText('500.00')).not.toBeInTheDocument();
   });
 
-  it('opens dropdown when "Set up wallet" pill is clicked', async () => {
-    mockUseWalletContext.mockReturnValue({
-      isConfigured: false,
-      isLoading: false
-    });
-
+  it('opens the credits panel when the wallet button is clicked', async () => {
     const user = userEvent.setup();
     renderIndicator();
 
-    await user.click(screen.getByText('Set up wallet'));
-    // Pill toggles dropdown; the actual settings link lives inside the panel.
-    expect(screen.getByText('Wallet settings')).toBeInTheDocument();
-  });
-
-  it('shows compact balance for healthy balance', () => {
-    renderIndicator();
-    expect(screen.getByText('500.00')).toBeInTheDocument();
-  });
-
-  it('shows balance with K suffix for large numbers', () => {
-    mockUseWalletBalance.mockReturnValue({
-      balance: {
-        balance: 15_000,
-        currency: 'credits',
-        recent_transactions: [],
-        wallet_configured: true
-      },
-      isLoading: false,
-      error: null,
-      refetch: mockRefetch
-    });
-
-    renderIndicator();
-    expect(screen.getByText('15.0K')).toBeInTheDocument();
-  });
-
-  it('shows "Error" text on the pill when there is an error', () => {
-    mockUseWalletBalance.mockReturnValue({
-      balance: null,
-      isLoading: false,
-      error: 'Network error',
-      refetch: mockRefetch
-    });
-
-    renderIndicator();
-    expect(screen.getByText('Error')).toBeInTheDocument();
-  });
-
-  it('opens dropdown on click and renders the credits panel', async () => {
-    const user = userEvent.setup();
-    renderIndicator();
-
-    await user.click(screen.getByRole('button', { name: /account balance/i }));
+    await user.click(screen.getByRole('button', { name: /wallet/i }));
 
     expect(screen.getByText('Tempo · pathUSD')).toBeInTheDocument();
-    // "Endpoint subscriptions" appears both as a section header and inside
-    // the empty-state copy, so just confirm at least one rendered.
-    expect(screen.getAllByText(/Endpoint subscriptions/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Endpoint credits/i).length).toBeGreaterThan(0);
+  });
+
+  it('opens the credits panel when not configured (set-up flow lives inside)', async () => {
+    mockUseWalletContext.mockReturnValue({
+      isConfigured: false,
+      isLoading: false
+    });
+
+    const user = userEvent.setup();
+    renderIndicator();
+
+    await user.click(screen.getByRole('button', { name: /wallet/i }));
+    expect(screen.getByText('Wallet settings')).toBeInTheDocument();
   });
 
   it('shows empty subscriptions message when no Xendit wallets are funded', async () => {
     const user = userEvent.setup();
     renderIndicator();
 
-    await user.click(screen.getByRole('button', { name: /account balance/i }));
+    await user.click(screen.getByRole('button', { name: /wallet/i }));
 
     expect(screen.getByText(/No endpoint subscriptions yet/i)).toBeInTheDocument();
   });
@@ -198,7 +159,7 @@ describe('BalanceIndicator', () => {
     const user = userEvent.setup();
     renderIndicator();
 
-    await user.click(screen.getByRole('button', { name: /account balance/i }));
+    await user.click(screen.getByRole('button', { name: /wallet/i }));
     await user.click(screen.getByText('Wallet settings'));
 
     expect(mockOpenSettings).toHaveBeenCalledWith('payment');
@@ -208,7 +169,7 @@ describe('BalanceIndicator', () => {
     const user = userEvent.setup();
     renderIndicator();
 
-    await user.click(screen.getByRole('button', { name: /account balance/i }));
+    await user.click(screen.getByRole('button', { name: /wallet/i }));
     await user.click(screen.getByText('Manage all'));
 
     expect(mockOpenSettings).toHaveBeenCalledWith('subscriptions');
@@ -218,7 +179,7 @@ describe('BalanceIndicator', () => {
     const user = userEvent.setup();
     renderIndicator();
 
-    await user.click(screen.getByRole('button', { name: /account balance/i }));
+    await user.click(screen.getByRole('button', { name: /wallet/i }));
     expect(screen.getByText('Tempo · pathUSD')).toBeInTheDocument();
 
     await user.keyboard('{Escape}');
@@ -228,7 +189,7 @@ describe('BalanceIndicator', () => {
   it('closes dropdown on click outside', async () => {
     renderIndicator();
 
-    fireEvent.click(screen.getByRole('button', { name: /account balance/i }));
+    fireEvent.click(screen.getByRole('button', { name: /wallet/i }));
     expect(screen.getByText('Tempo · pathUSD')).toBeInTheDocument();
 
     fireEvent.mouseDown(document.body);

--- a/components/frontend/src/components/balance/balance-indicator.tsx
+++ b/components/frontend/src/components/balance/balance-indicator.tsx
@@ -1,31 +1,21 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { AnimatePresence, motion } from 'framer-motion';
-import AlertCircle from 'lucide-react/dist/esm/icons/alert-circle';
-import ChevronDown from 'lucide-react/dist/esm/icons/chevron-down';
-import Coins from 'lucide-react/dist/esm/icons/coins';
-import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
+import Wallet from 'lucide-react/dist/esm/icons/wallet';
 
 import { OnboardingCallout } from '@/components/onboarding';
 import { useWalletContext } from '@/context/wallet-context';
-import { useWalletBalance } from '@/hooks/use-wallet-api';
 import { cn } from '@/lib/utils';
 import { useSettingsModalStore } from '@/stores/settings-modal-store';
 
-import {
-  formatBalanceCompact,
-  getBalanceStatus,
-  statusColors,
-  statusRingColors
-} from './balance-display';
 import { CreditsPanel } from './credits-panel';
 
 /**
- * BalanceIndicator — top-bar pill that opens the unified Credits Panel.
+ * BalanceIndicator — top-bar wallet icon that opens the unified Credits Panel.
  *
- * The pill itself stays focused on the MPP wallet balance (the universal
- * SyftHub wallet); endpoint subscriptions live inside the dropdown so the
- * nav stays visually quiet.
+ * The trigger is intentionally minimal (icon only). Showing a single number
+ * here was confusing for users who had just paid but whose balance was still
+ * settling — the per-wallet detail belongs inside the dropdown panel.
  */
 export function BalanceIndicator() {
   const [isOpen, setIsOpen] = useState(false);
@@ -33,7 +23,6 @@ export function BalanceIndicator() {
   const buttonReference = useRef<HTMLButtonElement>(null);
 
   const { isConfigured, isLoading: isLoadingWallet } = useWalletContext();
-  const { balance: walletBalance, isLoading: isLoadingBalance, error } = useWalletBalance();
   const { openSettings } = useSettingsModalStore();
 
   useEffect(() => {
@@ -88,90 +77,30 @@ export function BalanceIndicator() {
 
   if (isLoadingWallet) return null;
 
-  if (!isConfigured) {
-    return (
-      <OnboardingCallout step='balance' position='bottom'>
-        <div className='relative'>
-          <button
-            ref={buttonReference}
-            onClick={toggleOpen}
-            className={cn(
-              'font-inter flex items-center gap-2 rounded-lg border px-3 py-1.5 text-xs transition-colors',
-              'border-amber-200 bg-amber-50 text-amber-700',
-              'hover:border-amber-300 hover:bg-amber-100'
-            )}
-            aria-expanded={isOpen}
-            aria-haspopup='true'
-          >
-            <Coins className='h-3.5 w-3.5' aria-hidden='true' />
-            <span>Set up wallet</span>
-            <ChevronDown className={cn('h-3 w-3 transition-transform', isOpen && 'rotate-180')} />
-          </button>
-          <Dropdown
-            isOpen={isOpen}
-            dropdownReference={dropdownReference}
-            onClose={closePanel}
-            onOpenWalletSettings={handleOpenWalletSettings}
-            onOpenSubscriptionsSettings={handleOpenSubscriptionsSettings}
-          />
-        </div>
-      </OnboardingCallout>
-    );
-  }
-
-  const isLoading = isLoadingBalance;
-  const balance = walletBalance?.balance ?? 0;
-  const status = getBalanceStatus(balance);
-
-  const renderStatusIcon = () => {
-    if (isLoading) {
-      return <Loader2 className='text-muted-foreground h-3.5 w-3.5 animate-spin' />;
-    }
-    if (error) {
-      return <AlertCircle className='h-3.5 w-3.5 text-red-500' />;
-    }
-    return (
-      <div className='relative'>
-        <div
-          className={cn(
-            'h-2 w-2 rounded-full',
-            statusColors[status],
-            status === 'empty' && 'animate-pulse'
-          )}
-        />
-        <div
-          className={cn('absolute inset-0 h-2 w-2 rounded-full ring-2', statusRingColors[status])}
-        />
-      </div>
-    );
-  };
-
   return (
     <OnboardingCallout step='balance' position='bottom'>
       <div className='relative'>
         <button
           ref={buttonReference}
+          type='button'
           onClick={toggleOpen}
           className={cn(
-            'font-inter flex items-center gap-2 rounded-lg border px-3 py-1.5 text-sm transition-colors transition-shadow',
-            'border-border bg-muted',
-            'hover:border-input hover:shadow-sm',
+            'relative inline-flex h-9 w-9 items-center justify-center rounded-lg border transition-colors transition-shadow',
+            'border-border bg-muted text-muted-foreground',
+            'hover:border-input hover:text-foreground hover:shadow-sm',
             'focus:ring-ring/20 focus:ring-2 focus:outline-none'
           )}
-          aria-label={`Account balance: ${formatBalanceCompact(balance)}`}
+          aria-label='Wallet'
           aria-expanded={isOpen}
           aria-haspopup='true'
         >
-          {renderStatusIcon()}
-          <span className='text-foreground font-medium tabular-nums'>
-            {error ? 'Error' : formatBalanceCompact(balance)}
-          </span>
-          <ChevronDown
-            className={cn(
-              'text-muted-foreground h-3 w-3 transition-transform',
-              isOpen && 'rotate-180'
-            )}
-          />
+          <Wallet className='h-4 w-4' aria-hidden='true' />
+          {!isConfigured && (
+            <span
+              aria-hidden='true'
+              className='ring-background absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-amber-500 ring-2'
+            />
+          )}
         </button>
 
         <Dropdown


### PR DESCRIPTION
## Summary

Replace the top-bar balance pill with a minimal wallet-icon button ([OME-247](https://linear.app/openmined/issue/OME-247/update-balance-status-upper-right-screen-with-a-wallet-icon-so-its-not)).

Showing the MPP balance directly in the top bar was confusing for users whose payment was still settling — a "0 IDR" pill right after a successful purchase made it look like the funds were lost. The trigger is now icon-only; per-wallet balance and status detail live inside the dropdown panel.

- `balance-indicator`: icon-only 36×36 button; amber dot overlay when the wallet isn't yet configured; drops `useWalletBalance` from the trigger so the top bar no longer polls the balance endpoint
- Tests: query the trigger by `Wallet` label; update section-header expectation to `Endpoint credits` (already renamed in OME-242)

## Test plan
- [ ] Top-right shows a single wallet icon (not a balance pill)
- [ ] Click opens the Credits Panel as before
- [ ] When the wallet is unconfigured, an amber dot appears on the icon and the panel still opens with the "Set up" CTA
- [ ] Existing tests pass (`vitest run balance-indicator.test.tsx`)