### PR TITLE
fix(policies): targeted applied_to overrides wildcard for listed viewer

### DIFF
--- a/components/backend/src/syfthub/schemas/endpoint.py
+++ b/components/backend/src/syfthub/schemas/endpoint.py
@@ -79,36 +79,55 @@ def filter_visible_policies(
 ) -> List[Any]:
     """Filter policies by their `config.applied_to` audience list.
 
-    Rules:
-    - Missing/empty `applied_to` is treated as `["*"]` (visible to everyone).
-    - `"*"` in `applied_to` is visible to everyone (including anonymous).
-    - Otherwise visible only when `viewer_email` (case-insensitive) is listed.
-    - When `viewer_email` is None, only wildcard policies are visible.
+    Specific targeting overrides the wildcard: if any policy explicitly
+    names the viewer's email, only those targeted policies are returned
+    (the wildcard fallback is suppressed for that viewer). Otherwise
+    the viewer falls back to wildcard / unset-`applied_to` policies.
+
+    `applied_to` semantics per policy:
+    - Missing/empty `applied_to` is treated as `["*"]` (wildcard fallback).
+    - `"*"` in `applied_to` makes the policy a wildcard fallback.
+    - Otherwise the policy is "targeted" and applies only to listed emails
+      (case-insensitive).
+    - An anonymous viewer (`viewer_email=None`) only ever sees wildcards.
 
     Accepts policies as Pydantic Policy instances or plain dicts.
     """
     normalized_viewer = viewer_email.strip().lower() if viewer_email else None
 
-    def _is_visible(policy: Any) -> bool:
+    def _applied_to(policy: Any) -> Optional[List[Any]]:
         if isinstance(policy, BaseModel):
             config = getattr(policy, "config", None) or {}
+        elif isinstance(policy, dict):
+            config = policy.get("config") or {}
         else:
-            config = policy.get("config") or {} if isinstance(policy, dict) else {}
-
+            config = {}
         applied_to = config.get("applied_to") if isinstance(config, dict) else None
-        if not applied_to:
-            return True
+        return applied_to if applied_to else None
 
+    def _is_wildcard(policy: Any) -> bool:
+        applied_to = _applied_to(policy)
+        if applied_to is None:
+            return True
+        return any(isinstance(e, str) and e.strip() == "*" for e in applied_to)
+
+    def _targets_viewer(policy: Any) -> bool:
+        if not normalized_viewer:
+            return False
+        applied_to = _applied_to(policy)
+        if applied_to is None:
+            return False
         for entry in applied_to:
             if not isinstance(entry, str):
                 continue
-            if entry.strip() == "*":
-                return True
-            if normalized_viewer and entry.strip().lower() == normalized_viewer:
+            if entry.strip().lower() == normalized_viewer:
                 return True
         return False
 
-    return [p for p in policies if _is_visible(p)]
+    targeted = [p for p in policies if _targets_viewer(p)]
+    if targeted:
+        return targeted
+    return [p for p in policies if _is_wildcard(p)]
 
 
 class Connection(BaseModel):

--- a/components/backend/tests/test_schemas/test_policy_filter.py
+++ b/components/backend/tests/test_schemas/test_policy_filter.py
@@ -42,14 +42,31 @@ class TestFilterVisiblePolicies:
         p = _xendit_policy(applied_to=["alice@example.com"])
         assert filter_visible_policies([p], None) == []
 
-    def test_mixed_list_returns_only_visible(self):
+    def test_targeted_policy_overrides_wildcard_for_listed_user(self):
         wildcard = _xendit_policy(applied_to=["*"], description="all")
         targeted = _xendit_policy(applied_to=["alice@example.com"], description="alice")
         other = _xendit_policy(applied_to=["bob@example.com"], description="bob")
         result = filter_visible_policies(
             [wildcard, targeted, other], "alice@example.com"
         )
-        assert result == [wildcard, targeted]
+        assert result == [targeted]
+
+    def test_unlisted_user_falls_back_to_wildcard(self):
+        wildcard = _xendit_policy(applied_to=["*"], description="all")
+        targeted = _xendit_policy(applied_to=["alice@example.com"], description="alice")
+        other = _xendit_policy(applied_to=["bob@example.com"], description="bob")
+        result = filter_visible_policies(
+            [wildcard, targeted, other], "carol@example.com"
+        )
+        assert result == [wildcard]
+
+    def test_unset_applied_to_acts_as_wildcard_fallback(self):
+        unset = _xendit_policy(applied_to=None, description="default")
+        targeted = _xendit_policy(applied_to=["alice@example.com"], description="alice")
+        result_alice = filter_visible_policies([unset, targeted], "alice@example.com")
+        assert result_alice == [targeted]
+        result_carol = filter_visible_policies([unset, targeted], "carol@example.com")
+        assert result_carol == [unset]
 
     def test_accepts_dict_policies(self):
         wildcard = {"type": "xendit", "config": {"applied_to": ["*"]}}
@@ -64,7 +81,7 @@ class TestFilterVisiblePolicies:
         result = filter_visible_policies(
             [wildcard, targeted, other], "alice@example.com"
         )
-        assert result == [wildcard, targeted]
+        assert result == [targeted]
 
     def test_non_string_applied_to_entries_ignored(self):
         p = _xendit_policy(applied_to=[None, 42, "alice@example.com"])


### PR DESCRIPTION
## Summary
- Bug: viewers listed in a targeted policy were also seeing the wildcard fallback. On `irinamb7/test-diff-pricing`, `ionesio@openmined.org` and `tauquir@openmined.org` saw both the 100 IDR personalized policy and the 200 IDR all-users policy.
- Fix: change `filter_visible_policies` from a union rule to a precedence rule — if any policy explicitly names the viewer's email, only those targeted policies are returned and the wildcard fallback is suppressed for that viewer.
- Unlisted viewers still fall back to wildcard / unset-`applied_to` policies. Anonymous viewers still see wildcards only.

## Test plan
- [x] Updated `tests/test_schemas/test_policy_filter.py` (12 cases) — green
- [x] `tests/test_endpoints.py` + `tests/test_services/test_endpoint_service.py` — 152 passed
- [ ] Manual: log in as `ionesio@openmined.org` and confirm `test-diff-pricing` shows only the 100 IDR personalized policy; log in as a non-listed user and confirm only the 200 IDR all-users policy is shown
