### PR TITLE
feat(profile): add public user profile page at /:username

### DIFF
--- a/components/backend/alembic/versions/20260506_000000_add_user_public_profile_fields.py
+++ b/components/backend/alembic/versions/20260506_000000_add_user_public_profile_fields.py
@@ -1,0 +1,38 @@
+"""Add bio and is_email_public to users.
+
+Backs the public ``/:username`` profile page by giving users an editable bio
+(Markdown) and an opt-in toggle that controls whether their email is shown
+to anonymous viewers.
+
+Revision ID: 012_user_public_profile
+Revises: 011_xendit_subs
+Create Date: 2026-05-06 00:00:00.000000+00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "012_user_public_profile"
+down_revision: str | None = "011_xendit_subs"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("bio", sa.Text(), nullable=True))
+    op.add_column(
+        "users",
+        sa.Column(
+            "is_email_public",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "is_email_public")
+    op.drop_column("users", "bio")

--- a/components/backend/src/syfthub/api/endpoints/users.py
+++ b/components/backend/src/syfthub/api/endpoints/users.py
@@ -17,6 +17,7 @@ from syfthub.schemas.auth import UserRole
 from syfthub.schemas.user import (
     HeartbeatRequest,
     HeartbeatResponse,
+    PublicUserProfile,
     TunnelCredentialsResponse,
     User,
     UserResponse,
@@ -153,6 +154,33 @@ async def check_email_availability(
     """Check if an email is available (public endpoint)."""
     available = user_service.email_available(email.lower())
     return {"available": available, "email": email.lower()}
+
+
+@router.get(
+    "/public/{username}",
+    response_model=PublicUserProfile,
+    summary="Get Public User Profile",
+    description="""
+Public, anonymous-accessible profile for a user.
+
+**No Authentication Required.**
+
+Returns a sanitized profile suitable for the ``/:username`` page. Email is
+only present in the response when the user has opted in via
+``is_email_public``. Returns 404 for unknown or deactivated accounts.
+""",
+)
+async def get_public_user_profile(
+    username: str,
+    user_service: Annotated[UserService, Depends(get_user_service)],
+) -> PublicUserProfile:
+    """Return a sanitized public profile for ``username``."""
+    profile = user_service.get_public_user_profile(username.lower())
+    if profile is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+    return profile
 
 
 @router.get("/{user_id}", response_model=UserResponse)

--- a/components/backend/src/syfthub/models/user.py
+++ b/components/backend/src/syfthub/models/user.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional
 
-from sqlalchemy import Boolean, DateTime, Index, String
+from sqlalchemy import Boolean, DateTime, Index, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from syfthub.models.base import BaseModel, TimestampMixin
@@ -55,6 +55,14 @@ class UserModel(BaseModel, TimestampMixin):
     # Custom aggregator URL for RAG/chat workflows
     aggregator_url: Mapped[Optional[str]] = mapped_column(
         String(500), nullable=True, default=None
+    )
+
+    # Public profile bio (Markdown). Surfaced on /:username public profile page.
+    bio: Mapped[Optional[str]] = mapped_column(Text, nullable=True, default=None)
+
+    # Whether the user's email is shown on their public profile page.
+    is_email_public: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
     )
 
     # Heartbeat tracking fields for push-based health monitoring

--- a/components/backend/src/syfthub/repositories/user.py
+++ b/components/backend/src/syfthub/repositories/user.py
@@ -145,6 +145,12 @@ class UserRepository(BaseRepository[UserModel]):
             # Aggregator URL
             if user_data.aggregator_url is not None:
                 user_model.aggregator_url = user_data.aggregator_url
+            # Public profile fields. Use model_fields_set so callers can
+            # explicitly clear the bio (set to "") without it being ignored.
+            if "bio" in user_data.model_fields_set:
+                user_model.bio = user_data.bio
+            if user_data.is_email_public is not None:
+                user_model.is_email_public = user_data.is_email_public
 
             self.session.commit()
             self.session.refresh(user_model)

--- a/components/backend/src/syfthub/schemas/user.py
+++ b/components/backend/src/syfthub/schemas/user.py
@@ -88,6 +88,13 @@ class User(UserBase):
     encryption_public_key: Optional[str] = Field(
         None, description="X25519 public key for tunnel encryption (base64url)"
     )
+    # Public profile fields
+    bio: Optional[str] = Field(
+        None, description="Markdown bio shown on the user's public profile"
+    )
+    is_email_public: bool = Field(
+        False, description="Whether the user's email is visible on their public profile"
+    )
 
     model_config = {"from_attributes": True}
 
@@ -132,6 +139,13 @@ class UserResponse(BaseModel):
     encryption_public_key: Optional[str] = Field(
         None, description="X25519 public key for tunnel encryption (base64url)"
     )
+    # Public profile fields
+    bio: Optional[str] = Field(
+        None, description="Markdown bio shown on the user's public profile"
+    )
+    is_email_public: bool = Field(
+        False, description="Whether the user's email is visible on their public profile"
+    )
 
     model_config = {"from_attributes": True}
 
@@ -165,6 +179,16 @@ class UserUpdate(BaseModel):
         None,
         max_length=500,
         description="Custom aggregator URL for RAG/chat workflows",
+    )
+    # Public profile fields
+    bio: Optional[str] = Field(
+        None,
+        max_length=2000,
+        description="Markdown bio shown on the user's public profile",
+    )
+    is_email_public: Optional[bool] = Field(
+        None,
+        description="Whether the user's email is visible on their public profile",
     )
 
     @field_validator("domain")
@@ -201,6 +225,33 @@ class UserUpdate(BaseModel):
         if not parsed.netloc:
             raise ValueError("Domain must contain a valid hostname")
         return v
+
+
+class PublicUserProfile(BaseModel):
+    """Sanitized public profile shown on /:username.
+
+    Only fields safe to expose to anonymous viewers are included. Email is
+    only present when the user has opted in via ``is_email_public``.
+    """
+
+    username: str = Field(..., description="Username (URL slug)")
+    full_name: str = Field(..., description="Display name")
+    avatar_url: Optional[str] = Field(None, description="URL to user's avatar image")
+    role: UserRole = Field(..., description="User role")
+    bio: Optional[str] = Field(None, description="Markdown bio")
+    domain: Optional[str] = Field(
+        None, description="Public domain associated with the user (if any)"
+    )
+    email: Optional[str] = Field(
+        None,
+        description="Email address — only populated when the user has set is_email_public=True",
+    )
+    is_email_public: bool = Field(
+        ..., description="Whether the user has opted in to public email visibility"
+    )
+    created_at: datetime = Field(..., description="When the account was created")
+
+    model_config = {"from_attributes": True}
 
 
 class TunnelCredentialsResponse(BaseModel):

--- a/components/backend/src/syfthub/services/user_service.py
+++ b/components/backend/src/syfthub/services/user_service.py
@@ -19,6 +19,7 @@ from syfthub.repositories.user import UserRepository
 from syfthub.schemas.user import (
     TUNNELING_PREFIX,
     HeartbeatResponse,
+    PublicUserProfile,
     User,
     UserResponse,
     UserUpdate,
@@ -76,6 +77,29 @@ class UserService(BaseService):
         if user:
             return UserResponse.model_validate(user)
         return None
+
+    def get_public_user_profile(self, username: str) -> Optional[PublicUserProfile]:
+        """Get a sanitized public profile by username.
+
+        Returns ``None`` if the user does not exist or is inactive. The email
+        field is populated only when the user has opted in via
+        ``is_email_public``.
+        """
+        user = self.user_repository.get_by_username(username)
+        if user is None or not user.is_active:
+            return None
+
+        return PublicUserProfile(
+            username=user.username,
+            full_name=user.full_name,
+            avatar_url=user.avatar_url,
+            role=user.role,
+            bio=user.bio,
+            domain=user.domain,
+            email=user.email if user.is_email_public else None,
+            is_email_public=user.is_email_public,
+            created_at=user.created_at,
+        )
 
     def get_users_list(
         self, skip: int = 0, limit: int = 10, active_only: bool = True

--- a/components/frontend/src/app.tsx
+++ b/components/frontend/src/app.tsx
@@ -27,6 +27,7 @@ const AboutPage = lazyWithRetry(() => import('./pages/about'));
 const ProfilePage = lazyWithRetry(() => import('./pages/profile'));
 const EndpointsPage = lazyWithRetry(() => import('./pages/endpoints'));
 const EndpointDetailPage = lazyWithRetry(() => import('./pages/endpoint-detail'));
+const UserProfilePage = lazyWithRetry(() => import('./pages/user-profile'));
 // TODO(agent-feature): Uncomment when agent endpoint UI is re-enabled
 // const AgentPage = lazyWithRetry(() => import('./pages/agent'));
 const NotFoundPage = lazyWithRetry(() => import('./pages/not-found'));
@@ -167,6 +168,16 @@ export default function App() {
                         element={
                           <RouteBoundary>
                             <EndpointDetailPage />
+                          </RouteBoundary>
+                        }
+                      />
+
+                      {/* Public user profile: /:username */}
+                      <Route
+                        path=':username'
+                        element={
+                          <RouteBoundary>
+                            <UserProfilePage />
                           </RouteBoundary>
                         }
                       />

--- a/components/frontend/src/components/balance/credits-panel.tsx
+++ b/components/frontend/src/components/balance/credits-panel.tsx
@@ -262,9 +262,11 @@ function SubscriptionRow({
   const liveBalance = balance ?? subscription.last_known_balance ?? 0;
   const status = balanceStatus(liveBalance, 0);
   const label = subscription.endpoint_owner;
-  const targetPath = subscription.endpoint_slug
-    ? `/${subscription.endpoint_owner}/${subscription.endpoint_slug}`
-    : `/${subscription.endpoint_owner}`;
+  // Xendit wallets are scoped per-publisher, so the row always navigates to
+  // the publisher's profile page — not the specific endpoint that originally
+  // triggered funding (the same wallet is reusable across all endpoints owned
+  // by that publisher).
+  const targetPath = `/${subscription.endpoint_owner}`;
 
   return (
     <div

--- a/components/frontend/src/components/browse-view.tsx
+++ b/components/frontend/src/components/browse-view.tsx
@@ -21,12 +21,7 @@ import X from 'lucide-react/dist/esm/icons/x';
 import { Link } from 'react-router-dom';
 
 import { usePaginatedPublicEndpoints } from '@/hooks/use-endpoint-queries';
-import {
-  getEndpointTypeIcon,
-  getEndpointTypeIconColor,
-  getEndpointTypeLabel,
-  isDataSourceEndpoint
-} from '@/lib/endpoint-utils';
+import { isDataSourceEndpoint } from '@/lib/endpoint-utils';
 import { useContextSelectionStore } from '@/stores/context-selection-store';
 
 import {
@@ -36,6 +31,7 @@ import {
   extractUniqueTags,
   hasActiveFilters
 } from './browse-filters-modal';
+import { EndpointTypeIcon } from './endpoint-type-icon';
 import { Badge } from './ui/badge';
 import { LoadingSpinner } from './ui/loading-spinner';
 import { PageHeader } from './ui/page-header';
@@ -54,28 +50,6 @@ import { Tabs, TabsList, TabsTrigger } from './ui/tabs';
 // ============================================================================
 
 const PAGE_SIZE = 12;
-
-// ============================================================================
-// Helper functions
-// ============================================================================
-
-function getTypeIcon(type: EndpointType) {
-  // model_data_source renders a compound icon (two icons side by side)
-  if (type === 'model_data_source') {
-    return (
-      <span className='flex shrink-0 items-center gap-0.5' aria-label='Model and Data Source'>
-        <Sparkles className='h-3.5 w-3.5 text-purple-500' />
-        <Database className='h-3.5 w-3.5 text-emerald-500' />
-      </span>
-    );
-  }
-
-  const Icon = getEndpointTypeIcon(type);
-  const colorClass = getEndpointTypeIconColor(type);
-  const label = getEndpointTypeLabel(type);
-
-  return <Icon className={`h-4 w-4 shrink-0 ${colorClass}`} aria-label={label} />;
-}
 
 // ============================================================================
 // Tab types
@@ -489,7 +463,7 @@ export function BrowseView({ initialQuery = '' }: Readonly<BrowseViewProperties>
                       <div className='mb-3 flex items-start justify-between'>
                         <div className='min-w-0 flex-1 pr-8'>
                           <h3 className='font-inter text-foreground group-hover:text-primary flex items-center gap-1.5 text-base font-semibold'>
-                            {getTypeIcon(endpoint.type)}
+                            <EndpointTypeIcon type={endpoint.type} />
                             <span className='truncate'>{endpoint.name}</span>
                           </h3>
                           {endpoint.owner_username && (

--- a/components/frontend/src/components/endpoint-type-icon.tsx
+++ b/components/frontend/src/components/endpoint-type-icon.tsx
@@ -1,0 +1,36 @@
+import type { EndpointType } from '@/lib/types';
+
+import Database from 'lucide-react/dist/esm/icons/database';
+import Sparkles from 'lucide-react/dist/esm/icons/sparkles';
+
+import {
+  getEndpointTypeIcon,
+  getEndpointTypeIconColor,
+  getEndpointTypeLabel
+} from '@/lib/endpoint-utils';
+
+interface EndpointTypeIconProps {
+  type: EndpointType;
+  /** Size class — defaults to "h-4 w-4". Pass e.g. "h-3.5 w-3.5" for compound branch parity. */
+  className?: string;
+}
+
+export function EndpointTypeIcon({ type, className = 'h-4 w-4' }: Readonly<EndpointTypeIconProps>) {
+  if (type === 'model_data_source') {
+    return (
+      <span className='flex shrink-0 items-center gap-0.5' aria-label='Model and Data Source'>
+        <Sparkles className='h-3.5 w-3.5 text-purple-500' />
+        <Database className='h-3.5 w-3.5 text-emerald-500' />
+      </span>
+    );
+  }
+
+  const Icon = getEndpointTypeIcon(type);
+  const colorClass = getEndpointTypeIconColor(type);
+  return (
+    <Icon
+      className={`${className} shrink-0 ${colorClass}`}
+      aria-label={getEndpointTypeLabel(type)}
+    />
+  );
+}

--- a/components/frontend/src/components/settings/profile-settings-tab.tsx
+++ b/components/frontend/src/components/settings/profile-settings-tab.tsx
@@ -6,11 +6,14 @@ import AlertCircle from 'lucide-react/dist/esm/icons/alert-circle';
 import Check from 'lucide-react/dist/esm/icons/check';
 import Globe from 'lucide-react/dist/esm/icons/globe';
 import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
+import Mail from 'lucide-react/dist/esm/icons/mail';
 import Save from 'lucide-react/dist/esm/icons/save';
+import UserIcon from 'lucide-react/dist/esm/icons/user';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { useAuth } from '@/context/auth-context';
 import {
   checkEmailAvailability,
@@ -30,7 +33,11 @@ interface ProfileFormData {
   full_name: string;
   avatar_url: string;
   domain: string;
+  bio: string;
+  is_email_public: boolean;
 }
+
+const BIO_MAX_LENGTH = 2000;
 
 export function ProfileSettingsTab() {
   const { user, updateUser } = useAuth();
@@ -44,7 +51,9 @@ export function ProfileSettingsTab() {
     email: user?.email ?? '',
     full_name: user?.full_name ?? '',
     avatar_url: user?.avatar_url ?? '',
-    domain: user?.domain ?? ''
+    domain: user?.domain ?? '',
+    bio: user?.bio ?? '',
+    is_email_public: user?.is_email_public ?? false
   });
 
   // Sync form data when user context changes (e.g., after successful update)
@@ -56,7 +65,9 @@ export function ProfileSettingsTab() {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Defensive null check
         full_name: user.full_name ?? '',
         avatar_url: user.avatar_url ?? '',
-        domain: user.domain ?? ''
+        domain: user.domain ?? '',
+        bio: user.bio ?? '',
+        is_email_public: user.is_email_public ?? false
       });
     }
   }, [user]);
@@ -182,6 +193,18 @@ export function ProfileSettingsTab() {
     };
   }, []);
 
+  const handleBioChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setFormData((previous) => ({ ...previous, bio: e.target.value }));
+    setError(null);
+    setSuccess(null);
+  }, []);
+
+  const handleEmailVisibilityChange = useCallback((checked: boolean) => {
+    setFormData((previous) => ({ ...previous, is_email_public: checked }));
+    setError(null);
+    setSuccess(null);
+  }, []);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
@@ -198,7 +221,7 @@ export function ProfileSettingsTab() {
     }
 
     // Build update payload (only changed fields)
-    const updates: Record<string, string> = {};
+    const updates: Record<string, string | boolean> = {};
     if (formData.username !== user?.username) {
       updates.username = formData.username.trim().toLowerCase();
     }
@@ -216,6 +239,12 @@ export function ProfileSettingsTab() {
       let domainValue = formData.domain.trim();
       domainValue = domainValue.replace(/^https?:\/\//, '');
       updates.domain = domainValue;
+    }
+    if (formData.bio !== (user?.bio ?? '')) {
+      updates.bio = formData.bio;
+    }
+    if (formData.is_email_public !== (user?.is_email_public ?? false)) {
+      updates.is_email_public = formData.is_email_public;
     }
 
     // If nothing changed, show message
@@ -252,7 +281,9 @@ export function ProfileSettingsTab() {
     formData.email !== user?.email ||
     formData.full_name !== (user?.full_name ?? '') ||
     formData.avatar_url !== (user?.avatar_url ?? '') ||
-    formData.domain !== (user?.domain ?? '');
+    formData.domain !== (user?.domain ?? '') ||
+    formData.bio !== (user?.bio ?? '') ||
+    formData.is_email_public !== (user?.is_email_public ?? false);
   /* eslint-enable @typescript-eslint/no-unnecessary-condition */
 
   const canSubmit =
@@ -347,6 +378,64 @@ export function ProfileSettingsTab() {
           onChange={handleInputChange('full_name')}
           isLoading={isLoading}
         />
+
+        {/* Public Profile Section */}
+        <div className='border-border mt-6 border-t pt-6'>
+          <div className='mb-4 flex items-center gap-2'>
+            <UserIcon className='text-muted-foreground h-4 w-4' />
+            <h4 className='text-muted-foreground text-sm font-medium'>Public profile</h4>
+          </div>
+          <p className='text-muted-foreground mb-4 text-xs'>
+            What anonymous viewers see at{' '}
+            <span className='font-mono'>/{user?.username ?? 'username'}</span>.
+          </p>
+
+          {/* Bio */}
+          <div className='space-y-2'>
+            <div className='flex items-center justify-between'>
+              <Label htmlFor='bio'>Bio</Label>
+              <span className='text-muted-foreground text-[11px] tabular-nums'>
+                {formData.bio.length}/{BIO_MAX_LENGTH}
+              </span>
+            </div>
+            <textarea
+              id='bio'
+              value={formData.bio}
+              onChange={handleBioChange}
+              placeholder='Tell others what you do, what you publish, or what you care about. Markdown is supported.'
+              disabled={isLoading}
+              rows={5}
+              maxLength={BIO_MAX_LENGTH}
+              className='font-inter border-border bg-background focus:ring-ring/30 w-full resize-y rounded-md border px-3 py-2 text-sm focus:ring-2 focus:outline-none'
+            />
+            <p className='text-muted-foreground text-xs'>
+              Supports Markdown. Headings, lists, links, and code blocks render on your profile.
+            </p>
+          </div>
+
+          {/* Email visibility toggle */}
+          <div className='border-border mt-5 flex items-start justify-between gap-4 rounded-lg border p-4'>
+            <div className='flex items-start gap-3'>
+              <Mail
+                className='text-muted-foreground mt-0.5 h-4 w-4 flex-shrink-0'
+                aria-hidden='true'
+              />
+              <div>
+                <p className='text-foreground text-sm font-medium'>Show email on public profile</p>
+                <p className='text-muted-foreground mt-1 text-xs'>
+                  When enabled, your email address is visible to anyone viewing your profile page.
+                  Off by default.
+                </p>
+              </div>
+            </div>
+            <Switch
+              checked={formData.is_email_public}
+              onCheckedChange={handleEmailVisibilityChange}
+              disabled={isLoading}
+              aria-label='Show email on public profile'
+            />
+          </div>
+        </div>
 
         {/* Endpoint Configuration Section */}
         <div className='border-border mt-6 border-t pt-6'>

--- a/components/frontend/src/components/settings/subscriptions-settings-tab.tsx
+++ b/components/frontend/src/components/settings/subscriptions-settings-tab.tsx
@@ -106,9 +106,11 @@ function SubscriptionCard({ subscription }: Readonly<{ subscription: XenditSubsc
 
   const liveBalance = balance ?? subscription.last_known_balance ?? 0;
   const label = subscription.endpoint_owner;
-  const targetPath = subscription.endpoint_slug
-    ? `/${subscription.endpoint_owner}/${subscription.endpoint_slug}`
-    : `/${subscription.endpoint_owner}`;
+  // Xendit wallets are scoped per-publisher, so the row always navigates to
+  // the publisher's profile page — not the specific endpoint that originally
+  // triggered funding (the same wallet is reusable across all endpoints owned
+  // by that publisher).
+  const targetPath = `/${subscription.endpoint_owner}`;
 
   const handleTopUp = useCallback(() => {
     openCheckoutWindow(subscription.payment_url);

--- a/components/frontend/src/components/user-profile/profile-about.tsx
+++ b/components/frontend/src/components/user-profile/profile-about.tsx
@@ -1,0 +1,76 @@
+import { useMemo } from 'react';
+
+import type { Components } from 'react-markdown';
+
+import ExternalLink from 'lucide-react/dist/esm/icons/external-link';
+
+import { Markdown } from '@/components/prompt-kit/markdown';
+
+interface ProfileAboutProps {
+  bio: string;
+}
+
+export function ProfileAbout({ bio }: Readonly<ProfileAboutProps>) {
+  const components = useMemo(
+    (): Components => ({
+      h1: ({ children }) => (
+        <h1 className='font-rubik text-foreground mt-4 mb-3 text-xl font-medium'>{children}</h1>
+      ),
+      h2: ({ children }) => (
+        <h2 className='font-rubik text-foreground mt-4 mb-2 text-lg font-medium'>{children}</h2>
+      ),
+      h3: ({ children }) => (
+        <h3 className='font-rubik text-foreground mt-3 mb-2 text-base font-medium'>{children}</h3>
+      ),
+      p: ({ children }) => <p className='font-inter text-muted-foreground mb-3'>{children}</p>,
+      ul: ({ children }) => <ul className='mb-3 list-disc space-y-1 pl-5'>{children}</ul>,
+      ol: ({ children }) => <ol className='mb-3 list-decimal space-y-1 pl-5'>{children}</ol>,
+      li: ({ children }) => <li className='font-inter text-muted-foreground'>{children}</li>,
+      a: ({ href, children }) => (
+        <a
+          href={href}
+          className='text-secondary hover:text-foreground inline-flex items-center gap-0.5 hover:underline'
+          target='_blank'
+          rel='noopener noreferrer'
+        >
+          {children}
+          <ExternalLink className='ml-0.5 inline-block h-3 w-3 flex-shrink-0' aria-hidden='true' />
+          <span className='sr-only'>(opens in new tab)</span>
+        </a>
+      ),
+      code: ({ className, children }) => {
+        const isInline = !className;
+        return isInline ? (
+          <code className='bg-muted text-foreground rounded px-1 py-0.5 font-mono text-xs'>
+            {children}
+          </code>
+        ) : (
+          <code className='block'>{children}</code>
+        );
+      },
+      blockquote: ({ children }) => (
+        <blockquote className='border-border text-muted-foreground my-3 border-l-4 pl-4 italic'>
+          {children}
+        </blockquote>
+      )
+    }),
+    []
+  );
+
+  return (
+    <section
+      aria-labelledby='profile-about-heading'
+      className='border-border bg-card mb-6 rounded-xl border p-6'
+    >
+      <h2
+        id='profile-about-heading'
+        className='font-rubik text-muted-foreground mb-3 text-xs tracking-wider uppercase'
+      >
+        About
+      </h2>
+      <div className='prose prose-sm max-w-none'>
+        <Markdown components={components}>{bio}</Markdown>
+      </div>
+    </section>
+  );
+}

--- a/components/frontend/src/components/user-profile/profile-endpoints-list.tsx
+++ b/components/frontend/src/components/user-profile/profile-endpoints-list.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import type { ChatSource, EndpointType } from '@/lib/types';
+
+import Calendar from 'lucide-react/dist/esm/icons/calendar';
+import ChevronRight from 'lucide-react/dist/esm/icons/chevron-right';
+import Package from 'lucide-react/dist/esm/icons/package';
+import Star from 'lucide-react/dist/esm/icons/star';
+import { Link } from 'react-router-dom';
+
+import { EndpointTypeIcon } from '@/components/endpoint-type-icon';
+import { Badge } from '@/components/ui/badge';
+import {
+  Pagination,
+  PaginationButton,
+  PaginationContent,
+  PaginationItem,
+  PaginationNext,
+  PaginationPrevious
+} from '@/components/ui/pagination';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { isDataSourceEndpoint, isModelEndpoint } from '@/lib/endpoint-utils';
+
+type Filter = 'all' | 'model' | 'data_source' | 'agent';
+type SortKey = 'updated' | 'stars' | 'name';
+
+const PAGE_SIZE = 20;
+
+interface ProfileEndpointsListProps {
+  username: string;
+  endpoints: ChatSource[];
+  isOwnProfile: boolean;
+}
+
+function matchesFilter(endpoint: ChatSource, filter: Filter): boolean {
+  if (filter === 'all') return true;
+  if (filter === 'model') return isModelEndpoint(endpoint.type);
+  if (filter === 'data_source') return isDataSourceEndpoint(endpoint.type);
+  return endpoint.type === 'agent';
+}
+
+function countByType(endpoints: ChatSource[], type: EndpointType): number {
+  return endpoints.filter((ep) => ep.type === type).length;
+}
+
+export function ProfileEndpointsList({
+  username,
+  endpoints,
+  isOwnProfile
+}: Readonly<ProfileEndpointsListProps>) {
+  const [filter, setFilter] = useState<Filter>('all');
+  const [sortKey, setSortKey] = useState<SortKey>('updated');
+  const [page, setPage] = useState(1);
+
+  // Reset to first page when filter or sort changes — otherwise users can land
+  // on a page that no longer exists for the new filter.
+  useEffect(() => {
+    setPage(1);
+  }, [filter, sortKey]);
+
+  const counts = useMemo(
+    () => ({
+      all: endpoints.length,
+      model: countByType(endpoints, 'model'),
+      data_source: countByType(endpoints, 'data_source'),
+      model_data_source: countByType(endpoints, 'model_data_source'),
+      agent: countByType(endpoints, 'agent')
+    }),
+    [endpoints]
+  );
+
+  const filtered = useMemo(() => {
+    const matched = endpoints.filter((ep) => matchesFilter(ep, filter));
+    if (sortKey === 'stars') return matched.toSorted((a, b) => b.stars_count - a.stars_count);
+    if (sortKey === 'name') return matched.toSorted((a, b) => a.name.localeCompare(b.name));
+    const withTs = matched.map((ep) => [Date.parse(ep.updated_at), ep] as const);
+    withTs.sort((a, b) => b[0] - a[0]);
+    return withTs.map(([, ep]) => ep);
+  }, [endpoints, filter, sortKey]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages);
+  const pageStart = (safePage - 1) * PAGE_SIZE;
+  const pageEnd = Math.min(pageStart + PAGE_SIZE, filtered.length);
+  const paginated = filtered.slice(pageStart, pageEnd);
+
+  // Hide tabs that have zero endpoints (avoid noisy filter strip).
+  const allTabs: { value: Filter; label: string; count: number }[] = [
+    { value: 'all', label: 'All', count: counts.all },
+    { value: 'model', label: 'Models', count: counts.model + counts.model_data_source },
+    {
+      value: 'data_source',
+      label: 'Data Sources',
+      count: counts.data_source + counts.model_data_source
+    },
+    { value: 'agent', label: 'Agents', count: counts.agent }
+  ];
+  const tabConfig = allTabs.filter((tab) => tab.value === 'all' || tab.count > 0);
+
+  const getEmptyMessage = (): string => {
+    if (endpoints.length > 0) return 'No endpoints match the current filter.';
+    if (isOwnProfile) return "You haven't published any endpoints yet.";
+    return `@${username} hasn't published any endpoints yet.`;
+  };
+
+  return (
+    <section aria-labelledby='profile-endpoints-heading' className='space-y-4'>
+      <div className='flex flex-wrap items-center justify-between gap-3'>
+        <h2
+          id='profile-endpoints-heading'
+          className='font-rubik text-foreground text-xl font-medium'
+        >
+          Endpoints
+          <span className='text-muted-foreground ml-2 text-sm font-normal'>{endpoints.length}</span>
+        </h2>
+
+        <div className='flex flex-wrap items-center gap-3'>
+          <Tabs
+            value={filter}
+            onValueChange={(value) => {
+              setFilter(value as Filter);
+            }}
+          >
+            <TabsList className='gap-1 bg-transparent'>
+              {tabConfig.map((tab) => (
+                <TabsTrigger
+                  key={tab.value}
+                  value={tab.value}
+                  className='font-inter data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=inactive]:text-muted-foreground data-[state=inactive]:hover:bg-muted data-[state=inactive]:hover:text-foreground flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs data-[state=active]:shadow-none'
+                >
+                  {tab.label}
+                  <span className='text-[10px] tabular-nums opacity-70'>{tab.count}</span>
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+
+          <label className='flex items-center gap-2 text-xs'>
+            <span className='font-inter text-muted-foreground'>Sort</span>
+            <select
+              value={sortKey}
+              onChange={(e) => {
+                setSortKey(e.target.value as SortKey);
+              }}
+              className='font-inter border-border bg-background text-foreground focus:ring-ring/30 rounded-md border px-2 py-1.5 text-xs focus:ring-2 focus:outline-none'
+              aria-label='Sort endpoints'
+            >
+              <option value='updated'>Recently updated</option>
+              <option value='stars'>Most stars</option>
+              <option value='name'>Name (A–Z)</option>
+            </select>
+          </label>
+        </div>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className='border-border bg-card rounded-xl border p-10 text-center'>
+          <p className='font-inter text-muted-foreground text-sm'>{getEmptyMessage()}</p>
+        </div>
+      ) : (
+        <ul
+          className='border-border bg-card divide-border divide-y rounded-xl border'
+          aria-label={`Public endpoints for @${username}`}
+        >
+          {paginated.map((endpoint) => (
+            <li key={endpoint.id}>
+              <Link
+                to={`/${username}/${endpoint.slug}`}
+                className='group flex items-start gap-4 p-4 transition-colors hover:bg-[var(--accent)]'
+              >
+                <div className='mt-1'>
+                  <EndpointTypeIcon type={endpoint.type} />
+                </div>
+
+                <div className='min-w-0 flex-1'>
+                  <div className='flex flex-wrap items-baseline gap-x-2 gap-y-1'>
+                    <h3 className='font-inter text-foreground group-hover:text-primary truncate text-sm font-semibold transition-colors'>
+                      {endpoint.name}
+                    </h3>
+                    <span className='text-muted-foreground font-mono text-xs'>
+                      @{username}/{endpoint.slug}
+                    </span>
+                  </div>
+
+                  {endpoint.description ? (
+                    <p className='font-inter text-muted-foreground mt-1 line-clamp-2 text-xs'>
+                      {endpoint.description}
+                    </p>
+                  ) : null}
+
+                  {endpoint.tags.length > 0 ? (
+                    <div className='mt-2 flex flex-wrap gap-1'>
+                      {endpoint.tags.slice(0, 4).map((tag) => (
+                        <Badge
+                          key={tag}
+                          variant='secondary'
+                          className='font-inter px-1.5 py-0 text-[10px]'
+                        >
+                          {tag}
+                        </Badge>
+                      ))}
+                      {endpoint.tags.length > 4 ? (
+                        <Badge variant='secondary' className='font-inter px-1.5 py-0 text-[10px]'>
+                          +{endpoint.tags.length - 4}
+                        </Badge>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </div>
+
+                <div className='hidden flex-shrink-0 flex-col items-end gap-1 text-xs sm:flex'>
+                  <div className='text-muted-foreground flex items-center gap-3'>
+                    {endpoint.stars_count > 0 ? (
+                      <span className='inline-flex items-center gap-1 tabular-nums'>
+                        <Star className='h-3 w-3' aria-hidden='true' />
+                        {endpoint.stars_count}
+                      </span>
+                    ) : null}
+                    <span className='inline-flex items-center gap-1'>
+                      <Package className='h-3 w-3' aria-hidden='true' />v{endpoint.version}
+                    </span>
+                  </div>
+                  <span className='text-muted-foreground inline-flex items-center gap-1'>
+                    <Calendar className='h-3 w-3' aria-hidden='true' />
+                    {endpoint.updated}
+                  </span>
+                </div>
+
+                <ChevronRight
+                  className='text-muted-foreground/60 mt-1 h-4 w-4 flex-shrink-0 transition-transform group-hover:translate-x-0.5'
+                  aria-hidden='true'
+                />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {totalPages > 1 ? (
+        <div className='flex flex-col items-center gap-3 pt-2 sm:flex-row sm:justify-between'>
+          <p className='font-inter text-muted-foreground text-xs tabular-nums' aria-live='polite'>
+            Showing {pageStart + 1}–{pageEnd} of {filtered.length}
+          </p>
+          <Pagination>
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationPrevious
+                  onClick={() => {
+                    setPage((p) => Math.max(1, p - 1));
+                  }}
+                  disabled={safePage === 1}
+                  aria-disabled={safePage === 1}
+                />
+              </PaginationItem>
+              <PaginationItem>
+                <PaginationButton isActive disabled className='pointer-events-none'>
+                  {safePage} / {totalPages}
+                </PaginationButton>
+              </PaginationItem>
+              <PaginationItem>
+                <PaginationNext
+                  onClick={() => {
+                    setPage((p) => Math.min(totalPages, p + 1));
+                  }}
+                  disabled={safePage === totalPages}
+                  aria-disabled={safePage === totalPages}
+                />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/components/frontend/src/components/user-profile/profile-hero.tsx
+++ b/components/frontend/src/components/user-profile/profile-hero.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react';
+
+import type { PublicUserProfile } from '@/lib/types';
+
+import Check from 'lucide-react/dist/esm/icons/check';
+import Copy from 'lucide-react/dist/esm/icons/copy';
+import ExternalLink from 'lucide-react/dist/esm/icons/external-link';
+import Globe from 'lucide-react/dist/esm/icons/globe';
+import Mail from 'lucide-react/dist/esm/icons/mail';
+import Pencil from 'lucide-react/dist/esm/icons/pencil';
+import UserIcon from 'lucide-react/dist/esm/icons/user';
+import { Link } from 'react-router-dom';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { formatDateLong } from '@/lib/date-utils';
+
+interface ProfileHeroProps {
+  username: string;
+  profile: PublicUserProfile | null;
+  isOwnProfile: boolean;
+}
+
+function getInitials(name: string, fallback: string): string {
+  const source = (name || fallback).trim();
+  if (!source) return '?';
+  const parts = source.split(/\s+/).filter(Boolean);
+  const initials = parts.slice(0, 2).map((p) => p[0]?.toUpperCase() ?? '');
+  return initials.join('') || (source[0]?.toUpperCase() ?? '?');
+}
+
+function normalizeDomainHref(domain: string): string {
+  if (/^https?:\/\//i.test(domain)) return domain;
+  return `https://${domain}`;
+}
+
+export function ProfileHero({ username, profile, isOwnProfile }: Readonly<ProfileHeroProps>) {
+  const [copied, setCopied] = useState(false);
+
+  const trimmedFullName = profile?.full_name.trim() ?? '';
+  const displayName = trimmedFullName === '' ? username : trimmedFullName;
+  const initials = getInitials(displayName, username);
+  const memberSince = profile?.created_at ? formatDateLong(profile.created_at) : null;
+  const showEmail = Boolean(profile?.email);
+  const showDomain = Boolean(profile?.domain);
+
+  const handleCopyEmail = () => {
+    if (!profile?.email) return;
+    void navigator.clipboard.writeText(profile.email).then(() => {
+      setCopied(true);
+      setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    });
+  };
+
+  return (
+    <header className='border-border bg-card border-b'>
+      <div className='mx-auto max-w-5xl px-6 py-8'>
+        <div className='flex flex-col gap-6 sm:flex-row sm:items-start'>
+          {/* Avatar */}
+          <div
+            className='from-secondary to-chart-3 flex h-24 w-24 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br text-white shadow-sm'
+            role='img'
+            aria-label={`Avatar for ${displayName}`}
+          >
+            {profile?.avatar_url ? (
+              <img
+                src={profile.avatar_url}
+                alt={displayName}
+                width={96}
+                height={96}
+                loading='lazy'
+                className='h-24 w-24 rounded-full object-cover'
+              />
+            ) : (
+              <span className='font-rubik text-2xl font-medium tracking-wide'>{initials}</span>
+            )}
+          </div>
+
+          {/* Identity + actions */}
+          <div className='min-w-0 flex-1'>
+            <div className='flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between'>
+              <div className='min-w-0'>
+                <h1 className='font-rubik text-foreground truncate text-3xl font-medium'>
+                  {displayName}
+                </h1>
+                <div className='mt-1 flex items-center gap-2'>
+                  <p className='text-muted-foreground truncate font-mono text-sm'>@{username}</p>
+                  {profile?.role && profile.role !== 'user' ? (
+                    <Badge
+                      variant='outline'
+                      className='font-inter text-[10px] tracking-wider uppercase'
+                    >
+                      {profile.role}
+                    </Badge>
+                  ) : null}
+                </div>
+              </div>
+
+              {isOwnProfile ? (
+                <div className='flex flex-shrink-0 items-center gap-2'>
+                  <Button asChild variant='outline' size='sm' className='gap-2'>
+                    <Link to='/profile'>
+                      <Pencil className='h-3.5 w-3.5' aria-hidden='true' />
+                      Edit profile
+                    </Link>
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+
+            {/* Contact row */}
+            {(showEmail || showDomain || memberSince) && (
+              <div className='mt-4 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm'>
+                {showEmail ? (
+                  <div className='text-muted-foreground flex items-center gap-1.5'>
+                    <Mail className='h-3.5 w-3.5' aria-hidden='true' />
+                    <a
+                      href={`mailto:${profile?.email ?? ''}`}
+                      className='font-inter hover:text-foreground transition-colors'
+                    >
+                      {profile?.email}
+                    </a>
+                    <button
+                      type='button'
+                      onClick={handleCopyEmail}
+                      className='hover:text-foreground ml-0.5 inline-flex h-5 w-5 items-center justify-center rounded transition-colors'
+                      aria-label='Copy email address'
+                    >
+                      {copied ? (
+                        <Check className='h-3 w-3 text-green-500' aria-hidden='true' />
+                      ) : (
+                        <Copy className='h-3 w-3' aria-hidden='true' />
+                      )}
+                    </button>
+                  </div>
+                ) : null}
+
+                {showDomain && profile?.domain ? (
+                  <div className='text-muted-foreground flex items-center gap-1.5'>
+                    <Globe className='h-3.5 w-3.5' aria-hidden='true' />
+                    <a
+                      href={normalizeDomainHref(profile.domain)}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='font-inter hover:text-foreground inline-flex items-center gap-0.5 transition-colors'
+                    >
+                      {profile.domain.replace(/^https?:\/\//, '')}
+                      <ExternalLink className='h-3 w-3' aria-hidden='true' />
+                    </a>
+                  </div>
+                ) : null}
+
+                {memberSince ? (
+                  <div className='text-muted-foreground flex items-center gap-1.5'>
+                    <UserIcon className='h-3.5 w-3.5' aria-hidden='true' />
+                    <span className='font-inter'>Joined {memberSince}</span>
+                  </div>
+                ) : null}
+              </div>
+            )}
+
+            {isOwnProfile ? (
+              <p className='font-inter text-muted-foreground mt-4 text-xs'>
+                This is how others see your public profile.
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/components/frontend/src/components/user-profile/profile-skeleton.tsx
+++ b/components/frontend/src/components/user-profile/profile-skeleton.tsx
@@ -1,0 +1,54 @@
+/**
+ * Loading skeleton for the public user profile page.
+ *
+ * Mirrors the layout of profile-hero + stats-strip + endpoints-list so the
+ * page doesn't shift when data resolves.
+ */
+export function ProfileSkeleton() {
+  return (
+    <div className='bg-background min-h-screen' role='status' aria-label='Loading user profile'>
+      {/* Hero band */}
+      <div className='border-border bg-card border-b'>
+        <div className='mx-auto max-w-5xl px-6 py-8'>
+          <div className='flex flex-col gap-6 sm:flex-row sm:items-center'>
+            <div className='bg-muted h-24 w-24 flex-shrink-0 animate-pulse rounded-full' />
+            <div className='flex-1 space-y-3'>
+              <div className='bg-muted h-8 w-64 animate-pulse rounded' />
+              <div className='bg-muted h-4 w-40 animate-pulse rounded' />
+              <div className='bg-muted h-4 w-80 animate-pulse rounded' />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Stats strip */}
+      <div className='border-border bg-background border-b'>
+        <div className='mx-auto flex max-w-5xl flex-wrap gap-8 px-6 py-4'>
+          {[0, 1, 2, 3].map((index) => (
+            <div key={index} className='space-y-2'>
+              <div className='bg-muted h-3 w-16 animate-pulse rounded' />
+              <div className='bg-muted h-5 w-12 animate-pulse rounded' />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* List */}
+      <div className='mx-auto max-w-5xl px-6 py-8'>
+        <div className='bg-muted mb-6 h-9 w-72 animate-pulse rounded' />
+        <div className='border-border bg-card divide-border divide-y rounded-xl border'>
+          {[0, 1, 2, 3, 4].map((index) => (
+            <div key={index} className='flex items-center gap-4 p-4'>
+              <div className='bg-muted h-5 w-5 flex-shrink-0 animate-pulse rounded' />
+              <div className='flex-1 space-y-2'>
+                <div className='bg-muted h-4 w-48 animate-pulse rounded' />
+                <div className='bg-muted h-3 w-72 animate-pulse rounded' />
+              </div>
+              <div className='bg-muted h-4 w-20 animate-pulse rounded' />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/frontend/src/components/user-profile/profile-stats-strip.tsx
+++ b/components/frontend/src/components/user-profile/profile-stats-strip.tsx
@@ -1,0 +1,70 @@
+import type { ChatSource } from '@/lib/types';
+
+import Clock from 'lucide-react/dist/esm/icons/clock';
+import Package from 'lucide-react/dist/esm/icons/package';
+import Star from 'lucide-react/dist/esm/icons/star';
+
+import { formatRelativeTime } from '@/lib/date-utils';
+
+interface ProfileStatsStripProps {
+  endpoints: ChatSource[];
+}
+
+interface StatTileProps {
+  icon: React.ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
+  label: string;
+  value: string;
+}
+
+function StatTile({ icon: Icon, label, value }: Readonly<StatTileProps>) {
+  return (
+    <div className='flex items-center gap-2'>
+      <Icon className='text-muted-foreground h-4 w-4' aria-hidden={true} />
+      <div className='flex flex-col'>
+        <span className='font-rubik text-foreground text-sm font-medium tabular-nums'>{value}</span>
+        <span className='font-inter text-muted-foreground text-[11px] tracking-wide uppercase'>
+          {label}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function ProfileStatsStrip({ endpoints }: Readonly<ProfileStatsStripProps>) {
+  const endpointCount = endpoints.length;
+  let totalStars = 0;
+  let maxTs = 0;
+  let mostRecentUpdate: string | null = null;
+  for (const ep of endpoints) {
+    totalStars += ep.stars_count;
+    const ts = Date.parse(ep.updated_at);
+    if (ts > maxTs) {
+      maxTs = ts;
+      mostRecentUpdate = ep.updated_at;
+    }
+  }
+
+  return (
+    <div className='border-border bg-background border-b'>
+      <div className='mx-auto flex max-w-5xl flex-wrap gap-x-10 gap-y-4 px-6 py-4'>
+        <StatTile
+          icon={Package}
+          label={endpointCount === 1 ? 'endpoint' : 'endpoints'}
+          value={String(endpointCount)}
+        />
+        <StatTile
+          icon={Star}
+          label={totalStars === 1 ? 'star' : 'stars'}
+          value={String(totalStars)}
+        />
+        {mostRecentUpdate ? (
+          <StatTile
+            icon={Clock}
+            label='last updated'
+            value={formatRelativeTime(mostRecentUpdate)}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/frontend/src/components/user-profile/user-profile-view.tsx
+++ b/components/frontend/src/components/user-profile/user-profile-view.tsx
@@ -1,0 +1,86 @@
+import { Link } from 'react-router-dom';
+
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/context/auth-context';
+import { useEndpointsByOwner } from '@/hooks/use-endpoint-queries';
+import { useUserProfile } from '@/hooks/use-user-profile';
+
+import { ProfileAbout } from './profile-about';
+import { ProfileEndpointsList } from './profile-endpoints-list';
+import { ProfileHero } from './profile-hero';
+import { ProfileSkeleton } from './profile-skeleton';
+import { ProfileStatsStrip } from './profile-stats-strip';
+
+interface UserProfileViewProps {
+  username: string;
+}
+
+export function UserProfileView({ username }: Readonly<UserProfileViewProps>) {
+  const normalizedUsername = username.toLowerCase();
+  const { user } = useAuth();
+  const isOwnProfile = user?.username.toLowerCase() === normalizedUsername;
+
+  const profileQuery = useUserProfile(normalizedUsername);
+  const endpointsQuery = useEndpointsByOwner(normalizedUsername);
+
+  const isLoading = profileQuery.isLoading || endpointsQuery.isLoading;
+  if (isLoading) {
+    return <ProfileSkeleton />;
+  }
+
+  const profile = profileQuery.data ?? null;
+  const endpoints = endpointsQuery.data ?? [];
+
+  // 404: profile fetch returned null AND user has no public endpoints to anchor
+  // identity. Profile-fetch errors (network/5xx) also land here so the user
+  // sees something actionable rather than a blank page.
+  if (!profile && endpoints.length === 0) {
+    const isError = profileQuery.isError;
+    return (
+      <div className='bg-background flex min-h-screen flex-col items-center justify-center px-6 py-16 text-center'>
+        <h1 className='font-rubik text-foreground mb-2 text-2xl font-medium'>
+          {isError ? 'Profile unavailable' : 'User not found'}
+        </h1>
+        <p className='font-inter text-muted-foreground mb-6 max-w-md text-sm'>
+          {isError ? (
+            <>
+              We hit an error loading the profile for{' '}
+              <span className='font-mono'>@{normalizedUsername}</span>. Please try again in a
+              moment.
+            </>
+          ) : (
+            <>
+              We couldn&rsquo;t find a public profile for{' '}
+              <span className='font-mono'>@{normalizedUsername}</span>. The account may be
+              deactivated or the URL may contain a typo.
+            </>
+          )}
+        </p>
+        <div className='flex gap-3'>
+          <Button asChild variant='outline'>
+            <Link to='/browse'>Browse endpoints</Link>
+          </Button>
+          <Button asChild>
+            <Link to='/'>Go home</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='bg-background min-h-screen pb-24'>
+      <ProfileHero username={normalizedUsername} profile={profile} isOwnProfile={isOwnProfile} />
+      <ProfileStatsStrip endpoints={endpoints} />
+
+      <main className='mx-auto max-w-5xl px-6 py-8'>
+        {profile?.bio ? <ProfileAbout bio={profile.bio} /> : null}
+        <ProfileEndpointsList
+          username={normalizedUsername}
+          endpoints={endpoints}
+          isOwnProfile={isOwnProfile}
+        />
+      </main>
+    </div>
+  );
+}

--- a/components/frontend/src/context/auth-context.tsx
+++ b/components/frontend/src/context/auth-context.tsx
@@ -145,7 +145,9 @@ export function mapSdkUserToFrontend(sdkUser: SdkUser): User {
     created_at: sdkUser.createdAt.toISOString(),
     updated_at: sdkUser.updatedAt?.toISOString() ?? sdkUser.createdAt.toISOString(),
     domain: sdkUser.domain ?? undefined,
-    aggregator_url: sdkUser.aggregatorUrl ?? undefined
+    aggregator_url: sdkUser.aggregatorUrl ?? undefined,
+    bio: sdkUser.bio ?? undefined,
+    is_email_public: sdkUser.isEmailPublic ?? false
   };
 }
 

--- a/components/frontend/src/hooks/use-endpoint-queries.ts
+++ b/components/frontend/src/hooks/use-endpoint-queries.ts
@@ -6,6 +6,7 @@ import {
   getGroupedPublicEndpoints,
   getPublicEndpointByPath,
   getPublicEndpoints,
+  getPublicEndpointsByOwner,
   getPublicEndpointsPaginated,
   getTotalEndpointsCount,
   getTrendingEndpoints
@@ -82,5 +83,18 @@ export function useEndpointByPath(path: string | undefined) {
     queryKey: endpointKeys.byPath(path ?? ''),
     queryFn: () => (path ? getPublicEndpointByPath(path) : null),
     enabled: !!path
+  });
+}
+
+/**
+ * Hook for fetching all public endpoints owned by a single user.
+ *
+ * Used by the public user profile page to render the endpoints list.
+ */
+export function useEndpointsByOwner(owner: string | undefined) {
+  return useQuery({
+    queryKey: endpointKeys.byOwner(owner ?? ''),
+    queryFn: () => (owner ? getPublicEndpointsByOwner(owner) : []),
+    enabled: !!owner
   });
 }

--- a/components/frontend/src/hooks/use-user-profile.ts
+++ b/components/frontend/src/hooks/use-user-profile.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { userKeys } from '@/lib/query-keys';
+import { getPublicUserProfileAPI } from '@/lib/sdk-client';
+
+/**
+ * Hook for fetching a user's sanitized public profile by username.
+ *
+ * Returns ``null`` (rather than throwing) for 404s so callers can fall back
+ * to identity inferred from the user's endpoints.
+ */
+export function useUserProfile(username: string | undefined) {
+  return useQuery({
+    queryKey: userKeys.publicProfile(username ?? ''),
+    queryFn: () => (username ? getPublicUserProfileAPI(username) : null),
+    enabled: !!username
+  });
+}

--- a/components/frontend/src/lib/endpoint-utils.ts
+++ b/components/frontend/src/lib/endpoint-utils.ts
@@ -240,6 +240,7 @@ export function mapEndpointPublicToSource(endpoint: SdkEndpointPublic): ChatSour
     description: endpoint.description,
     type: endpoint.type,
     updated: formatRelativeTime(updatedDate),
+    updated_at: updatedDate.toISOString(),
     status: status,
     slug: endpoint.slug,
     stars_count: endpoint.starsCount,

--- a/components/frontend/src/lib/query-keys.ts
+++ b/components/frontend/src/lib/query-keys.ts
@@ -15,7 +15,13 @@ export const endpointKeys = {
     [...endpointKeys.all, 'public', 'grouped', maxPerOwner] as const,
   trending: (limit: number) => [...endpointKeys.all, 'trending', limit] as const,
   count: () => [...endpointKeys.all, 'count'] as const,
-  byPath: (path: string) => [...endpointKeys.all, 'byPath', path] as const
+  byPath: (path: string) => [...endpointKeys.all, 'byPath', path] as const,
+  byOwner: (owner: string) => [...endpointKeys.all, 'byOwner', owner] as const
+};
+
+export const userKeys = {
+  all: ['users'] as const,
+  publicProfile: (username: string) => [...userKeys.all, 'public', username] as const
 };
 
 export const modelKeys = {

--- a/components/frontend/src/lib/sdk-client.ts
+++ b/components/frontend/src/lib/sdk-client.ts
@@ -6,6 +6,7 @@ import type {
   AvailabilityResponse,
   User as FrontendUser,
   PasswordChange,
+  PublicUserProfile,
   UserRole,
   UserUpdate
 } from './types';
@@ -263,7 +264,9 @@ export async function updateUserProfileAPI(profileData: UserUpdate): Promise<Fro
     fullName: profileData.full_name,
     avatarUrl: profileData.avatar_url,
     domain: profileData.domain,
-    aggregatorUrl: profileData.aggregator_url
+    aggregatorUrl: profileData.aggregator_url,
+    bio: profileData.bio,
+    isEmailPublic: profileData.is_email_public
   });
 
   // Convert SDK User to frontend User format
@@ -279,8 +282,34 @@ export async function updateUserProfileAPI(profileData: UserUpdate): Promise<Fro
     created_at: sdkUser.createdAt.toISOString(),
     updated_at: sdkUser.updatedAt?.toISOString() ?? sdkUser.createdAt.toISOString(),
     domain: sdkUser.domain ?? undefined,
-    aggregator_url: sdkUser.aggregatorUrl ?? undefined
+    aggregator_url: sdkUser.aggregatorUrl ?? undefined,
+    bio: sdkUser.bio ?? undefined,
+    is_email_public: sdkUser.isEmailPublic ?? false
   };
+}
+
+/**
+ * Fetch a user's sanitized public profile by username.
+ *
+ * Backed by the unauthenticated ``GET /api/v1/users/public/{username}`` route.
+ * Returns ``null`` for 404s so callers can render a not-found state without
+ * try/catch. All other errors propagate so React Query can surface a real
+ * error UI instead of silently masking network failures as not-found.
+ */
+export async function getPublicUserProfileAPI(username: string): Promise<PublicUserProfile | null> {
+  const baseUrl = getBaseUrl() ?? '';
+  const response = await fetch(`${baseUrl}/api/v1/users/public/${encodeURIComponent(username)}`, {
+    method: 'GET'
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`Failed to fetch user profile (status ${String(response.status)})`);
+  }
+
+  return (await response.json()) as PublicUserProfile;
 }
 
 /**

--- a/components/frontend/src/lib/search-service.ts
+++ b/components/frontend/src/lib/search-service.ts
@@ -140,6 +140,7 @@ export async function searchEndpoints(
         tags: result.tags,
         status: 'active' as const, // Search results are assumed active
         updated: formatRelativeTime(new Date(result.updated_at)),
+        updated_at: result.updated_at,
         stars_count: result.stars_count,
         version: result.version,
         readme: result.readme,

--- a/components/frontend/src/lib/types.ts
+++ b/components/frontend/src/lib/types.ts
@@ -47,6 +47,10 @@ export interface User {
   domain?: string;
   /** Custom aggregator URL for RAG/chat workflows */
   aggregator_url?: string;
+  /** Markdown bio shown on the user's public profile */
+  bio?: string;
+  /** Whether the user's email is shown on their public profile */
+  is_email_public?: boolean;
 }
 
 // Authentication request schemas
@@ -99,6 +103,27 @@ export interface UserUpdate {
   domain?: string;
   /** Custom aggregator URL for RAG/chat workflows */
   aggregator_url?: string;
+  /** Markdown bio shown on the user's public profile */
+  bio?: string;
+  /** Whether the user's email is shown on their public profile */
+  is_email_public?: boolean;
+}
+
+// =============================================================================
+// Public User Profile (for /:username page)
+// =============================================================================
+
+export interface PublicUserProfile {
+  username: string;
+  full_name: string;
+  avatar_url?: string;
+  role: UserRole;
+  bio?: string;
+  domain?: string;
+  /** Only present when the user has opted in to public email visibility */
+  email?: string;
+  is_email_public: boolean;
+  created_at: string;
 }
 
 // =============================================================================
@@ -262,7 +287,8 @@ export interface ChatSource {
   tags: string[]; // Tags for categorization
   description: string;
   type: EndpointType; // Endpoint type (model or data_source)
-  updated: string; // Mapped from updated_at
+  updated: string; // Pre-formatted relative time, e.g. "2 days ago" (mapped from updated_at)
+  updated_at: string; // Raw ISO 8601 timestamp — use this for sorting/comparisons
   status: 'active' | 'warning' | 'inactive'; // Derived from backend data
   slug: string; // Backend URL identifier
   stars_count: number;

--- a/components/frontend/src/pages/user-profile.tsx
+++ b/components/frontend/src/pages/user-profile.tsx
@@ -1,0 +1,25 @@
+import { useParams } from 'react-router-dom';
+
+import { UserProfileView } from '@/components/user-profile/user-profile-view';
+
+/**
+ * Public user profile page rendered at ``/:username`` (e.g. ``/cambridge-press-oa``).
+ *
+ * Coexists with the GitHub-style ``/:username/:slug`` endpoint detail route —
+ * the segment count differs so the routes never collide. Reserved top-level
+ * paths (``browse``, ``chat``, ``profile``, etc.) are registered explicitly in
+ * ``app.tsx`` and win on react-router specificity.
+ */
+export default function UserProfilePage() {
+  const { username } = useParams<{ username: string }>();
+
+  if (!username) {
+    return (
+      <div className='flex min-h-[400px] items-center justify-center'>
+        <p className='text-muted-foreground'>Invalid profile URL</p>
+      </div>
+    );
+  }
+
+  return <UserProfileView username={username} />;
+}

--- a/components/frontend/src/test/mocks/fixtures.ts
+++ b/components/frontend/src/test/mocks/fixtures.ts
@@ -55,6 +55,7 @@ export function createMockChatSource(overrides: Partial<ChatSource> = {}): ChatS
     description: 'A test data source',
     type: 'data_source',
     updated: '2 days ago',
+    updated_at: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
     status: 'active',
     slug: 'test-source',
     stars_count: 5,

--- a/sdk/typescript/src/models/user.ts
+++ b/sdk/typescript/src/models/user.ts
@@ -17,6 +17,10 @@ export interface User {
   readonly domain: string | null;
   /** Custom aggregator URL for RAG/chat workflows */
   readonly aggregatorUrl: string | null;
+  /** Markdown bio shown on the user's public profile */
+  readonly bio?: string | null;
+  /** Whether the user's email is shown on their public profile */
+  readonly isEmailPublic?: boolean;
 }
 
 /**
@@ -64,6 +68,10 @@ export interface UserUpdateInput {
   domain?: string;
   /** Custom aggregator URL for RAG/chat workflows */
   aggregatorUrl?: string;
+  /** Markdown bio shown on the user's public profile */
+  bio?: string;
+  /** Whether the user's email is shown on their public profile */
+  isEmailPublic?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a public, anonymous-accessible user profile page at `/:username` with bio (Markdown), opt-in email visibility, and the user's public endpoints (filterable by type, sortable by recency/stars/name, paginated).
- Backend: new `GET /api/v1/users/public/{username}` returns a sanitized `PublicUserProfile`; new `bio` (TEXT) and `is_email_public` (BOOL, default false) columns on `users` via Alembic migration `012_user_public_profile`.
- Frontend: new page + components (`UserProfileView`, `ProfileHero`, `ProfileStatsStrip`, `ProfileAbout`, `ProfileEndpointsList`, `ProfileSkeleton`), `useUserProfile` hook, and bio + email-visibility controls in profile settings (uses the existing `<Switch>` component).
- Side fixes: Xendit subscription rows now route to the publisher's profile (wallets are per-publisher, so the per-endpoint route was misleading); extracts the duplicated endpoint-type icon (with the `model_data_source` compound branch) into a shared `<EndpointTypeIcon>` and migrates `browse-view` to use it.

## Test plan

- [ ] Run `make test` (backend + frontend); 251 frontend tests should pass
- [ ] Apply migration `012_user_public_profile` to a dev DB and confirm `bio` / `is_email_public` columns exist with `is_email_public=false` default
- [ ] As an anonymous viewer, navigate to `/<existing-user>` — expect hero, stats, About (if bio set), endpoints list
- [ ] Navigate to `/<unknown-user>` — expect "User not found" page
- [ ] In Settings → Profile, set a bio and toggle "Show email on public profile"; reload the public profile and verify email appears only when toggled on
- [ ] Filter endpoints by Models / Data Sources tabs and verify `model_data_source` endpoints appear in BOTH tabs (regression check on the count-vs-filter mismatch this PR fixed)
- [ ] In Wallet → top-up flow, verify subscription rows now navigate to `/<publisher>` (not `/<publisher>/<endpoint>`)
- [ ] Trigger a 5xx on `GET /users/public/{username}` — verify the page shows "Profile unavailable" rather than masking it as "User not found"