### PR TITLE
feat(policies): filter endpoint policies by viewer's applied_to audience

### DIFF
--- a/components/backend/src/syfthub/repositories/endpoint.py
+++ b/components/backend/src/syfthub/repositories/endpoint.py
@@ -23,6 +23,7 @@ from syfthub.schemas.endpoint import (
     EndpointUpdate,
     EndpointVisibility,
     GroupedEndpointsResponse,
+    filter_visible_policies,
     get_matching_types,
 )
 
@@ -75,6 +76,9 @@ class EndpointRepository(BaseRepository[EndpointModel]):
         or SQLAlchemy Row) so it works for both regular and window-function queries.
         """
         transformed_connect = transform_connection_urls(domain, row.connect or [])
+        # Public response surfaces to anyone (including unauthenticated viewers),
+        # so only policies whose `applied_to` includes "*" (or is unset) are exposed.
+        visible_policies = filter_visible_policies(row.policies or [], None)
         return EndpointPublicResponse(
             name=row.name,
             slug=row.slug,
@@ -86,7 +90,7 @@ class EndpointRepository(BaseRepository[EndpointModel]):
             readme=row.readme,
             tags=row.tags or [],
             stars_count=row.stars_count,
-            policies=row.policies,
+            policies=visible_policies,
             connect=transformed_connect,
             created_at=row.created_at,
             updated_at=row.updated_at,

--- a/components/backend/src/syfthub/schemas/endpoint.py
+++ b/components/backend/src/syfthub/schemas/endpoint.py
@@ -74,6 +74,43 @@ class Policy(BaseModel):
     )
 
 
+def filter_visible_policies(
+    policies: List[Any], viewer_email: Optional[str]
+) -> List[Any]:
+    """Filter policies by their `config.applied_to` audience list.
+
+    Rules:
+    - Missing/empty `applied_to` is treated as `["*"]` (visible to everyone).
+    - `"*"` in `applied_to` is visible to everyone (including anonymous).
+    - Otherwise visible only when `viewer_email` (case-insensitive) is listed.
+    - When `viewer_email` is None, only wildcard policies are visible.
+
+    Accepts policies as Pydantic Policy instances or plain dicts.
+    """
+    normalized_viewer = viewer_email.strip().lower() if viewer_email else None
+
+    def _is_visible(policy: Any) -> bool:
+        if isinstance(policy, BaseModel):
+            config = getattr(policy, "config", None) or {}
+        else:
+            config = policy.get("config") or {} if isinstance(policy, dict) else {}
+
+        applied_to = config.get("applied_to") if isinstance(config, dict) else None
+        if not applied_to:
+            return True
+
+        for entry in applied_to:
+            if not isinstance(entry, str):
+                continue
+            if entry.strip() == "*":
+                return True
+            if normalized_viewer and entry.strip().lower() == normalized_viewer:
+                return True
+        return False
+
+    return [p for p in policies if _is_visible(p)]
+
+
 class Connection(BaseModel):
     """Connection configuration for endpoints.
 

--- a/components/backend/src/syfthub/services/endpoint_service.py
+++ b/components/backend/src/syfthub/services/endpoint_service.py
@@ -35,6 +35,7 @@ from syfthub.schemas.endpoint import (
     Policy,
     SyncEndpointsResponse,
     SyncValidationError,
+    filter_visible_policies,
     generate_slug_from_name,
     get_matching_types,
 )
@@ -74,7 +75,10 @@ class EndpointService(BaseService):
         return None
 
     def _to_response_with_urls(
-        self, endpoint: Endpoint, owner_domain: Optional[str] = None
+        self,
+        endpoint: Endpoint,
+        owner_domain: Optional[str] = None,
+        current_user: Optional[User] = None,
     ) -> EndpointResponse:
         """Convert Endpoint to EndpointResponse with transformed URLs.
 
@@ -82,6 +86,8 @@ class EndpointService(BaseService):
             endpoint: The endpoint model to convert.
             owner_domain: Pre-fetched owner domain. When provided, skips the
                 per-endpoint DB lookup (use in listing methods to avoid N+1).
+            current_user: The authenticated viewer. Used to filter policies
+                whose `config.applied_to` does not include the viewer.
         """
         domain = (
             owner_domain
@@ -95,9 +101,13 @@ class EndpointService(BaseService):
             [c.model_dump() for c in endpoint.connect] if endpoint.connect else [],
         )
 
-        # Create response with transformed connections
+        viewer_email = current_user.email if current_user else None
+
         endpoint_dict = endpoint.model_dump()
         endpoint_dict["connect"] = transformed_connect
+        endpoint_dict["policies"] = filter_visible_policies(
+            endpoint_dict.get("policies") or [], viewer_email
+        )
         return EndpointResponse.model_validate(endpoint_dict)
 
     def _is_slug_available(
@@ -283,7 +293,7 @@ class EndpointService(BaseService):
         if endpoint.visibility == EndpointVisibility.PUBLIC:
             self._ingest_to_rag(endpoint.id)
 
-        return self._to_response_with_urls(endpoint)
+        return self._to_response_with_urls(endpoint, current_user=current_user)
 
     def get_endpoint_by_user_and_slug(
         self, user_id: int, slug: str
@@ -324,7 +334,11 @@ class EndpointService(BaseService):
         for endpoint in endpoints:
             if self._can_access_endpoint(endpoint, current_user, "user"):
                 accessible_endpoints.append(
-                    self._to_response_with_urls(endpoint, owner_domain=user_domain)
+                    self._to_response_with_urls(
+                        endpoint,
+                        owner_domain=user_domain,
+                        current_user=current_user,
+                    )
                 )
 
         return accessible_endpoints
@@ -350,7 +364,11 @@ class EndpointService(BaseService):
         for endpoint in endpoints:
             if self._can_access_endpoint(endpoint, current_user, "organization"):
                 accessible_endpoints.append(
-                    self._to_response_with_urls(endpoint, owner_domain=org_domain)
+                    self._to_response_with_urls(
+                        endpoint,
+                        owner_domain=org_domain,
+                        current_user=current_user,
+                    )
                 )
 
         return accessible_endpoints
@@ -418,7 +436,7 @@ class EndpointService(BaseService):
             endpoint.id, old_visibility, new_visibility
         )
 
-        return self._to_response_with_urls(updated_endpoint)
+        return self._to_response_with_urls(updated_endpoint, current_user=current_user)
 
     def update_endpoint(
         self, endpoint_id: int, endpoint_data: EndpointUpdate, current_user: User
@@ -488,7 +506,7 @@ class EndpointService(BaseService):
                 detail="Failed to update endpoint",
             )
 
-        return self._to_response_with_urls(updated_endpoint)
+        return self._to_response_with_urls(updated_endpoint, current_user=current_user)
 
     # Router-compatible methods
     def list_user_endpoints(
@@ -867,7 +885,7 @@ class EndpointService(BaseService):
                 detail="Endpoint not found",
             )
 
-        return self._to_response_with_urls(endpoint)
+        return self._to_response_with_urls(endpoint, current_user=current_user)
 
     def delete_endpoint(self, endpoint_id: int, current_user: User) -> bool:
         """Delete endpoint."""
@@ -1273,7 +1291,9 @@ class EndpointService(BaseService):
             user = self.user_repository.get_by_id(current_user.id)
             user_domain = user.domain if user else None
             response_endpoints = [
-                self._to_response_with_urls(ep, owner_domain=user_domain)
+                self._to_response_with_urls(
+                    ep, owner_domain=user_domain, current_user=current_user
+                )
                 for ep in created_endpoints
             ]
 

--- a/components/backend/tests/test_schemas/test_policy_filter.py
+++ b/components/backend/tests/test_schemas/test_policy_filter.py
@@ -1,0 +1,72 @@
+"""Tests for filter_visible_policies."""
+
+from syfthub.schemas.endpoint import Policy, filter_visible_policies
+
+
+def _xendit_policy(applied_to=None, description="p"):
+    config = {"price_per_request": 1.0}
+    if applied_to is not None:
+        config["applied_to"] = applied_to
+    return Policy(type="xendit", description=description, config=config)
+
+
+class TestFilterVisiblePolicies:
+    def test_missing_applied_to_visible_to_everyone(self):
+        p = _xendit_policy(applied_to=None)
+        assert filter_visible_policies([p], "user@example.com") == [p]
+        assert filter_visible_policies([p], None) == [p]
+
+    def test_empty_applied_to_visible_to_everyone(self):
+        p = _xendit_policy(applied_to=[])
+        assert filter_visible_policies([p], "user@example.com") == [p]
+        assert filter_visible_policies([p], None) == [p]
+
+    def test_wildcard_visible_to_everyone(self):
+        p = _xendit_policy(applied_to=["*"])
+        assert filter_visible_policies([p], "user@example.com") == [p]
+        assert filter_visible_policies([p], None) == [p]
+
+    def test_email_match_visible(self):
+        p = _xendit_policy(applied_to=["alice@example.com", "bob@example.com"])
+        assert filter_visible_policies([p], "alice@example.com") == [p]
+
+    def test_email_match_is_case_insensitive(self):
+        p = _xendit_policy(applied_to=["Alice@Example.com"])
+        assert filter_visible_policies([p], "ALICE@example.COM") == [p]
+
+    def test_no_match_filtered_out(self):
+        p = _xendit_policy(applied_to=["alice@example.com"])
+        assert filter_visible_policies([p], "carol@example.com") == []
+
+    def test_anonymous_viewer_filters_personalized(self):
+        p = _xendit_policy(applied_to=["alice@example.com"])
+        assert filter_visible_policies([p], None) == []
+
+    def test_mixed_list_returns_only_visible(self):
+        wildcard = _xendit_policy(applied_to=["*"], description="all")
+        targeted = _xendit_policy(applied_to=["alice@example.com"], description="alice")
+        other = _xendit_policy(applied_to=["bob@example.com"], description="bob")
+        result = filter_visible_policies(
+            [wildcard, targeted, other], "alice@example.com"
+        )
+        assert result == [wildcard, targeted]
+
+    def test_accepts_dict_policies(self):
+        wildcard = {"type": "xendit", "config": {"applied_to": ["*"]}}
+        targeted = {
+            "type": "xendit",
+            "config": {"applied_to": ["alice@example.com"]},
+        }
+        other = {
+            "type": "xendit",
+            "config": {"applied_to": ["bob@example.com"]},
+        }
+        result = filter_visible_policies(
+            [wildcard, targeted, other], "alice@example.com"
+        )
+        assert result == [wildcard, targeted]
+
+    def test_non_string_applied_to_entries_ignored(self):
+        p = _xendit_policy(applied_to=[None, 42, "alice@example.com"])
+        assert filter_visible_policies([p], "alice@example.com") == [p]
+        assert filter_visible_policies([p], "bob@example.com") == []


### PR DESCRIPTION
## Summary
- Each policy's `config.applied_to` now controls visibility: missing/empty or `"*"` → everyone; otherwise only viewers whose email is listed (case-insensitive) see it.
- Anonymous viewers (public/browse/search responses) only see wildcard policies, preventing leakage of other users' targeted-policy emails through public listings.
- Filter is applied at two seams: `EndpointService._to_response_with_urls` (authenticated paths, threading `current_user`) and `EndpointRepository._build_public_response` (public/search paths, anonymous).

## Notes
- No owner exemption — owners viewing their own endpoint via the regular GET only see policies that include their email or `"*"`. If owners need to manage policies targeted at others, a separate raw-policies endpoint will need to be added.

## Test plan
- [x] New unit tests in `tests/test_schemas/test_policy_filter.py` (10 cases: wildcard, missing/empty applied_to, case-insensitive email match, no match, anonymous viewer, mixed lists, dict-shaped policies, non-string entries)
- [x] Existing endpoint-service tests pass (74)
- [x] Existing endpoint API + schema tests pass (118)