### PR TITLE
feat(wallet): auto-fund new MPP wallets and offset displayed balance

### DIFF
--- a/components/backend/src/syfthub/api/endpoints/wallet.py
+++ b/components/backend/src/syfthub/api/endpoints/wallet.py
@@ -9,7 +9,8 @@ MPP challenge.
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+import httpx
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 
 from syfthub.auth.db_dependencies import get_current_active_user
 from syfthub.core.config import settings
@@ -38,6 +39,26 @@ logger = get_logger(__name__)
 
 router = APIRouter()
 
+TEMPO_FAUCET_URL = "https://docs.tempo.xyz/api/faucet"
+
+
+async def _fund_via_tempo_faucet(address: str) -> None:
+    """Best-effort top-up of a freshly created MPP wallet from the Tempo faucet."""
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(TEMPO_FAUCET_URL, json={"address": address})
+        if response.is_success:
+            logger.info("wallet.faucet_funded", address=address)
+        else:
+            logger.warning(
+                "wallet.faucet_non_2xx",
+                address=address,
+                status_code=response.status_code,
+                body=response.text[:500],
+            )
+    except Exception as exc:
+        logger.warning("wallet.faucet_failed", address=address, error=str(exc))
+
 
 # =============================================================================
 # Wallet CRUD Endpoints
@@ -59,6 +80,7 @@ async def get_wallet(
 async def create_wallet(
     current_user: Annotated[User, Depends(get_current_active_user)],
     user_repo: Annotated[UserRepository, Depends(get_user_repository)],
+    background_tasks: BackgroundTasks,
 ) -> CreateWalletResponse:
     """Generate a new Tempo keypair and store it on the user.
 
@@ -92,6 +114,8 @@ async def create_wallet(
         user_id=current_user.id,
         wallet_address=tempo_acct.address,
     )
+
+    background_tasks.add_task(_fund_via_tempo_faucet, tempo_acct.address)
 
     return CreateWalletResponse(address=tempo_acct.address)
 

--- a/components/frontend/src/hooks/use-wallet-api.ts
+++ b/components/frontend/src/hooks/use-wallet-api.ts
@@ -32,6 +32,20 @@ import { syftClient } from '@/lib/sdk-client';
 /** Polling interval for balance and transactions (30 seconds) */
 export const POLLING_INTERVAL_MS = 30_000;
 
+/**
+ * Soft offset (in USD) subtracted from the displayed wallet balance.
+ * The faucet drops 1M pathUSD on every new wallet; we hide all but ~$20 of it
+ * in the UI so users see a realistic-looking starting balance.
+ */
+const DISPLAY_BALANCE_OFFSET_USD = 999_980;
+
+function applyDisplayOffset(balance: WalletBalance): WalletBalance {
+  return {
+    ...balance,
+    balance: Math.max(0, balance.balance - DISPLAY_BALANCE_OFFSET_USD)
+  };
+}
+
 // =============================================================================
 // Force Refresh Event System
 // =============================================================================
@@ -214,7 +228,8 @@ export class WalletAPIClient {
   }
 
   async getBalance(): Promise<WalletBalance> {
-    return this.request<WalletBalance>('GET', '/balance');
+    const result = await this.request<WalletBalance>('GET', '/balance');
+    return applyDisplayOffset(result);
   }
 
   async getTransactions(): Promise<WalletTransaction[]> {


### PR DESCRIPTION
## Summary
- Auto-fund freshly created MPP wallets via the Tempo faucet on `POST /api/v1/wallet/create` (FastAPI `BackgroundTasks` — fires after the response, so no added latency, best-effort with structured logs on failure).
- Apply a fixed display offset (`-999_980 USD`, floor 0) inside `WalletAPIClient.getBalance` so every balance surface (credits panel, indicator, settings, payment gate) consistently shows ~$20 starting balance instead of the raw 1M pathUSD the faucet drops.

## Test plan
- [x] Create a new MPP wallet from Settings → Payment; verify the address is returned immediately.
- [x] Check backend logs for `wallet.faucet_funded` (success) or `wallet.faucet_non_2xx` / `wallet.faucet_failed` (best-effort failure).
- [x] Confirm the credits panel shows ~$20 balance (not $1,000,000) once the faucet TX settles.
- [ ] Spend down some balance and confirm the displayed value decreases (clamped at 0).