### PR TITLE
feat(chat): surface MPP-policy endpoints in PaymentGate

### DIFF
--- a/components/frontend/src/components/chat/payment-gate.tsx
+++ b/components/frontend/src/components/chat/payment-gate.tsx
@@ -2,9 +2,14 @@
  * PaymentGate
  *
  * Inline gate rendered in the chat history (right after the user's bubble)
- * when one or more selected endpoints carry an unfunded Xendit policy.
- * Each row drives its own buy flow (popup checkout window); the parent polls
- * credits_url to detect when each wallet flips active and unlocks Send.
+ * when one or more selected endpoints carry an unfunded paid policy.
+ *
+ * Two row variants:
+ *   - xendit: drives its own buy flow (popup checkout window); the parent
+ *     polls credits_url to detect when each wallet flips active and unlocks
+ *     Send.
+ *   - mpp: payment is not implemented yet — shows a "supported in a future
+ *     release" notice and forces the user to remove the endpoint to send.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -32,6 +37,7 @@ import {
 function distinctOwners(pending: PendingSubscription[]): string[] {
   const owners = new Set<string>();
   for (const p of pending) {
+    if (p.policyType !== 'xendit') continue;
     for (const e of p.endpoints) owners.add(e.owner);
   }
   return [...owners];
@@ -70,6 +76,65 @@ function renderStatusLine(pending: PendingSubscription, isActive: boolean, liveB
     <span className='tabular-nums'>
       {pending.currency} {pending.pricePerRequest.toLocaleString()} per request
     </span>
+  );
+}
+
+interface MppRowProperties {
+  pending: PendingSubscription;
+  onRemove: () => void;
+}
+
+function MppPaymentGateRow({ pending, onRemove }: Readonly<MppRowProperties>) {
+  const primaryEndpoint = pending.endpoints[0];
+  const roleLabel = primaryEndpoint?.role === 'model' ? 'Model' : 'Data source';
+
+  return (
+    <div className='dark:bg-card rounded-md border border-amber-200/60 bg-white px-3 py-2.5 dark:border-amber-900/40'>
+      <div className='flex flex-wrap items-center justify-between gap-x-3 gap-y-2'>
+        <div className='flex min-w-0 flex-1 items-center gap-2.5'>
+          <div className='flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-amber-200 bg-amber-50 text-amber-600 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-400'>
+            <CreditCard className='h-3.5 w-3.5' />
+          </div>
+          <div className='min-w-0'>
+            <div className='flex items-center gap-1.5'>
+              <span className='text-foreground truncate text-sm font-medium'>
+                {primaryEndpoint?.path ?? 'Unknown endpoint'}
+              </span>
+              <span className='text-muted-foreground text-[11px]'>· {roleLabel}</span>
+            </div>
+            <div className='text-muted-foreground mt-0.5 text-[11px]'>
+              {pending.pricePerRequest === null ? (
+                <>MPP credits required</>
+              ) : (
+                <span className='tabular-nums'>
+                  {pending.currency} {pending.pricePerRequest.toLocaleString()} per request (MPP)
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className='flex shrink-0 items-center gap-1.5'>
+          <button
+            type='button'
+            onClick={onRemove}
+            aria-label='Remove from selection'
+            title='Remove from selection'
+            className={cn(
+              'text-muted-foreground hover:text-foreground rounded-md p-1 transition-colors',
+              'hover:bg-muted/60 focus:ring-ring/30 focus:ring-2 focus:outline-none'
+            )}
+          >
+            <X className='h-3.5 w-3.5' />
+          </button>
+        </div>
+      </div>
+
+      <div className='mt-2 text-[11px] text-amber-700 dark:text-amber-400'>
+        MPP endpoints will be supported in a future release. Remove this endpoint from the selection
+        to send your message.
+      </div>
+    </div>
   );
 }
 
@@ -291,6 +356,8 @@ export function PaymentGate({
 
   const isWalletActive = useCallback(
     (p: PendingSubscription) => {
+      // mpp has no payment flow yet — these rows can never become active.
+      if (p.policyType === 'mpp') return false;
       const balance = balances[p.walletKey] ?? 0;
       const threshold = p.pricePerRequest ?? 1;
       return balance >= threshold;
@@ -305,6 +372,7 @@ export function PaymentGate({
   const registeredKeysReference = useRef<Set<string>>(new Set());
   useEffect(() => {
     for (const p of pending) {
+      if (p.policyType !== 'xendit') continue;
       const balance = balances[p.walletKey] ?? 0;
       if (balance <= 0) continue;
       if (registeredKeysReference.current.has(p.walletKey)) continue;
@@ -330,6 +398,7 @@ export function PaymentGate({
     const tick = async () => {
       const inactive = new Map<string, PendingSubscription>();
       for (const p of pending) {
+        if (p.policyType !== 'xendit') continue;
         if (isWalletActive(p)) continue;
         if (!inactive.has(p.walletKey)) inactive.set(p.walletKey, p);
       }
@@ -391,17 +460,31 @@ export function PaymentGate({
       </div>
 
       <div className='mt-3 space-y-1.5'>
-        {pending.map((p) => (
-          <PaymentGateRow
-            key={`${p.walletKey}::${p.endpoints[0]?.path ?? ''}`}
-            pending={p}
-            liveBalance={balances[p.walletKey] ?? 0}
-            isActive={isWalletActive(p)}
-            onRemove={() => {
-              onRemovePending(p);
-            }}
-          />
-        ))}
+        {pending.map((p) => {
+          const key = `${p.walletKey}::${p.endpoints[0]?.path ?? ''}`;
+          if (p.policyType === 'mpp') {
+            return (
+              <MppPaymentGateRow
+                key={key}
+                pending={p}
+                onRemove={() => {
+                  onRemovePending(p);
+                }}
+              />
+            );
+          }
+          return (
+            <PaymentGateRow
+              key={key}
+              pending={p}
+              liveBalance={balances[p.walletKey] ?? 0}
+              isActive={isWalletActive(p)}
+              onRemove={() => {
+                onRemovePending(p);
+              }}
+            />
+          );
+        })}
       </div>
 
       <div className='mt-4 flex items-center justify-end gap-2 border-t border-amber-200/60 pt-3 dark:border-amber-900/40'>

--- a/components/frontend/src/hooks/use-xendit-precheck.ts
+++ b/components/frontend/src/hooks/use-xendit-precheck.ts
@@ -2,11 +2,15 @@
  * useXenditPrecheck
  *
  * Pre-flight subscription check run before a chat message is sent.
- * Inspects the model + selected data sources for Xendit-policy gates,
+ * Inspects the model + selected data sources for paid-policy gates,
  * dedupes by credits_url (one wallet may back multiple endpoints), and
  * fetches each balance via a satellite token. Returns the rows that
  * still need a paid subscription so the chat view can open the gate
  * modal — or an empty array when the user is clear to send.
+ *
+ * Also surfaces `mpp`-typed policies as always-pending rows: payment
+ * for those endpoints isn't implemented yet, so the gate informs the
+ * user and forces them to remove the endpoint to send.
  */
 import { useCallback } from 'react';
 
@@ -29,17 +33,23 @@ export interface EndpointReference {
   role: EndpointRole;
 }
 
+export type PolicyKind = 'xendit' | 'mpp';
+
 export interface PendingSubscription {
-  /** Stable identity (the credits_url, which uniquely names a wallet). */
+  /** Which policy type this row represents. Drives the gate UI branch. */
+  policyType: PolicyKind;
+  /** Stable identity. credits_url for xendit; synthetic for mpp. */
   walletKey: string;
   /** All endpoints covered by this single wallet subscription. */
   endpoints: EndpointReference[];
+  /** Empty string for mpp (no payment endpoint yet). */
   paymentUrl: string;
+  /** Empty string for mpp (no balance endpoint yet). */
   creditsUrl: string;
   bundles: MoneyBundle[];
   currency: string;
   pricePerRequest: number | null;
-  /** Last balance reading (0 when unsubscribed). */
+  /** Last balance reading (0 when unsubscribed; always 0 for mpp). */
   balance: number;
 }
 
@@ -78,27 +88,54 @@ function endpointReferenceFor(source: ChatSource, role: EndpointRole): EndpointR
 }
 
 interface XenditCandidate {
+  kind: 'xendit';
   endpoint: EndpointReference;
   policy: ResolvedXenditPolicy;
 }
 
-function candidatesFromSource(source: ChatSource, role: EndpointRole): XenditCandidate[] {
+interface MppCandidate {
+  kind: 'mpp';
+  endpoint: EndpointReference;
+  currency: string;
+  pricePerRequest: number | null;
+}
+
+type Candidate = XenditCandidate | MppCandidate;
+
+function resolveMppPolicy(
+  policy: Policy
+): { currency: string; pricePerRequest: number | null } | null {
+  if (!policy.enabled) return null;
+  if (policy.type.toLowerCase() !== 'mpp') return null;
+  const config = policy.config;
+  const rawPrice = config.price ?? config.price_per_request ?? config.pricePerRequest;
+  const pricePerRequest = typeof rawPrice === 'number' ? rawPrice : null;
+  const rawCurrency = config.currency;
+  const currency = typeof rawCurrency === 'string' && rawCurrency ? rawCurrency : 'USD';
+  return { currency, pricePerRequest };
+}
+
+function candidatesFromSource(source: ChatSource, role: EndpointRole): Candidate[] {
   if (!source.policies) return [];
   const ref = endpointReferenceFor(source, role);
   if (!ref) return [];
-  const out: XenditCandidate[] = [];
+  const out: Candidate[] = [];
   for (const policy of source.policies) {
-    const resolved = resolveXenditPolicy(policy);
-    if (resolved) out.push({ endpoint: ref, policy: resolved });
+    const xendit = resolveXenditPolicy(policy);
+    if (xendit) {
+      out.push({ kind: 'xendit', endpoint: ref, policy: xendit });
+      continue;
+    }
+    const mpp = resolveMppPolicy(policy);
+    if (mpp) {
+      out.push({ kind: 'mpp', endpoint: ref, ...mpp });
+    }
   }
   return out;
 }
 
-function collectXenditCandidates(
-  model: ChatSource | null,
-  dataSources: ChatSource[]
-): XenditCandidate[] {
-  const out: XenditCandidate[] = [];
+function collectCandidates(model: ChatSource | null, dataSources: ChatSource[]): Candidate[] {
+  const out: Candidate[] = [];
   if (model) out.push(...candidatesFromSource(model, 'model'));
   for (const ds of dataSources) out.push(...candidatesFromSource(ds, 'data_source'));
   return out;
@@ -124,13 +161,17 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
 
   const runPrecheck = useCallback(
     async (signal?: AbortSignal): Promise<PendingSubscription[]> => {
-      const candidates = collectXenditCandidates(model, dataSources);
+      const candidates = collectCandidates(model, dataSources);
       if (candidates.length === 0) return [];
       if (!syftClient.getTokens()) return [];
 
-      // One satellite token per distinct owner — multiple wallets owned by
-      // the same publisher reuse the token.
-      const owners = [...new Set(candidates.map((c) => c.endpoint.owner))];
+      const xenditCandidates = candidates.filter((c): c is XenditCandidate => c.kind === 'xendit');
+      const mppCandidates = candidates.filter((c): c is MppCandidate => c.kind === 'mpp');
+
+      // One satellite token per distinct xendit owner — multiple wallets
+      // owned by the same publisher reuse the token. mpp rows skip this
+      // because they have no balance endpoint to authenticate against.
+      const owners = [...new Set(xenditCandidates.map((c) => c.endpoint.owner))];
       const tokenByOwner = new Map<string, string>();
       await Promise.all(
         owners.map(async (owner) => {
@@ -143,11 +184,11 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
       // share a wallet — paying once funds them all — but the gate UI lists
       // each endpoint separately, so we need to know each row's status
       // without re-hitting the same credits_url.
-      const distinctCreditsUrls = [...new Set(candidates.map((c) => c.policy.creditsUrl))];
+      const distinctCreditsUrls = [...new Set(xenditCandidates.map((c) => c.policy.creditsUrl))];
       const balanceByCreditsUrl = new Map<string, number | null>();
       await Promise.all(
         distinctCreditsUrls.map(async (creditsUrl) => {
-          const sample = candidates.find((c) => c.policy.creditsUrl === creditsUrl);
+          const sample = xenditCandidates.find((c) => c.policy.creditsUrl === creditsUrl);
           if (!sample) return;
           const token = tokenByOwner.get(sample.endpoint.owner);
           if (!token) return;
@@ -156,17 +197,18 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
         })
       );
 
-      // One PendingSubscription per endpoint. Rows that share a wallet keep
-      // the same `walletKey` (= credits_url) so the gate's polling loop and
-      // auto-registration can dedupe by wallet, and a single payment flips
-      // every sibling row to active at once.
+      // One PendingSubscription per endpoint. xendit rows that share a
+      // wallet keep the same `walletKey` (= credits_url) so the gate's
+      // polling loop and auto-registration can dedupe by wallet, and a
+      // single payment flips every sibling row to active at once.
       const out: PendingSubscription[] = [];
-      for (const c of candidates) {
+      for (const c of xenditCandidates) {
         const balance = balanceByCreditsUrl.get(c.policy.creditsUrl);
         if (balance === null || balance === undefined) continue;
         const threshold = c.policy.pricePerRequest ?? 1;
         if (balance >= threshold) continue;
         out.push({
+          policyType: 'xendit',
           walletKey: c.policy.creditsUrl,
           endpoints: [c.endpoint],
           paymentUrl: c.policy.paymentUrl,
@@ -175,6 +217,22 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
           currency: c.policy.currency,
           pricePerRequest: c.policy.pricePerRequest,
           balance
+        });
+      }
+      // mpp rows are always pending — no payment flow exists yet, so we
+      // surface them in the gate purely to inform the user and force a
+      // remove-or-cancel decision. walletKey is synthetic (per-endpoint).
+      for (const c of mppCandidates) {
+        out.push({
+          policyType: 'mpp',
+          walletKey: `mpp::${c.endpoint.owner}/${c.endpoint.slug}`,
+          endpoints: [c.endpoint],
+          paymentUrl: '',
+          creditsUrl: '',
+          bundles: [],
+          currency: c.currency,
+          pricePerRequest: c.pricePerRequest,
+          balance: 0
         });
       }
       return out;


### PR DESCRIPTION
## Summary
- Extend the chat pre-send precheck (`useXenditPrecheck`) to also detect `mpp`-typed policies on the selected model and data sources, surfacing them as always-pending rows in the existing "Some endpoints need payment" gate.
- New `MppPaymentGateRow` variant: same layout as the Xendit row but **no bundle picker and no Buy button**. Shows a "MPP endpoints will be supported in a future release. Remove this endpoint from the selection to send your message." notice.
- `isWalletActive` returns `false` for MPP rows so the footer **Send message** button stays disabled until the user removes every MPP endpoint via the row's `×` button.
- Polling, satellite-token minting, and subscription auto-registration loops all skip non-Xendit rows — no network calls are made for MPP endpoints.

Triggered by `irinamb7/test-irina-mpp` on prod, which carries `policy.type = "mpp"` with `price: 400, currency: "USD"`. Before this change, that policy was inert and the chat sent straight through.

## Test plan
- [ ] Select a model or data source carrying an enabled `xendit` policy with insufficient balance — gate appears with the existing Buy flow (regression check).
- [ ] Select `irinamb7/test-irina-mpp` (or any endpoint with `policy.type = "mpp"`) and submit a chat message — gate appears with one MPP row showing `USD 400 per request (MPP)` and the coming-soon notice; **Send message** is disabled.
- [ ] Click `×` on the MPP row — endpoint is removed from selection; if it was the only blocker, the queued message sends.
- [ ] Click **Cancel** — user bubble is dropped, gate closes.
- [ ] Mixed selection (one Xendit + one MPP): Xendit row still shows Buy + bundle picker; MPP row shows notice; **Send** stays disabled even after Xendit wallet is funded, until MPP row is removed.