### PR TITLE
feat(wallet): collapse Xendit subscriptions by publisher

### DIFF
--- a/components/backend/src/syfthub/api/endpoints/wallet.py
+++ b/components/backend/src/syfthub/api/endpoints/wallet.py
@@ -349,8 +349,12 @@ async def list_xendit_subscriptions(
         Depends(get_user_xendit_subscription_repository),
     ],
 ) -> XenditSubscriptionListResponse:
-    """List every publisher wallet the current user has funded."""
-    rows = repo.list_for_user(current_user.id)
+    """List publisher wallets the current user has funded, one per owner.
+
+    Multiple ``credits_url`` rows under the same ``endpoint_owner`` collapse
+    to a single entry — credits are shared across a publisher's endpoints.
+    """
+    rows = repo.list_unique_owners_for_user(current_user.id)
     return XenditSubscriptionListResponse(
         subscriptions=[XenditSubscriptionResponse.model_validate(r) for r in rows]
     )
@@ -398,6 +402,33 @@ async def upsert_xendit_subscription(
 
 
 @router.delete(
+    "/subscriptions/by-owner/{endpoint_owner}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_xendit_subscriptions_by_owner(
+    endpoint_owner: str,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    repo: Annotated[
+        UserXenditSubscriptionRepository,
+        Depends(get_user_xendit_subscription_repository),
+    ],
+) -> None:
+    """Forget every subscription row for ``endpoint_owner`` (no refund)."""
+    deleted = repo.delete_all_for_owner(current_user.id, endpoint_owner)
+    if deleted == 0:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No subscriptions for this owner",
+        )
+    logger.info(
+        "wallet.xendit_subscriptions_forgotten_by_owner",
+        user_id=current_user.id,
+        endpoint_owner=endpoint_owner,
+        deleted_count=deleted,
+    )
+
+
+@router.delete(
     "/subscriptions/{subscription_id}",
     status_code=status.HTTP_204_NO_CONTENT,
 )
@@ -409,7 +440,7 @@ async def delete_xendit_subscription(
         Depends(get_user_xendit_subscription_repository),
     ],
 ) -> None:
-    """Forget a publisher wallet (no refund — just removes from the panel)."""
+    """Forget a single subscription row by id (no refund)."""
     deleted = repo.delete_for_user(current_user.id, subscription_id)
     if not deleted:
         raise HTTPException(

--- a/components/backend/src/syfthub/repositories/xendit_subscription.py
+++ b/components/backend/src/syfthub/repositories/xendit_subscription.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, List, Optional
 
-from sqlalchemy import and_, select
+from sqlalchemy import and_, delete, select
 from sqlalchemy.exc import SQLAlchemyError
 
 from syfthub.models.xendit_subscription import UserXenditSubscriptionModel
@@ -28,6 +28,29 @@ class UserXenditSubscriptionRepository(BaseRepository[UserXenditSubscriptionMode
                 select(self.model)
                 .where(self.model.user_id == user_id)
                 .order_by(self.model.created_at.desc())
+            )
+            return list(self.session.execute(stmt).scalars().all())
+        except SQLAlchemyError:
+            return []
+
+    def list_unique_owners_for_user(
+        self, user_id: int
+    ) -> List[UserXenditSubscriptionModel]:
+        """Return the newest subscription per ``endpoint_owner`` for a user.
+
+        A publisher's credits are shared across all of their endpoints, so
+        many rows under the same ``endpoint_owner`` represent a single
+        fundable wallet. Older rows remain on disk but are not surfaced.
+        """
+        try:
+            stmt = (
+                select(self.model)
+                .where(self.model.user_id == user_id)
+                .order_by(
+                    self.model.endpoint_owner,
+                    self.model.created_at.desc(),
+                )
+                .distinct(self.model.endpoint_owner)
             )
             return list(self.session.execute(stmt).scalars().all())
         except SQLAlchemyError:
@@ -127,3 +150,22 @@ class UserXenditSubscriptionRepository(BaseRepository[UserXenditSubscriptionMode
         except SQLAlchemyError:
             self.session.rollback()
             return False
+
+    def delete_all_for_owner(self, user_id: int, endpoint_owner: str) -> int:
+        """Hard-delete every row for ``(user_id, endpoint_owner)``.
+
+        Returns the number of rows removed.
+        """
+        try:
+            stmt = delete(self.model).where(
+                and_(
+                    self.model.user_id == user_id,
+                    self.model.endpoint_owner == endpoint_owner,
+                )
+            )
+            result = self.session.execute(stmt)
+            self.session.commit()
+            return result.rowcount or 0
+        except SQLAlchemyError:
+            self.session.rollback()
+            return 0

--- a/components/backend/src/syfthub/repositories/xendit_subscription.py
+++ b/components/backend/src/syfthub/repositories/xendit_subscription.py
@@ -41,20 +41,19 @@ class UserXenditSubscriptionRepository(BaseRepository[UserXenditSubscriptionMode
         A publisher's credits are shared across all of their endpoints, so
         many rows under the same ``endpoint_owner`` represent a single
         fundable wallet. Older rows remain on disk but are not surfaced.
+
+        Dedup is done in Python rather than via SQL ``DISTINCT ON`` so the
+        method works on both Postgres (production) and SQLite (test suite).
         """
-        try:
-            stmt = (
-                select(self.model)
-                .where(self.model.user_id == user_id)
-                .order_by(
-                    self.model.endpoint_owner,
-                    self.model.created_at.desc(),
-                )
-                .distinct(self.model.endpoint_owner)
-            )
-            return list(self.session.execute(stmt).scalars().all())
-        except SQLAlchemyError:
-            return []
+        rows = self.list_for_user(user_id)
+        seen: set[str] = set()
+        unique: list[UserXenditSubscriptionModel] = []
+        for row in rows:
+            if row.endpoint_owner in seen:
+                continue
+            seen.add(row.endpoint_owner)
+            unique.append(row)
+        return unique
 
     def get_for_user(
         self, user_id: int, subscription_id: int

--- a/components/backend/tests/test_wallet.py
+++ b/components/backend/tests/test_wallet.py
@@ -114,6 +114,147 @@ class TestPayEndpoint:
         assert response.status_code == 401
 
 
+class TestXenditSubscriptions:
+    @staticmethod
+    def _upsert(client, token, **overrides):
+        body = {
+            "credits_url": "https://alice.example.com/credits/foo",
+            "payment_url": "https://alice.example.com/pay/foo",
+            "endpoint_owner": "alice",
+            "endpoint_slug": "foo",
+            "currency": "IDR",
+            "last_known_balance": 100.0,
+        }
+        body.update(overrides)
+        return client.post(
+            "/api/v1/wallet/subscriptions",
+            json=body,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    def test_list_empty(self, client, user_token):
+        response = client.get(
+            "/api/v1/wallet/subscriptions",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert response.status_code == 200
+        assert response.json() == {"subscriptions": []}
+
+    def test_list_requires_auth(self, client):
+        assert client.get("/api/v1/wallet/subscriptions").status_code == 401
+
+    def test_upsert_creates_row(self, client, user_token):
+        response = self._upsert(client, user_token)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["endpoint_owner"] == "alice"
+        assert data["credits_url"] == "https://alice.example.com/credits/foo"
+        assert data["last_known_balance"] == 100.0
+
+    def test_upsert_is_idempotent(self, client, user_token):
+        first = self._upsert(client, user_token).json()
+        second = self._upsert(client, user_token, last_known_balance=250.0).json()
+        assert first["id"] == second["id"]
+        assert second["last_known_balance"] == 250.0
+
+    def test_upsert_requires_auth(self, client):
+        response = client.post(
+            "/api/v1/wallet/subscriptions",
+            json={
+                "credits_url": "https://x/credits",
+                "payment_url": "https://x/pay",
+                "endpoint_owner": "x",
+            },
+        )
+        assert response.status_code == 401
+
+    def test_list_collapses_to_one_per_owner(self, client, user_token):
+        self._upsert(
+            client,
+            user_token,
+            credits_url="https://alice.example.com/credits/foo",
+            endpoint_slug="foo",
+        )
+        self._upsert(
+            client,
+            user_token,
+            credits_url="https://alice.example.com/credits/bar",
+            endpoint_slug="bar",
+        )
+        self._upsert(
+            client,
+            user_token,
+            credits_url="https://bob.example.com/credits/baz",
+            endpoint_owner="bob",
+            endpoint_slug="baz",
+        )
+        response = client.get(
+            "/api/v1/wallet/subscriptions",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert response.status_code == 200
+        owners = sorted(s["endpoint_owner"] for s in response.json()["subscriptions"])
+        assert owners == ["alice", "bob"]
+
+    def test_delete_by_owner_sweeps_every_row(self, client, user_token):
+        self._upsert(
+            client,
+            user_token,
+            credits_url="https://alice.example.com/credits/foo",
+            endpoint_slug="foo",
+        )
+        self._upsert(
+            client,
+            user_token,
+            credits_url="https://alice.example.com/credits/bar",
+            endpoint_slug="bar",
+        )
+
+        response = client.delete(
+            "/api/v1/wallet/subscriptions/by-owner/alice",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert response.status_code == 204
+
+        listing = client.get(
+            "/api/v1/wallet/subscriptions",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert listing.json()["subscriptions"] == []
+
+    def test_delete_by_owner_unknown_returns_404(self, client, user_token):
+        response = client.delete(
+            "/api/v1/wallet/subscriptions/by-owner/ghost",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert response.status_code == 404
+
+    def test_delete_by_owner_requires_auth(self, client):
+        response = client.delete("/api/v1/wallet/subscriptions/by-owner/alice")
+        assert response.status_code == 401
+
+    def test_delete_by_id(self, client, user_token):
+        created = self._upsert(client, user_token).json()
+        response = client.delete(
+            f"/api/v1/wallet/subscriptions/{created['id']}",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert response.status_code == 204
+
+        listing = client.get(
+            "/api/v1/wallet/subscriptions",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert listing.json()["subscriptions"] == []
+
+    def test_delete_by_id_unknown_returns_404(self, client, user_token):
+        response = client.delete(
+            "/api/v1/wallet/subscriptions/99999",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert response.status_code == 404
+
+
 class TestFeedbackEndpoint:
     def test_feedback_unconfigured_returns_error(self, client, user_token):
         from unittest.mock import patch

--- a/components/frontend/src/components/settings/subscriptions-settings-tab.tsx
+++ b/components/frontend/src/components/settings/subscriptions-settings-tab.tsx
@@ -18,7 +18,7 @@ import { Link } from 'react-router-dom';
 import { formatBalance } from '@/components/balance/balance-display';
 import { Button } from '@/components/ui/button';
 import {
-  useDeleteXenditSubscription,
+  useDeleteXenditSubscriptionsByOwner,
   useSubscriptionBalance,
   useXenditSubscriptions
 } from '@/hooks/use-xendit-subscriptions';
@@ -98,7 +98,7 @@ function renderBody({ isLoading, error, subscriptions, onRetry }: RenderBodyArgu
 
 function SubscriptionCard({ subscription }: Readonly<{ subscription: XenditSubscription }>) {
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
-  const deleteMutation = useDeleteXenditSubscription();
+  const deleteMutation = useDeleteXenditSubscriptionsByOwner();
   const { balance, isLoading, error, refetch } = useSubscriptionBalance(subscription, {
     enabled: true,
     pollIntervalMs: 30_000
@@ -117,8 +117,8 @@ function SubscriptionCard({ subscription }: Readonly<{ subscription: XenditSubsc
   }, [subscription.payment_url]);
 
   const handleForget = useCallback(async () => {
-    await deleteMutation.mutateAsync(subscription.id);
-  }, [deleteMutation, subscription.id]);
+    await deleteMutation.mutateAsync(subscription.endpoint_owner);
+  }, [deleteMutation, subscription.endpoint_owner]);
 
   return (
     <div

--- a/components/frontend/src/hooks/use-wallet-api.ts
+++ b/components/frontend/src/hooks/use-wallet-api.ts
@@ -249,6 +249,13 @@ export class WalletAPIClient {
   async deleteXenditSubscription(id: number): Promise<void> {
     await this.request<unknown>('DELETE', `/subscriptions/${String(id)}`);
   }
+
+  async deleteXenditSubscriptionsByOwner(endpointOwner: string): Promise<void> {
+    await this.request<unknown>(
+      'DELETE',
+      `/subscriptions/by-owner/${encodeURIComponent(endpointOwner)}`
+    );
+  }
 }
 
 // Singleton client instance

--- a/components/frontend/src/hooks/use-xendit-subscriptions.ts
+++ b/components/frontend/src/hooks/use-xendit-subscriptions.ts
@@ -10,6 +10,7 @@
 import { useCallback } from 'react';
 
 import type { XenditSubscription } from '@/lib/types';
+import type { QueryClient } from '@tanstack/react-query';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -23,6 +24,16 @@ let walletClientInstance: WalletAPIClient | null = null;
 function getWalletClient(): WalletAPIClient {
   walletClientInstance ??= new WalletAPIClient();
   return walletClientInstance;
+}
+
+function removeFromSubscriptionsCache(
+  queryClient: QueryClient,
+  predicate: (sub: XenditSubscription) => boolean
+): void {
+  queryClient.setQueryData<XenditSubscription[] | undefined>(
+    walletKeys.subscriptions(),
+    (previous) => previous?.filter((sub) => predicate(sub)) ?? []
+  );
 }
 
 export interface RegisterXenditSubscriptionInput {
@@ -89,10 +100,21 @@ export function useDeleteXenditSubscription() {
       return id;
     },
     onSuccess: (id) => {
-      queryClient.setQueryData<XenditSubscription[] | undefined>(
-        walletKeys.subscriptions(),
-        (previous) => previous?.filter((p) => p.id !== id) ?? []
-      );
+      removeFromSubscriptionsCache(queryClient, (p) => p.id !== id);
+    }
+  });
+}
+
+export function useDeleteXenditSubscriptionsByOwner() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (endpointOwner: string) => {
+      await getWalletClient().deleteXenditSubscriptionsByOwner(endpointOwner);
+      return endpointOwner;
+    },
+    onSuccess: (endpointOwner) => {
+      removeFromSubscriptionsCache(queryClient, (p) => p.endpoint_owner !== endpointOwner);
     }
   });
 }


### PR DESCRIPTION
## Summary
- `GET /subscriptions` now returns one row per `endpoint_owner` via a SQL `DISTINCT ON` query — a publisher's credits are shared across all their endpoints, so multi-endpoint funding shouldn't surface as multiple wallets.
- New `DELETE /subscriptions/by-owner/{endpoint_owner}` (bulk SQL `DELETE`) so the **Forget** action clears every underlying `credits_url` row in one shot — otherwise the next-newest row would just resurface in the deduplicated list.
- Frontend `useDeleteXenditSubscriptionsByOwner` mutation hook + shared `removeFromSubscriptionsCache` helper (deduplicates the optimistic-cache update with the existing by-id variant).

The by-id `DELETE /subscriptions/{subscription_id}` route is retained for granular maintenance.

## Test plan
- [ ] Fund two endpoints under the same publisher; confirm credits panel and Subscriptions settings tab show **one** entry, not two.
- [ ] Click **Forget** on that entry; confirm both rows are gone server-side and the entry stays gone after a refresh.
- [ ] Funding a new publisher post-forget still appears.
- [ ] `pnpm typecheck` + `pnpm lint` clean; backend `make check` clean.