### PR TITLE
refactor(ui): redesign Xendit prepaid credits policy card

### DIFF
--- a/components/frontend/src/components/chat/payment-gate.tsx
+++ b/components/frontend/src/components/chat/payment-gate.tsx
@@ -64,7 +64,7 @@ function renderStatusLine(pending: PendingSubscription, isActive: boolean, liveB
     );
   }
   if (pending.pricePerRequest === null) {
-    return <>Pay-in-advance required</>;
+    return <>Prepaid credits required</>;
   }
   return (
     <span className='tabular-nums'>

--- a/components/frontend/src/components/endpoint/bundle-picker.tsx
+++ b/components/frontend/src/components/endpoint/bundle-picker.tsx
@@ -30,9 +30,14 @@ function RequestEstimate({
   pricePerRequest
 }: Readonly<{ amount: number; pricePerRequest: number }>) {
   return (
-    <span className='text-[10px] font-normal opacity-70'>
-      ({formatRequestEstimate(amount, pricePerRequest)})
-    </span>
+    <>
+      <span className='opacity-40' aria-hidden='true'>
+        ·
+      </span>
+      <span className='text-[11px] font-normal opacity-75'>
+        {formatRequestEstimate(amount, pricePerRequest)}
+      </span>
+    </>
   );
 }
 
@@ -54,16 +59,15 @@ export function BundlePicker({
     <Select value={value} onValueChange={onChange} disabled={disabled}>
       <SelectTrigger
         className={cn(
-          'h-8 text-xs transition-colors',
-          'border-violet-300 bg-violet-50 text-violet-700',
-          'hover:bg-violet-100 focus:ring-violet-400/40',
-          'dark:border-violet-700 dark:bg-violet-950/30 dark:text-violet-300',
-          'dark:hover:bg-violet-900/40 dark:focus:ring-violet-500/30',
+          'h-10 text-sm transition-colors',
+          'border-border bg-background text-foreground',
+          'hover:border-input hover:bg-muted/40',
+          'focus:ring-violet-400/40 dark:focus:ring-violet-500/30',
           triggerClassName
         )}
       >
         <SelectValue>
-          <span className='flex w-full items-center gap-1.5 pr-1'>
+          <span className='flex w-full items-center gap-2 pr-1'>
             <span className='font-medium tabular-nums'>
               {currency} {selected.amount.toLocaleString()}
             </span>
@@ -73,22 +77,10 @@ export function BundlePicker({
           </span>
         </SelectValue>
       </SelectTrigger>
-      <SelectContent
-        className={cn(
-          'border-violet-200 bg-violet-50/95 backdrop-blur-sm',
-          'dark:border-violet-800 dark:bg-violet-950/95'
-        )}
-      >
+      <SelectContent>
         {bundles.map((bundle) => (
-          <SelectItem
-            key={bundle.name}
-            value={bundle.name}
-            className={cn(
-              'text-xs text-violet-800 focus:bg-violet-100 focus:text-violet-900',
-              'dark:text-violet-200 dark:focus:bg-violet-900/50 dark:focus:text-violet-100'
-            )}
-          >
-            <span className='flex items-center gap-1.5'>
+          <SelectItem key={bundle.name} value={bundle.name} className='text-sm'>
+            <span className='flex items-center gap-2'>
               <span className='font-medium tabular-nums'>
                 {currency} {bundle.amount.toLocaleString()}
               </span>

--- a/components/frontend/src/components/endpoint/policy-item.tsx
+++ b/components/frontend/src/components/endpoint/policy-item.tsx
@@ -55,11 +55,11 @@ const POLICY_TYPE_CONFIG: Record<
   },
   xendit: {
     icon: CreditCard,
-    label: 'Pay-in-advance via Xendit',
+    label: 'Prepaid credits',
     color: 'text-violet-600 dark:text-violet-400',
     bgColor: 'bg-violet-50 dark:bg-violet-950/30',
     borderColor: 'border-violet-200 dark:border-violet-800',
-    description: 'Top up credits in advance to use this endpoint'
+    description: 'Top up credits to use this endpoint.'
   },
   // Access control policies
   public: {
@@ -195,6 +195,85 @@ export const PolicyItem = memo(function PolicyItem({
       ? xenditParsed.pricePerRequest
       : null;
 
+  if (isXendit) {
+    return (
+      <div
+        className={cn(
+          'group bg-card relative rounded-lg border transition-colors transition-shadow duration-200',
+          'border-border',
+          policy.enabled ? 'hover:shadow-md hover:shadow-black/5' : 'opacity-60 grayscale-[30%]'
+        )}
+      >
+        <div className='p-4'>
+          <div className='flex items-start gap-3'>
+            <div
+              className={cn(
+                'flex h-9 w-9 shrink-0 items-center justify-center rounded-lg',
+                config.bgColor,
+                'ring-1 ring-inset',
+                config.borderColor
+              )}
+            >
+              <Icon className={cn('h-4.5 w-4.5', config.color)} />
+            </div>
+
+            <div className='min-w-0 flex-1'>
+              <div className='flex items-start justify-between gap-2'>
+                <div className='min-w-0'>
+                  <h3 className='text-foreground text-sm leading-tight font-semibold'>
+                    {displayLabel}
+                  </h3>
+                  <p className='text-muted-foreground mt-0.5 text-[11px]'>via Xendit</p>
+                </div>
+                {policy.version ? (
+                  <span className='text-muted-foreground bg-muted/60 shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium tabular-nums'>
+                    v{policy.version}
+                  </span>
+                ) : null}
+              </div>
+
+              <div className='mt-1.5 flex items-center gap-1.5'>
+                <span
+                  aria-hidden='true'
+                  className={cn(
+                    'inline-block h-1.5 w-1.5 rounded-full',
+                    policy.enabled ? 'bg-emerald-500' : 'bg-muted-foreground/40'
+                  )}
+                />
+                <span
+                  className={cn(
+                    'text-[11px] font-medium',
+                    policy.enabled
+                      ? 'text-emerald-700 dark:text-emerald-400'
+                      : 'text-muted-foreground'
+                  )}
+                >
+                  {policy.enabled ? 'Active' : 'Disabled'}
+                </span>
+              </div>
+
+              {description && (
+                <p className='text-muted-foreground mt-2 text-xs leading-relaxed'>{description}</p>
+              )}
+              {xenditParsed && xenditPricePerRequest !== null && (
+                <p className='text-muted-foreground mt-0.5 text-[11px] tabular-nums'>
+                  {xenditParsed.currency} {xenditPricePerRequest.toLocaleString()} per request
+                </p>
+              )}
+
+              {Object.keys(policy.config).length > 0 &&
+                renderPolicyContent(policy, isTransaction, isXendit, endpointSlug, endpointOwner)}
+            </div>
+          </div>
+        </div>
+
+        <div className='border-border/60 border-t'>
+          <XenditHowItWorks />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div
       className={cn(
@@ -233,30 +312,17 @@ export const PolicyItem = memo(function PolicyItem({
               {policy.enabled ? 'Active' : 'Disabled'}
             </Badge>
           </div>
-          {description && (
-            <p className='text-muted-foreground mt-1 text-xs'>
-              {description}
-              {xenditParsed && xenditPricePerRequest !== null && (
-                <>
-                  {' '}
-                  <span className='font-semibold text-violet-700 tabular-nums dark:text-violet-300'>
-                    ({xenditParsed.currency} {xenditPricePerRequest.toLocaleString()} / request)
-                  </span>
-                </>
-              )}
-            </p>
-          )}
+          {description && <p className='text-muted-foreground mt-1 text-xs'>{description}</p>}
 
           {/* Policy-specific content */}
           {Object.keys(policy.config).length > 0 &&
             renderPolicyContent(policy, isTransaction, isXendit, endpointSlug, endpointOwner)}
 
-          <div className='mt-2 flex items-center gap-2'>
-            {policy.version ? (
+          {policy.version ? (
+            <div className='mt-2'>
               <p className='text-muted-foreground text-[10px]'>Version {policy.version}</p>
-            ) : null}
-            {isXendit && <XenditHowItWorks />}
-          </div>
+            </div>
+          ) : null}
         </div>
       </div>
     </div>
@@ -266,19 +332,25 @@ export const PolicyItem = memo(function PolicyItem({
 function XenditHowItWorks() {
   const [open, setOpen] = useState(false);
   return (
-    <Collapsible open={open} onOpenChange={setOpen} className='text-[10px]'>
+    <Collapsible open={open} onOpenChange={setOpen}>
       <CollapsibleTrigger
         className={cn(
-          'text-muted-foreground hover:text-foreground inline-flex cursor-pointer items-center gap-1',
+          'text-muted-foreground hover:text-foreground hover:bg-muted/40 flex w-full cursor-pointer items-center justify-between gap-2 rounded-b-lg px-4 py-2.5',
+          'focus-visible:bg-muted/40 focus-visible:text-foreground focus-visible:outline-none',
           'transition-colors select-none'
         )}
       >
-        <Info className='h-3 w-3' />
-        <span>How does this work?</span>
-        <ChevronDown className={cn('h-3 w-3 transition-transform', open && 'rotate-180')} />
+        <span className='inline-flex items-center gap-1.5 text-[11px] font-medium'>
+          <Info className='h-3 w-3' aria-hidden='true' />
+          How does this work?
+        </span>
+        <ChevronDown
+          className={cn('h-3.5 w-3.5 transition-transform', open && 'rotate-180')}
+          aria-hidden='true'
+        />
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <p className='text-muted-foreground mt-1.5 max-w-prose text-[11px] leading-relaxed'>
+        <p className='text-muted-foreground border-border/60 max-w-prose border-t px-4 py-3 text-[11px] leading-relaxed'>
           Purchase credits upfront with a data owner. Your balance is shared across all of their
           endpoints. Top up anytime — credits are deducted per request until your balance runs out.
         </p>

--- a/components/frontend/src/components/endpoint/xendit-policy-content.tsx
+++ b/components/frontend/src/components/endpoint/xendit-policy-content.tsx
@@ -244,22 +244,24 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
             disabled={!canPurchase || isCreatingAny}
             onClick={() => void handleSubscribe(selectedBundleName)}
             className={cn(
-              'group inline-flex h-8 w-full items-center justify-center gap-1.5 rounded-md text-xs font-medium transition-colors',
-              'border border-violet-300 bg-violet-50 text-violet-700 dark:border-violet-700 dark:bg-violet-950/30 dark:text-violet-300',
-              !canPurchase || isCreatingAny
-                ? 'cursor-not-allowed opacity-50'
-                : 'cursor-pointer hover:bg-violet-100 dark:hover:bg-violet-900/40'
+              'group inline-flex h-10 w-full items-center justify-center gap-1.5 rounded-md text-sm font-medium transition-colors',
+              'bg-violet-600 text-white shadow-sm',
+              'hover:bg-violet-500 active:bg-violet-700',
+              'focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-violet-400/50 focus-visible:ring-offset-2 focus-visible:outline-none',
+              'disabled:cursor-not-allowed disabled:bg-violet-600/40 disabled:shadow-none',
+              'dark:bg-violet-500 dark:hover:bg-violet-400 dark:active:bg-violet-600',
+              'dark:disabled:bg-violet-500/30'
             )}
           >
             {isCreatingAny ? (
               <>
-                <Loader2 className='h-3 w-3 animate-spin' />
+                <Loader2 className='h-3.5 w-3.5 animate-spin' />
                 Opening checkout…
               </>
             ) : (
               <>
-                Buy
-                <ArrowRight className='h-3 w-3 transition-transform group-hover:translate-x-0.5' />
+                Buy credits
+                <ArrowRight className='h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5' />
               </>
             )}
           </button>


### PR DESCRIPTION
## Summary

UI/UX audit pass on the Xendit policy card. The previous design had several affordance and hierarchy issues — the **Buy** button looked disabled, the amount dropdown read as two split controls, brand violet was applied to too many competing elements, and the footer mixed unrelated metadata with a disclosure trigger.

### Changes

- **Buy button** — solid violet fill (was tinted lavender), white label, 40px tall, proper hover/active/focus/disabled states. Now reads unambiguously as the primary CTA.
- **Amount picker** — neutral background so it doesn't compete with the CTA. Hint changes from `(~20 requests)` parentheses to a `· ~20 requests` middle-dot separator for a cleaner single-trigger feel.
- **Title** — renamed `Pay-in-advance via Xendit` → `Prepaid credits` (one line) with a small "via Xendit" attribution beneath. Xendit kept visible as payment-method credit.
- **Active status** — replaced the pill badge on the title baseline with a subtle `● Active` dot+label row so it stops fighting the title.
- **Description** — drops the publisher's "Regular price for {owner}" copy in favor of the canonical config description. Per-request price moved to its own muted secondary line instead of inline-violet emphasis.
- **Footer** — version moves to the top-right as a small `v1.0` tag. **How does this work?** becomes a full-width disclosure row separated by a top border, one clear affordance.
- **Brand color** — violet now reserved for the icon tile and the Buy button only (one emphasis target per card).
- Renamed chat payment-gate status string from "Pay-in-advance required" → "Prepaid credits required" to match.

## Test plan

- [ ] First-visit (no balance, no pending invoice) — Buy button is the primary CTA, dropdown shows amount + request estimate
- [ ] Active wallet — Active banner shows current balance, picker stays visible to allow further top-up
- [ ] Awaiting payment (pending invoice) — banner shows alongside picker, both Buy and Reopen checkout work
- [ ] Disabled policy — card renders muted/grayscale, Buy is disabled
- [ ] Light + dark mode — violet accent, neutral picker, and Active dot all read correctly
- [ ] Keyboard nav — Tab reaches picker → Buy → "How does this work?" with visible focus rings; Enter on the disclosure expands the body
- [ ] Screen reader — Active status announces; disclosure trigger announces expanded/collapsed state

🤖 Generated with [Claude Code](https://claude.com/claude-code)