### PR TITLE
feat(transaction-policy): unit 1 — Go SDK wire fields & PAYMENT_REQUIRED error code

### DIFF
--- a/sdk/golang/syfthubapi/requestlog.go
+++ b/sdk/golang/syfthubapi/requestlog.go
@@ -38,8 +38,44 @@ type RequestLog struct {
 	// Policy contains policy evaluation results (if policies were applied).
 	Policy *LogPolicy `json:"policy,omitempty"`
 
+	// Payment contains payment information when a TransactionPolicy required
+	// (and possibly verified) an on-chain payment for this request. Nil when
+	// the endpoint had no payment policy attached.
+	Payment *PaymentLog `json:"payment,omitempty"`
+
 	// Timing contains timing information.
 	Timing *LogTiming `json:"timing"`
+}
+
+// PaymentLog captures on-chain payment metadata for a request that flowed
+// through a TransactionPolicy. It records both the issued challenge and, if
+// the caller settled it, the resulting on-chain transaction.
+type PaymentLog struct {
+	// ChallengeID is the unique identifier for the payment challenge issued
+	// to the caller (mirrors the `id` field of the WWW-Authenticate-style header).
+	ChallengeID string `json:"challenge_id"`
+
+	// TxHash is the on-chain transaction hash that settled the challenge.
+	// Empty when the request was rejected with PAYMENT_REQUIRED before settlement.
+	TxHash string `json:"tx_hash,omitempty"`
+
+	// Amount is the required payment amount, stringified to preserve precision
+	// (e.g., "0.10").
+	Amount string `json:"amount"`
+
+	// Currency is the token contract address or symbol (e.g., a PathUSD address).
+	Currency string `json:"currency"`
+
+	// Recipient is the on-chain address that should receive (or did receive)
+	// the payment.
+	Recipient string `json:"recipient"`
+
+	// Status is one of "required", "verified", or "failed".
+	Status string `json:"status"`
+
+	// PaidAt is the RFC3339 timestamp the payment was verified on-chain.
+	// Empty when Status is "required" or "failed".
+	PaidAt string `json:"paid_at,omitempty"`
 }
 
 // LogUserInfo contains user information for the log entry.

--- a/sdk/golang/syfthubapi/requestlog_test.go
+++ b/sdk/golang/syfthubapi/requestlog_test.go
@@ -434,6 +434,122 @@ func TestLogPolicyJSONMarshaling(t *testing.T) {
 	}
 }
 
+func TestPaymentLogJSONMarshaling(t *testing.T) {
+	t.Run("verified payment round-trips", func(t *testing.T) {
+		payment := &PaymentLog{
+			ChallengeID: "abc",
+			TxHash:      "0x1234",
+			Amount:      "0.10",
+			Currency:    "0xCAFE",
+			Recipient:   "0xBEEF",
+			Status:      "verified",
+			PaidAt:      "2026-05-09T12:00:00Z",
+		}
+
+		data, err := json.Marshal(payment)
+		if err != nil {
+			t.Fatalf("Marshal error: %v", err)
+		}
+
+		var decoded PaymentLog
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("Unmarshal error: %v", err)
+		}
+
+		if decoded != *payment {
+			t.Errorf("decoded = %+v, want %+v", decoded, *payment)
+		}
+	})
+
+	t.Run("required-only payment omits tx_hash and paid_at", func(t *testing.T) {
+		payment := &PaymentLog{
+			ChallengeID: "abc",
+			Amount:      "0.10",
+			Currency:    "0xCAFE",
+			Recipient:   "0xBEEF",
+			Status:      "required",
+		}
+
+		data, err := json.Marshal(payment)
+		if err != nil {
+			t.Fatalf("Marshal error: %v", err)
+		}
+
+		raw := map[string]any{}
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("Unmarshal error: %v", err)
+		}
+		if _, ok := raw["tx_hash"]; ok {
+			t.Error("tx_hash should be omitted when empty")
+		}
+		if _, ok := raw["paid_at"]; ok {
+			t.Error("paid_at should be omitted when empty")
+		}
+	})
+}
+
+func TestRequestLogPaymentField(t *testing.T) {
+	t.Run("payment present", func(t *testing.T) {
+		log := &RequestLog{
+			ID:            "log-1",
+			CorrelationID: "corr-1",
+			EndpointSlug:  "ep",
+			EndpointType:  "model",
+			Request:       &LogRequest{Type: "model"},
+			Response:      &LogResponse{Success: true},
+			Timing:        &LogTiming{},
+			Payment: &PaymentLog{
+				ChallengeID: "abc",
+				Amount:      "0.10",
+				Currency:    "0xCAFE",
+				Recipient:   "0xBEEF",
+				Status:      "verified",
+				TxHash:      "0xdead",
+				PaidAt:      "2026-05-09T12:00:00Z",
+			},
+		}
+
+		data, err := json.Marshal(log)
+		if err != nil {
+			t.Fatalf("Marshal error: %v", err)
+		}
+
+		var decoded RequestLog
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("Unmarshal error: %v", err)
+		}
+		if decoded.Payment == nil {
+			t.Fatal("Payment should not be nil after round-trip")
+		}
+		if decoded.Payment.ChallengeID != "abc" {
+			t.Errorf("ChallengeID = %q", decoded.Payment.ChallengeID)
+		}
+		if decoded.Payment.Status != "verified" {
+			t.Errorf("Status = %q", decoded.Payment.Status)
+		}
+	})
+
+	t.Run("payment omitted when nil", func(t *testing.T) {
+		log := &RequestLog{
+			ID:       "log-2",
+			Request:  &LogRequest{Type: "model"},
+			Response: &LogResponse{Success: true},
+			Timing:   &LogTiming{},
+		}
+		data, err := json.Marshal(log)
+		if err != nil {
+			t.Fatalf("Marshal error: %v", err)
+		}
+		raw := map[string]any{}
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("Unmarshal error: %v", err)
+		}
+		if _, ok := raw["payment"]; ok {
+			t.Error("payment should be omitted when nil")
+		}
+	})
+}
+
 func TestLogTimingJSONMarshaling(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	timing := &LogTiming{

--- a/sdk/golang/syfthubapi/schemas.go
+++ b/sdk/golang/syfthubapi/schemas.go
@@ -120,6 +120,11 @@ type RequestContext struct {
 	// TransactionToken is the pre-authorized billing token for this request.
 	// Used by TransactionPolicy to verify billing authorization before execution.
 	TransactionToken string
+
+	// PaymentCredential is the on-chain payment proof (e.g., Tempo/PathUSD tx hash
+	// or signed challenge) presented by the caller to satisfy a TransactionPolicy
+	// payment challenge. Internal state — not serialized.
+	PaymentCredential string
 }
 
 // NewRequestContext creates a new RequestContext with initialized fields.
@@ -272,6 +277,12 @@ type TunnelRequest struct {
 	// SatelliteToken is the JWT for user verification.
 	SatelliteToken string `json:"satellite_token,omitempty"`
 
+	// PaymentCredential is the on-chain payment proof (e.g., Tempo/PathUSD tx hash
+	// or signed challenge response) supplied by the caller to satisfy a
+	// TransactionPolicy payment challenge. Optional; when absent the endpoint
+	// may respond with a PAYMENT_REQUIRED challenge.
+	PaymentCredential string `json:"payment_credential,omitempty"`
+
 	// EncryptionInfo contains the key-exchange metadata required to decrypt
 	// the EncryptedPayload. Always present in encrypted tunnel requests.
 	EncryptionInfo *EncryptionInfo `json:"encryption_info"`
@@ -392,6 +403,11 @@ const (
 	TunnelErrorCodeEndpointDisabled  TunnelErrorCode = "ENDPOINT_DISABLED"
 	TunnelErrorCodeRateLimitExceeded TunnelErrorCode = "RATE_LIMIT_EXCEEDED"
 	TunnelErrorCodeDecryptionFailed  TunnelErrorCode = "DECRYPTION_FAILED"
+	// TunnelErrorCodePaymentRequired indicates the endpoint requires an on-chain
+	// payment (e.g., Tempo/PathUSD) before serving the request. The TunnelError.Details
+	// map carries the challenge metadata (payment_challenge, payment_amount,
+	// payment_currency, payment_recipient, challenge_id, intent).
+	TunnelErrorCodePaymentRequired TunnelErrorCode = "PAYMENT_REQUIRED"
 )
 
 // EndpointInfo contains metadata about a registered endpoint.
@@ -519,6 +535,11 @@ type ExecutorInput struct {
 	// TransactionToken is the pre-authorized billing token for this request.
 	// Used by TransactionPolicy to verify billing authorization before execution.
 	TransactionToken string `json:"transaction_token,omitempty"`
+
+	// PaymentCredential is the on-chain payment proof (e.g., Tempo/PathUSD tx hash
+	// or signed challenge response) forwarded to the subprocess so a TransactionPolicy
+	// runner can verify payment before executing the handler.
+	PaymentCredential string `json:"payment_credential,omitempty"`
 }
 
 // ExecutorOutput is the output format from subprocess execution.

--- a/sdk/golang/syfthubapi/schemas_test.go
+++ b/sdk/golang/syfthubapi/schemas_test.go
@@ -478,6 +478,7 @@ func TestTunnelErrorCodes(t *testing.T) {
 		TunnelErrorCodeInternalError,
 		TunnelErrorCodeEndpointDisabled,
 		TunnelErrorCodeRateLimitExceeded,
+		TunnelErrorCodePaymentRequired,
 	}
 
 	expected := []string{
@@ -490,12 +491,172 @@ func TestTunnelErrorCodes(t *testing.T) {
 		"INTERNAL_ERROR",
 		"ENDPOINT_DISABLED",
 		"RATE_LIMIT_EXCEEDED",
+		"PAYMENT_REQUIRED",
 	}
 
 	for i, code := range codes {
 		if string(code) != expected[i] {
 			t.Errorf("TunnelErrorCode[%d] = %q, want %q", i, code, expected[i])
 		}
+	}
+}
+
+func TestPaymentRequiredErrorRoundTrip(t *testing.T) {
+	original := &TunnelError{
+		Code:    TunnelErrorCodePaymentRequired,
+		Message: "payment required",
+		Details: map[string]any{
+			"payment_challenge": `Payment id="abc", realm="x", method="tempo", amount="0.10", currency="0xCAFE", recipient="0xBEEF"`,
+			"payment_amount":    "0.10",
+			"payment_currency":  "0xCAFE",
+			"payment_recipient": "0xBEEF",
+			"challenge_id":      "abc",
+			"intent":            "charge",
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var decoded TunnelError
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if decoded.Code != TunnelErrorCodePaymentRequired {
+		t.Errorf("Code = %q, want %q", decoded.Code, TunnelErrorCodePaymentRequired)
+	}
+	if decoded.Message != original.Message {
+		t.Errorf("Message = %q, want %q", decoded.Message, original.Message)
+	}
+	for _, key := range []string{
+		"payment_challenge",
+		"payment_amount",
+		"payment_currency",
+		"payment_recipient",
+		"challenge_id",
+		"intent",
+	} {
+		got, ok := decoded.Details[key]
+		if !ok {
+			t.Errorf("Details[%q] missing after round-trip", key)
+			continue
+		}
+		want := original.Details[key]
+		if got != want {
+			t.Errorf("Details[%q] = %v, want %v", key, got, want)
+		}
+	}
+}
+
+func TestTunnelRequestPaymentCredential(t *testing.T) {
+	t.Run("present field round-trips", func(t *testing.T) {
+		req := TunnelRequest{
+			Protocol:          TunnelProtocolV1,
+			Type:              TunnelTypeRequest,
+			CorrelationID:     "req-1",
+			Endpoint:          TunnelEndpointInfo{Slug: "ep", Type: "model"},
+			PaymentCredential: "0xdeadbeef",
+		}
+		data, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("Marshal error: %v", err)
+		}
+		if !strings.Contains(string(data), `"payment_credential":"0xdeadbeef"`) {
+			t.Errorf("expected payment_credential in JSON: %s", string(data))
+		}
+		var decoded TunnelRequest
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("Unmarshal error: %v", err)
+		}
+		if decoded.PaymentCredential != "0xdeadbeef" {
+			t.Errorf("PaymentCredential = %q", decoded.PaymentCredential)
+		}
+	})
+
+	t.Run("empty field omitted", func(t *testing.T) {
+		req := TunnelRequest{
+			Protocol:      TunnelProtocolV1,
+			Type:          TunnelTypeRequest,
+			CorrelationID: "req-2",
+			Endpoint:      TunnelEndpointInfo{Slug: "ep", Type: "model"},
+		}
+		data, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("Marshal error: %v", err)
+		}
+		if strings.Contains(string(data), "payment_credential") {
+			t.Errorf("payment_credential should be omitted when empty: %s", string(data))
+		}
+	})
+}
+
+func TestExecutorInputPaymentCredential(t *testing.T) {
+	t.Run("present field round-trips", func(t *testing.T) {
+		input := ExecutorInput{
+			Type:              "model",
+			PaymentCredential: "0xfeedface",
+		}
+		data, err := json.Marshal(input)
+		if err != nil {
+			t.Fatalf("Marshal error: %v", err)
+		}
+		if !strings.Contains(string(data), `"payment_credential":"0xfeedface"`) {
+			t.Errorf("expected payment_credential in JSON: %s", string(data))
+		}
+		var decoded ExecutorInput
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("Unmarshal error: %v", err)
+		}
+		if decoded.PaymentCredential != "0xfeedface" {
+			t.Errorf("PaymentCredential = %q", decoded.PaymentCredential)
+		}
+	})
+
+	t.Run("empty field omitted", func(t *testing.T) {
+		input := ExecutorInput{Type: "model"}
+		data, err := json.Marshal(input)
+		if err != nil {
+			t.Fatalf("Marshal error: %v", err)
+		}
+		if strings.Contains(string(data), "payment_credential") {
+			t.Errorf("payment_credential should be omitted when empty: %s", string(data))
+		}
+	})
+}
+
+func TestAgentSessionStartPayloadPaymentCredential(t *testing.T) {
+	payload := AgentSessionStartPayload{
+		SessionID:         "sess-1",
+		Prompt:            "hi",
+		EndpointSlug:      "ep",
+		PaymentCredential: "0xabc",
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+	if !strings.Contains(string(data), `"payment_credential":"0xabc"`) {
+		t.Errorf("expected payment_credential in JSON: %s", string(data))
+	}
+	var decoded AgentSessionStartPayload
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if decoded.PaymentCredential != "0xabc" {
+		t.Errorf("PaymentCredential = %q", decoded.PaymentCredential)
+	}
+
+	// Verify omitempty when blank.
+	emptyPayload := AgentSessionStartPayload{SessionID: "s", EndpointSlug: "ep"}
+	emptyData, err := json.Marshal(emptyPayload)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+	if strings.Contains(string(emptyData), "payment_credential") {
+		t.Errorf("payment_credential should be omitted when empty: %s", string(emptyData))
 	}
 }
 

--- a/sdk/golang/syfthubapi/session_manager.go
+++ b/sdk/golang/syfthubapi/session_manager.go
@@ -87,6 +87,11 @@ type AgentSessionStartPayload struct {
 	EndpointSlug string      `json:"endpoint_slug"`
 	Messages     []Message   `json:"messages,omitempty"`
 	Config       AgentConfig `json:"config"`
+
+	// PaymentCredential is the on-chain payment proof (e.g., Tempo/PathUSD tx hash
+	// or signed challenge response) supplied by the caller to satisfy a
+	// TransactionPolicy payment challenge for the agent session intent.
+	PaymentCredential string `json:"payment_credential,omitempty"`
 }
 
 // AgentUserMessagePayload is the decrypted payload of an agent_user_message.


### PR DESCRIPTION
## Summary

Unit 1 of 15 in the transaction-policy / MPP scaffolding effort
(plan: `/home/junior/.claude/plans/nifty-skipping-rainbow.md`).

Adds the Go SDK side of the wire contract that the upcoming
TransactionPolicy will rely on to require an on-chain Tempo (PathUSD)
payment before serving a request. All additions are **additive and optional**
— behavior remains inert until the policy-manager TransactionPolicy lands
in its own repo.

## Changes (Go SDK — `sdk/golang/syfthubapi/`)

Wire fields added (all `omitempty` where serialized):

- `TunnelRequest.PaymentCredential` — `payment_credential`
- `RequestContext.PaymentCredential` — internal, no JSON tag
- `ExecutorInput.PaymentCredential` — `payment_credential`
- `AgentSessionStartPayload.PaymentCredential` — `payment_credential`

Error code:

- `TunnelErrorCodePaymentRequired = "PAYMENT_REQUIRED"` — challenge metadata
  rides on the existing `TunnelError.Details` map (`payment_challenge`,
  `payment_amount`, `payment_currency`, `payment_recipient`, `challenge_id`,
  `intent`) so we don't introduce new top-level error fields.

Telemetry types:

- `PaymentLog` struct + `RequestLog.Payment *PaymentLog` field. Type-only;
  `BuildRequestLog` populate logic is owned by unit 5 to keep the diff tight.

## Test plan

- [x] `cd sdk/golang/syfthubapi && go test ./...` — 842 tests pass
- [x] `cd sdk/golang && make lint` — clean (`go fmt`, `go vet`)
- [x] JSON round-trip + `omitempty` tests for each new field
- [x] `TunnelError{Code: PAYMENT_REQUIRED, Details: {...}}` round-trip
      preserves all six challenge keys
- [ ] Downstream units (2–15) wire these fields through transport, policies,
      runner, frontend, etc.