### PR TITLE
chore(settings): rename Subscriptions tab to "Top up credits"

### DIFF
--- a/components/frontend/src/components/settings/settings-modal.tsx
+++ b/components/frontend/src/components/settings/settings-modal.tsx
@@ -47,7 +47,7 @@ const TABS: TabItem[] = [
   },
   {
     id: 'subscriptions',
-    label: 'Subscriptions',
+    label: 'Top up credits',
     icon: <CreditCard className='h-4 w-4' aria-hidden='true' />
   },
   {

--- a/components/frontend/src/components/settings/subscriptions-settings-tab.tsx
+++ b/components/frontend/src/components/settings/subscriptions-settings-tab.tsx
@@ -32,7 +32,7 @@ export function SubscriptionsSettingsTab() {
   return (
     <div className='space-y-4'>
       <div>
-        <h2 className='text-foreground text-lg font-semibold'>Endpoint subscriptions</h2>
+        <h2 className='text-foreground text-lg font-semibold'>Top up credits</h2>
         <p className='text-muted-foreground mt-1 text-sm'>
           Publisher-side wallets you've funded via Xendit. Balances are fetched live from each
           publisher.
@@ -105,9 +105,7 @@ function SubscriptionCard({ subscription }: Readonly<{ subscription: XenditSubsc
   });
 
   const liveBalance = balance ?? subscription.last_known_balance ?? 0;
-  const label = subscription.endpoint_slug
-    ? `${subscription.endpoint_owner}/${subscription.endpoint_slug}`
-    : subscription.endpoint_owner;
+  const label = subscription.endpoint_owner;
   const targetPath = subscription.endpoint_slug
     ? `/${subscription.endpoint_owner}/${subscription.endpoint_slug}`
     : `/${subscription.endpoint_owner}`;


### PR DESCRIPTION
## Summary

- Settings sidebar tab label: `Subscriptions` → `Top up credits`
- Tab page heading: `Endpoint subscriptions` → `Top up credits`
- Subscription card label: show only the publisher username (was `owner/slug`), matching the wallet dropdown behaviour from OME-242

## Test plan
- [ ] Open Settings → tab shows "Top up credits"
- [ ] Page heading on that tab also reads "Top up credits"
- [ ] Funded Xendit pools list publisher usernames only (no `/slug` suffix)