### PR TITLE
fix(policies): personalize public endpoint responses by viewer

### DIFF
--- a/components/backend/src/syfthub/api/endpoints/endpoints.py
+++ b/components/backend/src/syfthub/api/endpoints/endpoints.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, Query, status
 
 from syfthub.auth.db_dependencies import (
     get_current_active_user,
+    get_optional_current_user,
     require_admin,
 )
 from syfthub.database.dependencies import (
@@ -77,6 +78,7 @@ async def list_my_endpoints(
 @router.get("/public", response_model=list[EndpointPublicResponse])
 async def list_public_endpoints(
     endpoint_service: Annotated[EndpointService, Depends(get_endpoint_service)],
+    current_user: Annotated[Optional[User], Depends(get_optional_current_user)],
     skip: int = Query(0, ge=0),
     limit: int = Query(10, ge=1, le=100),
     endpoint_type: Optional[EndpointType] = Query(
@@ -91,7 +93,11 @@ async def list_public_endpoints(
 ) -> list[EndpointPublicResponse]:
     """List all public endpoints with optional search filtering."""
     return endpoint_service.list_public_endpoints(
-        skip=skip, limit=limit, endpoint_type=endpoint_type, search=search
+        skip=skip,
+        limit=limit,
+        endpoint_type=endpoint_type,
+        search=search,
+        current_user=current_user,
     )
 
 
@@ -124,6 +130,7 @@ Returns a list of groups, where each group contains:
 )
 async def list_public_endpoints_grouped(
     endpoint_service: Annotated[EndpointService, Depends(get_endpoint_service)],
+    current_user: Annotated[Optional[User], Depends(get_optional_current_user)],
     max_per_owner: int = Query(
         15, ge=1, le=50, description="Maximum endpoints to return per owner"
     ),
@@ -133,7 +140,9 @@ async def list_public_endpoints_grouped(
     This provides a balanced view across multiple owners rather than having
     a single owner dominate the listing.
     """
-    return endpoint_service.list_public_endpoints_grouped(max_per_owner=max_per_owner)
+    return endpoint_service.list_public_endpoints_grouped(
+        max_per_owner=max_per_owner, current_user=current_user
+    )
 
 
 @router.get(
@@ -210,6 +219,7 @@ Returns a list of EndpointPublicResponse objects containing:
 async def list_public_endpoints_by_owner(
     owner_slug: str,
     endpoint_service: Annotated[EndpointService, Depends(get_endpoint_service)],
+    current_user: Annotated[Optional[User], Depends(get_optional_current_user)],
     skip: int = Query(0, ge=0, description="Number of endpoints to skip"),
     limit: int = Query(100, ge=1, le=500, description="Maximum endpoints to return"),
 ) -> list[EndpointPublicResponse]:
@@ -218,7 +228,7 @@ async def list_public_endpoints_by_owner(
     Returns all public, active endpoints belonging to the given user or organization.
     """
     return endpoint_service.list_public_endpoints_by_owner(
-        owner_slug=owner_slug, skip=skip, limit=limit
+        owner_slug=owner_slug, skip=skip, limit=limit, current_user=current_user
     )
 
 
@@ -240,14 +250,18 @@ async def get_public_endpoint_by_path(
     owner_username: str,
     slug: str,
     endpoint_service: Annotated[EndpointService, Depends(get_endpoint_service)],
+    current_user: Annotated[Optional[User], Depends(get_optional_current_user)],
 ) -> EndpointPublicResponse:
     """Get a single public endpoint by owner username and slug."""
-    return endpoint_service.get_public_endpoint_by_path(owner_username, slug)
+    return endpoint_service.get_public_endpoint_by_path(
+        owner_username, slug, current_user=current_user
+    )
 
 
 @router.get("/trending", response_model=list[EndpointPublicResponse])
 async def list_trending_endpoints(
     endpoint_service: Annotated[EndpointService, Depends(get_endpoint_service)],
+    current_user: Annotated[Optional[User], Depends(get_optional_current_user)],
     skip: int = Query(0, ge=0),
     limit: int = Query(10, ge=1, le=100),
     min_stars: Optional[int] = Query(None, ge=0),
@@ -257,7 +271,11 @@ async def list_trending_endpoints(
 ) -> list[EndpointPublicResponse]:
     """List trending public endpoints."""
     return endpoint_service.list_trending_endpoints(
-        skip=skip, limit=limit, min_stars=min_stars, endpoint_type=endpoint_type
+        skip=skip,
+        limit=limit,
+        min_stars=min_stars,
+        endpoint_type=endpoint_type,
+        current_user=current_user,
     )
 
 
@@ -289,6 +307,7 @@ endpoints they can actually use without additional authorization.
 )
 async def list_guest_accessible_endpoints(
     endpoint_service: Annotated[EndpointService, Depends(get_endpoint_service)],
+    current_user: Annotated[Optional[User], Depends(get_optional_current_user)],
     skip: int = Query(0, ge=0),
     limit: int = Query(10, ge=1, le=100),
     endpoint_type: Optional[EndpointType] = Query(
@@ -301,7 +320,10 @@ async def list_guest_accessible_endpoints(
     This ensures guests can only discover and use truly free endpoints.
     """
     return endpoint_service.list_guest_accessible_endpoints(
-        skip=skip, limit=limit, endpoint_type=endpoint_type
+        skip=skip,
+        limit=limit,
+        endpoint_type=endpoint_type,
+        current_user=current_user,
     )
 
 
@@ -331,12 +353,14 @@ relevance.
 async def search_endpoints(
     search_request: EndpointSearchRequest,
     endpoint_service: Annotated[EndpointService, Depends(get_endpoint_service)],
+    current_user: Annotated[Optional[User], Depends(get_optional_current_user)],
 ) -> EndpointSearchResponse:
     """Search endpoints using semantic search (RAG)."""
     return endpoint_service.search_endpoints(
         query=search_request.query,
         top_k=search_request.top_k,
         endpoint_type=search_request.type,
+        current_user=current_user,
     )
 
 

--- a/components/backend/src/syfthub/repositories/endpoint.py
+++ b/components/backend/src/syfthub/repositories/endpoint.py
@@ -77,11 +77,6 @@ class EndpointRepository(BaseRepository[EndpointModel]):
 
         Accepts any object with the EndpointModel attribute names (ORM instance
         or SQLAlchemy Row) so it works for both regular and window-function queries.
-
-        `viewer_email` is used to apply the per-viewer policy `applied_to`
-        filter — anonymous callers (None) only see wildcard policies; authenticated
-        callers see policies targeted at them (with targeted policies overriding
-        the wildcard fallback for that viewer).
         """
         transformed_connect = transform_connection_urls(domain, row.connect or [])
         visible_policies = filter_visible_policies(row.policies or [], viewer_email)

--- a/components/backend/src/syfthub/repositories/endpoint.py
+++ b/components/backend/src/syfthub/repositories/endpoint.py
@@ -68,17 +68,23 @@ class EndpointRepository(BaseRepository[EndpointModel]):
 
     @staticmethod
     def _build_public_response(
-        row: Any, owner_username: str, domain: Optional[str]
+        row: Any,
+        owner_username: str,
+        domain: Optional[str],
+        viewer_email: Optional[str] = None,
     ) -> EndpointPublicResponse:
         """Build an EndpointPublicResponse from a query row and owner context.
 
         Accepts any object with the EndpointModel attribute names (ORM instance
         or SQLAlchemy Row) so it works for both regular and window-function queries.
+
+        `viewer_email` is used to apply the per-viewer policy `applied_to`
+        filter — anonymous callers (None) only see wildcard policies; authenticated
+        callers see policies targeted at them (with targeted policies overriding
+        the wildcard fallback for that viewer).
         """
         transformed_connect = transform_connection_urls(domain, row.connect or [])
-        # Public response surfaces to anyone (including unauthenticated viewers),
-        # so only policies whose `applied_to` includes "*" (or is unset) are exposed.
-        visible_policies = filter_visible_policies(row.policies or [], None)
+        visible_policies = filter_visible_policies(row.policies or [], viewer_email)
         return EndpointPublicResponse(
             name=row.name,
             slug=row.slug,
@@ -220,6 +226,7 @@ class EndpointRepository(BaseRepository[EndpointModel]):
         limit: int = 10,
         endpoint_type: Optional[EndpointType] = None,
         search: Optional[str] = None,
+        viewer_email: Optional[str] = None,
     ) -> List[EndpointPublicResponse]:
         """Get all public endpoints with owner usernames and transformed URLs.
 
@@ -270,7 +277,9 @@ class EndpointRepository(BaseRepository[EndpointModel]):
             endpoints = []
             for endpoint_model, username, domain in rows:
                 endpoints.append(
-                    self._build_public_response(endpoint_model, username, domain)
+                    self._build_public_response(
+                        endpoint_model, username, domain, viewer_email
+                    )
                 )
 
             return endpoints
@@ -283,6 +292,7 @@ class EndpointRepository(BaseRepository[EndpointModel]):
         owner_slug: str,
         skip: int = 0,
         limit: int = 100,
+        viewer_email: Optional[str] = None,
     ) -> List[EndpointPublicResponse]:
         """Get all public endpoints for a specific owner.
 
@@ -319,7 +329,9 @@ class EndpointRepository(BaseRepository[EndpointModel]):
             endpoints = []
             for endpoint_model, username, domain in rows:
                 endpoints.append(
-                    self._build_public_response(endpoint_model, username, domain)
+                    self._build_public_response(
+                        endpoint_model, username, domain, viewer_email
+                    )
                 )
 
             return endpoints
@@ -328,7 +340,10 @@ class EndpointRepository(BaseRepository[EndpointModel]):
             return []
 
     def get_public_endpoint_by_owner_and_slug(
-        self, owner_username: str, slug: str
+        self,
+        owner_username: str,
+        slug: str,
+        viewer_email: Optional[str] = None,
     ) -> Optional[EndpointPublicResponse]:
         """Get a single public endpoint by owner username and slug.
 
@@ -368,7 +383,9 @@ class EndpointRepository(BaseRepository[EndpointModel]):
 
             endpoint_model, _username, domain = row
 
-            return self._build_public_response(endpoint_model, owner_username, domain)
+            return self._build_public_response(
+                endpoint_model, owner_username, domain, viewer_email
+            )
         except SQLAlchemyError as e:
             logger.error(
                 "Failed to query public endpoint %s/%s: %s",
@@ -381,6 +398,7 @@ class EndpointRepository(BaseRepository[EndpointModel]):
     def get_public_endpoints_by_ids(
         self,
         endpoint_ids: List[int],
+        viewer_email: Optional[str] = None,
     ) -> List[EndpointPublicResponse]:
         """Get public endpoints by IDs with owner usernames and transformed URLs.
 
@@ -415,7 +433,7 @@ class EndpointRepository(BaseRepository[EndpointModel]):
             id_to_endpoint: dict[int, EndpointPublicResponse] = {}
             for endpoint_model, username, domain in rows:
                 id_to_endpoint[endpoint_model.id] = self._build_public_response(
-                    endpoint_model, username, domain
+                    endpoint_model, username, domain, viewer_email
                 )
 
             # Return in the original order (preserves RAG ranking)
@@ -432,6 +450,7 @@ class EndpointRepository(BaseRepository[EndpointModel]):
         skip: int = 0,
         limit: int = 10,
         endpoint_type: Optional[EndpointType] = None,
+        viewer_email: Optional[str] = None,
     ) -> List[EndpointPublicResponse]:
         """Get all public endpoints that have no policies attached (guest-accessible).
 
@@ -472,7 +491,9 @@ class EndpointRepository(BaseRepository[EndpointModel]):
             endpoints = []
             for endpoint_model, username, domain in rows:
                 endpoints.append(
-                    self._build_public_response(endpoint_model, username, domain)
+                    self._build_public_response(
+                        endpoint_model, username, domain, viewer_email
+                    )
                 )
 
             return endpoints
@@ -485,6 +506,7 @@ class EndpointRepository(BaseRepository[EndpointModel]):
         limit: int = 10,
         min_stars: Optional[int] = None,
         endpoint_type: Optional[EndpointType] = None,
+        viewer_email: Optional[str] = None,
     ) -> List[EndpointPublicResponse]:
         """Get trending public endpoints with owner usernames and transformed URLs, sorted by stars count.
 
@@ -515,7 +537,9 @@ class EndpointRepository(BaseRepository[EndpointModel]):
             endpoints = []
             for endpoint_model, username, domain in rows:
                 endpoints.append(
-                    self._build_public_response(endpoint_model, username, domain)
+                    self._build_public_response(
+                        endpoint_model, username, domain, viewer_email
+                    )
                 )
 
             return endpoints
@@ -525,6 +549,7 @@ class EndpointRepository(BaseRepository[EndpointModel]):
     def get_public_endpoints_grouped(
         self,
         max_per_owner: int = 15,
+        viewer_email: Optional[str] = None,
     ) -> GroupedEndpointsResponse:
         """Get public endpoints grouped by owner with a limit per owner.
 
@@ -615,7 +640,7 @@ class EndpointRepository(BaseRepository[EndpointModel]):
                     }
 
                 owner_groups[username]["endpoints"].append(
-                    self._build_public_response(row, username, domain)
+                    self._build_public_response(row, username, domain, viewer_email)
                 )
 
             # Build the response groups

--- a/components/backend/src/syfthub/schemas/endpoint.py
+++ b/components/backend/src/syfthub/schemas/endpoint.py
@@ -105,29 +105,29 @@ def filter_visible_policies(
         applied_to = config.get("applied_to") if isinstance(config, dict) else None
         return applied_to if applied_to else None
 
-    def _is_wildcard(policy: Any) -> bool:
+    wildcards: List[Any] = []
+    targeted: List[Any] = []
+    for policy in policies:
         applied_to = _applied_to(policy)
         if applied_to is None:
-            return True
-        return any(isinstance(e, str) and e.strip() == "*" for e in applied_to)
-
-    def _targets_viewer(policy: Any) -> bool:
-        if not normalized_viewer:
-            return False
-        applied_to = _applied_to(policy)
-        if applied_to is None:
-            return False
+            wildcards.append(policy)
+            continue
+        is_wildcard = False
+        is_targeted = False
         for entry in applied_to:
             if not isinstance(entry, str):
                 continue
-            if entry.strip().lower() == normalized_viewer:
-                return True
-        return False
+            normalized_entry = entry.strip().lower()
+            if normalized_entry == "*":
+                is_wildcard = True
+            elif normalized_viewer and normalized_entry == normalized_viewer:
+                is_targeted = True
+        if is_targeted:
+            targeted.append(policy)
+        elif is_wildcard:
+            wildcards.append(policy)
 
-    targeted = [p for p in policies if _targets_viewer(p)]
-    if targeted:
-        return targeted
-    return [p for p in policies if _is_wildcard(p)]
+    return targeted or wildcards
 
 
 class Connection(BaseModel):

--- a/components/backend/src/syfthub/services/endpoint_service.py
+++ b/components/backend/src/syfthub/services/endpoint_service.py
@@ -379,10 +379,15 @@ class EndpointService(BaseService):
         limit: int = 10,
         endpoint_type: Optional[EndpointType] = None,
         search: Optional[str] = None,
+        current_user: Optional[User] = None,
     ) -> List[EndpointPublicResponse]:
         """Get public endpoints with optional search filtering."""
         return self.endpoint_repository.get_public_endpoints(
-            skip, limit, endpoint_type, search
+            skip,
+            limit,
+            endpoint_type,
+            search,
+            viewer_email=current_user.email if current_user else None,
         )
 
     def _apply_endpoint_update(
@@ -533,10 +538,15 @@ class EndpointService(BaseService):
         limit: int = 10,
         endpoint_type: Optional[EndpointType] = None,
         search: Optional[str] = None,
+        current_user: Optional[User] = None,
     ) -> List[EndpointPublicResponse]:
         """List public endpoints - router-compatible wrapper."""
         return self.get_public_endpoints(
-            skip=skip, limit=limit, endpoint_type=endpoint_type, search=search
+            skip=skip,
+            limit=limit,
+            endpoint_type=endpoint_type,
+            search=search,
+            current_user=current_user,
         )
 
     def list_public_endpoints_by_owner(
@@ -544,6 +554,7 @@ class EndpointService(BaseService):
         owner_slug: str,
         skip: int = 0,
         limit: int = 100,
+        current_user: Optional[User] = None,
     ) -> List[EndpointPublicResponse]:
         """List public endpoints for a specific owner.
 
@@ -556,17 +567,25 @@ class EndpointService(BaseService):
             List of EndpointPublicResponse objects for the owner.
         """
         return self.endpoint_repository.get_public_endpoints_by_owner(
-            owner_slug=owner_slug, skip=skip, limit=limit
+            owner_slug=owner_slug,
+            skip=skip,
+            limit=limit,
+            viewer_email=current_user.email if current_user else None,
         )
 
     def get_public_endpoint_by_path(
-        self, owner_username: str, slug: str
+        self,
+        owner_username: str,
+        slug: str,
+        current_user: Optional[User] = None,
     ) -> EndpointPublicResponse:
         """Get a single public endpoint by owner username and slug.
 
         Args:
             owner_username: The username of the endpoint owner
             slug: The endpoint slug
+            current_user: Optional authenticated viewer; their email is used to
+                personalize policies whose `applied_to` targets specific users.
 
         Returns:
             EndpointPublicResponse
@@ -575,7 +594,9 @@ class EndpointService(BaseService):
             HTTPException: 404 if endpoint is not found
         """
         endpoint = self.endpoint_repository.get_public_endpoint_by_owner_and_slug(
-            owner_username, slug
+            owner_username,
+            slug,
+            viewer_email=current_user.email if current_user else None,
         )
         if endpoint is None:
             raise HTTPException(
@@ -590,10 +611,15 @@ class EndpointService(BaseService):
         limit: int = 10,
         min_stars: Optional[int] = None,
         endpoint_type: Optional[EndpointType] = None,
+        current_user: Optional[User] = None,
     ) -> List[EndpointPublicResponse]:
         """List trending public endpoints sorted by stars count with optional min_stars filter."""
         return self.endpoint_repository.get_trending_endpoints(
-            skip, limit, min_stars, endpoint_type
+            skip,
+            limit,
+            min_stars,
+            endpoint_type,
+            viewer_email=current_user.email if current_user else None,
         )
 
     def list_guest_accessible_endpoints(
@@ -601,6 +627,7 @@ class EndpointService(BaseService):
         skip: int = 0,
         limit: int = 10,
         endpoint_type: Optional[EndpointType] = None,
+        current_user: Optional[User] = None,
     ) -> List[EndpointPublicResponse]:
         """List endpoints accessible to guest (unauthenticated) users.
 
@@ -620,12 +647,16 @@ class EndpointService(BaseService):
             List of EndpointPublicResponse objects for guest-accessible endpoints
         """
         return self.endpoint_repository.get_guest_accessible_endpoints(
-            skip=skip, limit=limit, endpoint_type=endpoint_type
+            skip=skip,
+            limit=limit,
+            endpoint_type=endpoint_type,
+            viewer_email=current_user.email if current_user else None,
         )
 
     def list_public_endpoints_grouped(
         self,
         max_per_owner: int = 15,
+        current_user: Optional[User] = None,
     ) -> GroupedEndpointsResponse:
         """List public endpoints grouped by owner with a limit per owner.
 
@@ -640,7 +671,8 @@ class EndpointService(BaseService):
             GroupedEndpointsResponse with groups ordered by total endpoint count (descending)
         """
         return self.endpoint_repository.get_public_endpoints_grouped(
-            max_per_owner=max_per_owner
+            max_per_owner=max_per_owner,
+            viewer_email=current_user.email if current_user else None,
         )
 
     def list_public_endpoint_owners(
@@ -796,6 +828,7 @@ class EndpointService(BaseService):
         query: str,
         top_k: int = 10,
         endpoint_type: Optional[EndpointType] = None,
+        current_user: Optional[User] = None,
     ) -> EndpointSearchResponse:
         """Search endpoints using semantic search (RAG).
 
@@ -822,7 +855,10 @@ class EndpointService(BaseService):
         endpoint_ids = list(score_map.keys())
 
         # Fetch endpoints from database (preserves ranking order)
-        endpoints = self.endpoint_repository.get_public_endpoints_by_ids(endpoint_ids)
+        endpoints = self.endpoint_repository.get_public_endpoints_by_ids(
+            endpoint_ids,
+            viewer_email=current_user.email if current_user else None,
+        )
 
         # Filter by type if specified (inclusive: model_data_source matches both)
         if endpoint_type:

--- a/components/backend/src/syfthub/services/endpoint_service.py
+++ b/components/backend/src/syfthub/services/endpoint_service.py
@@ -51,6 +51,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _viewer_email(user: Optional[User]) -> Optional[str]:
+    return user.email if user else None
+
+
 class EndpointService(BaseService):
     """Endpoint service for handling endpoint operations."""
 
@@ -387,7 +391,7 @@ class EndpointService(BaseService):
             limit,
             endpoint_type,
             search,
-            viewer_email=current_user.email if current_user else None,
+            viewer_email=_viewer_email(current_user),
         )
 
     def _apply_endpoint_update(
@@ -570,7 +574,7 @@ class EndpointService(BaseService):
             owner_slug=owner_slug,
             skip=skip,
             limit=limit,
-            viewer_email=current_user.email if current_user else None,
+            viewer_email=_viewer_email(current_user),
         )
 
     def get_public_endpoint_by_path(
@@ -584,8 +588,7 @@ class EndpointService(BaseService):
         Args:
             owner_username: The username of the endpoint owner
             slug: The endpoint slug
-            current_user: Optional authenticated viewer; their email is used to
-                personalize policies whose `applied_to` targets specific users.
+            current_user: Optional authenticated viewer for policy personalization
 
         Returns:
             EndpointPublicResponse
@@ -596,7 +599,7 @@ class EndpointService(BaseService):
         endpoint = self.endpoint_repository.get_public_endpoint_by_owner_and_slug(
             owner_username,
             slug,
-            viewer_email=current_user.email if current_user else None,
+            viewer_email=_viewer_email(current_user),
         )
         if endpoint is None:
             raise HTTPException(
@@ -619,7 +622,7 @@ class EndpointService(BaseService):
             limit,
             min_stars,
             endpoint_type,
-            viewer_email=current_user.email if current_user else None,
+            viewer_email=_viewer_email(current_user),
         )
 
     def list_guest_accessible_endpoints(
@@ -650,7 +653,7 @@ class EndpointService(BaseService):
             skip=skip,
             limit=limit,
             endpoint_type=endpoint_type,
-            viewer_email=current_user.email if current_user else None,
+            viewer_email=_viewer_email(current_user),
         )
 
     def list_public_endpoints_grouped(
@@ -672,7 +675,7 @@ class EndpointService(BaseService):
         """
         return self.endpoint_repository.get_public_endpoints_grouped(
             max_per_owner=max_per_owner,
-            viewer_email=current_user.email if current_user else None,
+            viewer_email=_viewer_email(current_user),
         )
 
     def list_public_endpoint_owners(
@@ -857,7 +860,7 @@ class EndpointService(BaseService):
         # Fetch endpoints from database (preserves ranking order)
         endpoints = self.endpoint_repository.get_public_endpoints_by_ids(
             endpoint_ids,
-            viewer_email=current_user.email if current_user else None,
+            viewer_email=_viewer_email(current_user),
         )
 
         # Filter by type if specified (inclusive: model_data_source matches both)

--- a/components/backend/tests/test_services/test_endpoint_service.py
+++ b/components/backend/tests/test_services/test_endpoint_service.py
@@ -1235,7 +1235,10 @@ class TestEndpointServiceGuestAccessible:
             )
 
             mock_method.assert_called_once_with(
-                skip=0, limit=10, endpoint_type=EndpointType.MODEL
+                skip=0,
+                limit=10,
+                endpoint_type=EndpointType.MODEL,
+                viewer_email=None,
             )
             assert len(result) == 1
             assert result[0].type == EndpointType.MODEL
@@ -1249,7 +1252,9 @@ class TestEndpointServiceGuestAccessible:
         ) as mock_method:
             endpoint_service.list_guest_accessible_endpoints(skip=10, limit=20)
 
-            mock_method.assert_called_once_with(skip=10, limit=20, endpoint_type=None)
+            mock_method.assert_called_once_with(
+                skip=10, limit=20, endpoint_type=None, viewer_email=None
+            )
 
 
 class TestEndpointHealthSchemas:

--- a/components/frontend/src/lib/endpoint-utils.ts
+++ b/components/frontend/src/lib/endpoint-utils.ts
@@ -29,6 +29,21 @@ import Sparkles from 'lucide-react/dist/esm/icons/sparkles';
 import { formatRelativeTime } from './date-utils';
 import { syftClient } from './sdk-client';
 
+/**
+ * Build a HeadersInit with a Bearer Authorization header when an access
+ * token is present in localStorage. Public endpoints accept the token
+ * optionally and use it to personalize per-viewer policy filtering
+ * (config.applied_to). Anonymous viewers receive only wildcard policies.
+ */
+function buildAuthHeaders(): Record<string, string> {
+  try {
+    const token = globalThis.localStorage.getItem('syft_access_token');
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  } catch {
+    return {};
+  }
+}
+
 // ============================================================================
 // Type Matching Helpers
 // ============================================================================
@@ -381,7 +396,9 @@ export async function getPublicEndpointsPaginated(
       queryParams.append('search', search.trim());
     }
 
-    const response = await fetch(`/api/v1/endpoints/public?${queryParams.toString()}`);
+    const response = await fetch(`/api/v1/endpoints/public?${queryParams.toString()}`, {
+      headers: buildAuthHeaders()
+    });
 
     if (!response.ok) {
       throw new Error(`Failed to fetch endpoints: ${response.statusText}`);
@@ -423,7 +440,8 @@ export async function getPublicEndpointByPath(path: string): Promise<ChatSource 
 
   try {
     const response = await fetch(
-      `/api/v1/endpoints/public/${encodeURIComponent(owner)}/${encodeURIComponent(slug)}`
+      `/api/v1/endpoints/public/${encodeURIComponent(owner)}/${encodeURIComponent(slug)}`,
+      { headers: buildAuthHeaders() }
     );
 
     if (!response.ok) {
@@ -495,7 +513,8 @@ export async function getPublicEndpointOwners(): Promise<OwnerInfo[]> {
 export async function getPublicEndpointsByOwner(owner: string): Promise<ChatSource[]> {
   try {
     const response = await fetch(
-      `/api/v1/endpoints/public/by-owner/${encodeURIComponent(owner)}?limit=500`
+      `/api/v1/endpoints/public/by-owner/${encodeURIComponent(owner)}?limit=500`,
+      { headers: buildAuthHeaders() }
     );
 
     if (!response.ok) {
@@ -546,7 +565,9 @@ export async function getGroupedPublicEndpoints(
       max_per_owner: String(maxPerOwner)
     });
 
-    const response = await fetch(`/api/v1/endpoints/public/grouped?${queryParams.toString()}`);
+    const response = await fetch(`/api/v1/endpoints/public/grouped?${queryParams.toString()}`, {
+      headers: buildAuthHeaders()
+    });
 
     if (!response.ok) {
       throw new Error(`Failed to fetch grouped endpoints: ${response.statusText}`);

--- a/components/frontend/src/lib/endpoint-utils.ts
+++ b/components/frontend/src/lib/endpoint-utils.ts
@@ -27,21 +27,13 @@ import Database from 'lucide-react/dist/esm/icons/database';
 import Sparkles from 'lucide-react/dist/esm/icons/sparkles';
 
 import { formatRelativeTime } from './date-utils';
-import { syftClient } from './sdk-client';
+import { getStoredAccessToken, syftClient } from './sdk-client';
 
-/**
- * Build a HeadersInit with a Bearer Authorization header when an access
- * token is present in localStorage. Public endpoints accept the token
- * optionally and use it to personalize per-viewer policy filtering
- * (config.applied_to). Anonymous viewers receive only wildcard policies.
- */
+// Public endpoints optionally accept a bearer token to personalize policy
+// filtering (config.applied_to). Without it, only wildcard policies are returned.
 function buildAuthHeaders(): Record<string, string> {
-  try {
-    const token = globalThis.localStorage.getItem('syft_access_token');
-    return token ? { Authorization: `Bearer ${token}` } : {};
-  } catch {
-    return {};
-  }
+  const token = getStoredAccessToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
 // ============================================================================

--- a/components/frontend/src/lib/sdk-client.ts
+++ b/components/frontend/src/lib/sdk-client.ts
@@ -152,6 +152,17 @@ export function hasPersistedTokens(): boolean {
   }
 }
 
+/**
+ * Read the persisted access token from localStorage, or null if absent.
+ */
+export function getStoredAccessToken(): string | null {
+  try {
+    return localStorage.getItem(ACCESS_TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
 // Re-export commonly used SDK types for convenience
 export type { AuthTokens } from '@syfthub/sdk';
 export {


### PR DESCRIPTION
This pull request enhances the public endpoints API to allow filtering endpoint policies based on the identity of the requesting user. Now, if a user is authenticated, endpoint responses will include policies specifically targeted to that user in addition to wildcard ("*") policies. This is achieved by passing the current user's email through the API, service, and repository layers, and updating the logic that filters visible policies.

Key changes include:

**API Layer: Passing User Context for Public Endpoints**
- All public endpoint listing and retrieval routes in `endpoints.py` now accept an optional `current_user` parameter (using `get_optional_current_user`), which is passed down to the service layer. [[1]](diffhunk://#diff-eee7184aa49703db8e04c3ed31cacc6f34ebf949cfdedf07f2e24ca2056f0df2R9) [[2]](diffhunk://#diff-eee7184aa49703db8e04c3ed31cacc6f34ebf949cfdedf07f2e24ca2056f0df2R81) [[3]](diffhunk://#diff-eee7184aa49703db8e04c3ed31cacc6f34ebf949cfdedf07f2e24ca2056f0df2L94-R100) [[4]](diffhunk://#diff-eee7184aa49703db8e04c3ed31cacc6f34ebf949cfdedf07f2e24ca2056f0df2R133) [[5]](diffhunk://#diff-eee7184aa49703db8e04c3ed31cacc6f34ebf949cfdedf07f2e24ca2056f0df2L136-R145) [[6]](diffhunk://#diff-eee7184aa49703db8e04c3ed31cacc6f34ebf949cfdedf07f2e24ca2056f0df2R222) [[7]](diffhunk://#diff-eee7184aa49703db8e04c3ed31cacc6f34ebf949cfdedf07f2e24ca2056f0df2L221-R231) [[8]](diffhunk://#diff-eee7184aa49703db8e04c3ed31cacc6f34ebf949cfdedf07f2e24ca2056f0df2R253-R264) [[9]](diffhunk://#diff-eee7184aa49703db8e04c3ed31cacc6f34ebf949cfdedf07f2e24ca2056f0df2L260-R278) [[10]](diffhunk://#diff-eee7184aa49703db8e04c3ed31cacc6f34ebf949cfdedf07f2e24ca2056f0df2R310) [[11]](diffhunk://#diff-eee7184aa49703db8e04c3ed31cacc6f34ebf949cfdedf07f2e24ca2056f0df2L304-R326) [[12]](diffhunk://#diff-eee7184aa49703db8e04c3ed31cacc6f34ebf949cfdedf07f2e24ca2056f0df2R356-R363)

**Service Layer: Propagating Viewer Email**
- The `EndpointService` methods now accept `current_user` and use a helper function `_viewer_email` to extract the user's email, which is passed to the repository methods as `viewer_email`. [[1]](diffhunk://#diff-cb1517ade0e21ae10b15e258625efc6f60545c56a47498e81ddd967e489029f8R54-R57) [[2]](diffhunk://#diff-cb1517ade0e21ae10b15e258625efc6f60545c56a47498e81ddd967e489029f8R386-R394)

**Repository Layer: Filtering by Viewer**
- All repository methods that build public endpoint responses now accept an optional `viewer_email` parameter, which is passed to the policy filtering logic. [[1]](diffhunk://#diff-24069e7e5cc9b855c49f99a0bd09caf06d1772eb18cba345b08da48357c7d85aL71-R82) [[2]](diffhunk://#diff-24069e7e5cc9b855c49f99a0bd09caf06d1772eb18cba345b08da48357c7d85aR224) [[3]](diffhunk://#diff-24069e7e5cc9b855c49f99a0bd09caf06d1772eb18cba345b08da48357c7d85aL273-R277) [[4]](diffhunk://#diff-24069e7e5cc9b855c49f99a0bd09caf06d1772eb18cba345b08da48357c7d85aR290) [[5]](diffhunk://#diff-24069e7e5cc9b855c49f99a0bd09caf06d1772eb18cba345b08da48357c7d85aL322-R329) [[6]](diffhunk://#diff-24069e7e5cc9b855c49f99a0bd09caf06d1772eb18cba345b08da48357c7d85aL331-R341) [[7]](diffhunk://#diff-24069e7e5cc9b855c49f99a0bd09caf06d1772eb18cba345b08da48357c7d85aL371-R383) [[8]](diffhunk://#diff-24069e7e5cc9b855c49f99a0bd09caf06d1772eb18cba345b08da48357c7d85aR396) [[9]](diffhunk://#diff-24069e7e5cc9b855c49f99a0bd09caf06d1772eb18cba345b08da48357c7d85aL418-R431) [[10]](diffhunk://#diff-24069e7e5cc9b855c49f99a0bd09caf06d1772eb18cba345b08da48357c7d85aR448) [[11]](diffhunk://#diff-24069e7e5cc9b855c49f99a0bd09caf06d1772eb18cba345b08da48357c7d85aL475-R491) [[12]](diffhunk://#diff-24069e7e5cc9b855c49f99a0bd09caf06d1772eb18cba345b08da48357c7d85aR504) [[13]](diffhunk://#diff-24069e7e5cc9b855c49f99a0bd09caf06d1772eb18cba345b08da48357c7d85aL518-R537) [[14]](diffhunk://#diff-24069e7e5cc9b855c49f99a0bd09caf06d1772eb18cba345b08da48357c7d85aR547) [[15]](diffhunk://#diff-24069e7e5cc9b855c49f99a0bd09caf06d1772eb18cba345b08da48357c7d85aL618-R638)

**Policy Filtering Logic: Targeted and Wildcard Policies**
- The `filter_visible_policies` function in `schemas/endpoint.py` is refactored to prioritize returning policies targeted to the current viewer (by email) if any exist; otherwise, it falls back to wildcard policies. This ensures users see policies meant for them, while guests see only general policies.

These changes allow the system to provide more personalized and secure policy information for public endpoints depending on the user's authentication state.