### PR TITLE
refactor(ui): move Access Policies card under README

### DIFF
--- a/components/frontend/src/components/endpoint/endpoint-detail.tsx
+++ b/components/frontend/src/components/endpoint/endpoint-detail.tsx
@@ -324,6 +324,13 @@ export const EndpointDetail = memo(function EndpointDetail({
                 )}
               </div>
             </article>
+
+            {/* Access Policies Card */}
+            <AccessPoliciesCard
+              policies={endpoint.policies}
+              endpointSlug={endpoint.full_path ?? endpoint.slug}
+              endpointOwner={endpoint.owner_username}
+            />
           </main>
 
           {/* Sidebar */}
@@ -386,13 +393,6 @@ export const EndpointDetail = memo(function EndpointDetail({
                 endpointSlug={endpoint.full_path}
               />
             ) : null}
-
-            {/* Access Policies Card */}
-            <AccessPoliciesCard
-              policies={endpoint.policies}
-              endpointSlug={endpoint.full_path ?? endpoint.slug}
-              endpointOwner={endpoint.owner_username}
-            />
           </aside>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Moves the Access Policies card out of the right sidebar and renders it directly below the README in the main content column. Policy details (Xendit prepaid card, transaction pricing, access rules) get the same visual weight as the documentation instead of being tucked into the narrower side rail.

The sidebar keeps the About card and the Connections card.

## Test plan

- [ ] Endpoint detail page: README renders, then Access Policies card directly beneath in the main column
- [ ] Sidebar shows About and (when present) Connections — no policy block
- [ ] Mobile / narrow viewport: stacking order remains README → Policies → Sidebar cards
- [ ] Endpoint without policies: no empty space artifact under README
