### PR TITLE
feat(transaction-policy): unit 7 — syft node policy add --type transaction

### DIFF
--- a/cli/internal/cmd/node_policy.go
+++ b/cli/internal/cmd/node_policy.go
@@ -48,14 +48,26 @@ var nodePolicyAddCmd = &cobra.Command{
 func init() {
 	nodePolicyAddCmd.Flags().StringVar(&nodePolicyAddName, "name", "", "Policy name (required)")
 	nodePolicyAddCmd.Flags().StringVar(&nodePolicyAddType, "type", "", "Policy type (required)")
-	nodePolicyAddCmd.Flags().StringSliceVar(&nodePolicyAddConfig, "config", nil, "Config key=value pairs (repeatable)")
+	nodePolicyAddCmd.Flags().StringSliceVar(&nodePolicyAddConfig, "config", nil, "Config key=value pairs (repeatable; ignored for --type transaction)")
 	nodePolicyAddCmd.Flags().BoolVar(&nodePolicyAddJSON, "json", false, "Output result as JSON")
 	nodePolicyAddCmd.MarkFlagRequired("name")
 	nodePolicyAddCmd.MarkFlagRequired("type")
+
+	// Transaction policies use a dedicated set of flags and write a per-policy
+	// YAML + HMAC secret instead of appending to policies.yaml.
+	registerTransactionPolicyFlags(nodePolicyAddCmd)
 }
 
 func runNodePolicyAdd(cmd *cobra.Command, args []string) error {
 	slug := args[0]
+
+	// Transaction policies have their own validation, file layout, and side
+	// effects (HMAC secret + .gitignore). Dispatch early so the legacy
+	// policies.yaml path stays untouched for non-transaction types.
+	if nodePolicyAddType == PolicyTypeTransaction {
+		return runNodePolicyAddTransaction(slug)
+	}
+
 	cfg := nodeconfig.Load()
 
 	// Parse config key=value pairs
@@ -90,6 +102,38 @@ func runNodePolicyAdd(cmd *cobra.Command, args []string) error {
 	} else {
 		output.Success("Added policy '%s' (%s) to endpoint '%s'.", nodePolicyAddName, nodePolicyAddType, slug)
 	}
+	return nil
+}
+
+// runNodePolicyAddTransaction is the cobra-side entry point for the
+// `--type transaction` branch. It glues the flag values onto the
+// implementation in node_policy_transaction.go and produces the JSON / human
+// output. Kept here (next to runNodePolicyAdd) so the dispatch is colocated
+// with the rest of the policy-add flow.
+func runNodePolicyAddTransaction(slug string) error {
+	endpointDir := resolveTransactionEndpointDir(slug)
+	args := transactionArgsFromFlags()
+
+	outcome, err := runTransactionPolicyAdd(endpointDir, args)
+	if err != nil {
+		output.ReplyErrorSoft(nodePolicyAddJSON, "%v", err)
+		return nil
+	}
+
+	if nodePolicyAddJSON {
+		output.JSON(map[string]any{
+			"status":            output.StatusSuccess,
+			"slug":              slug,
+			"policy":            nodePolicyAddName,
+			"type":              PolicyTypeTransaction,
+			"policy_path":       outcome.PolicyPath,
+			"secret_path":       outcome.SecretPath,
+			"gitignore_updated": outcome.GitignoreUpdated,
+		})
+		return nil
+	}
+
+	printTransactionPolicySuccess(slug, outcome)
 	return nil
 }
 

--- a/cli/internal/cmd/node_policy_test.go
+++ b/cli/internal/cmd/node_policy_test.go
@@ -1,0 +1,231 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// validArgs returns a transactionPolicyArgs prefilled with values that pass
+// validation. Tests can override individual fields to exercise edge cases
+// without re-listing every required flag.
+func validArgs() transactionPolicyArgs {
+	return transactionPolicyArgs{
+		Name:       "paid",
+		Recipient:  "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+		Amount:     "0.10",
+		Currency:   defaultTxCurrency,
+		Method:     defaultTxMethod,
+		Intent:     defaultTxIntent,
+		ChainID:    defaultTxChainID,
+		RPCURL:     "https://rpc.tempo.example",
+		TTLSeconds: defaultTxTTLSeconds,
+	}
+}
+
+func TestPolicyAddTransaction_HappyPath(t *testing.T) {
+	endpointDir := t.TempDir()
+
+	out, err := runTransactionPolicyAdd(endpointDir, validArgs())
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	// Policy YAML exists with expected shape.
+	policyPath := filepath.Join(endpointDir, "policy", "transaction.yaml")
+	if out.PolicyPath != policyPath {
+		t.Errorf("PolicyPath = %q, want %q", out.PolicyPath, policyPath)
+	}
+	policyBytes, err := os.ReadFile(policyPath)
+	if err != nil {
+		t.Fatalf("failed to read policy file: %v", err)
+	}
+	var doc map[string]interface{}
+	if err := yaml.Unmarshal(policyBytes, &doc); err != nil {
+		t.Fatalf("policy file is not valid YAML: %v", err)
+	}
+	if doc["type"] != "transaction" {
+		t.Errorf("policy type = %v, want %q", doc["type"], "transaction")
+	}
+	if doc["name"] != "paid" {
+		t.Errorf("policy name = %v, want %q", doc["name"], "paid")
+	}
+	cfg, ok := doc["config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("config is not a map: %T", doc["config"])
+	}
+	if cfg["recipient"] != "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" {
+		t.Errorf("recipient = %v", cfg["recipient"])
+	}
+	if cfg["chain_id"] != defaultTxChainID {
+		t.Errorf("chain_id = %v, want %d", cfg["chain_id"], defaultTxChainID)
+	}
+
+	// Secret file exists with mode 0600 and decodable content.
+	secretPath := filepath.Join(endpointDir, "policy", ".transaction_secret")
+	if out.SecretPath != secretPath {
+		t.Errorf("SecretPath = %q, want %q", out.SecretPath, secretPath)
+	}
+	info, err := os.Stat(secretPath)
+	if err != nil {
+		t.Fatalf("failed to stat secret: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0600 {
+		t.Errorf("secret file mode = %v, want 0600", mode)
+	}
+	secretBytes, err := os.ReadFile(secretPath)
+	if err != nil {
+		t.Fatalf("failed to read secret: %v", err)
+	}
+	// 32 raw bytes -> base64url ≈ 43 chars (no padding).
+	if len(strings.TrimSpace(string(secretBytes))) < 40 {
+		t.Errorf("secret length = %d, expected at least 40 base64url chars", len(secretBytes))
+	}
+
+	// .gitignore exists and lists the secret.
+	if !out.GitignoreUpdated {
+		t.Error("expected GitignoreUpdated=true on first run")
+	}
+	gitignoreBytes, err := os.ReadFile(filepath.Join(endpointDir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("failed to read .gitignore: %v", err)
+	}
+	if !strings.Contains(string(gitignoreBytes), "policy/.transaction_secret") {
+		t.Errorf(".gitignore missing entry, got:\n%s", string(gitignoreBytes))
+	}
+}
+
+func TestPolicyAddTransaction_AlreadyExists_NoOverwrite(t *testing.T) {
+	endpointDir := t.TempDir()
+
+	// First call seeds the secret.
+	out1, err := runTransactionPolicyAdd(endpointDir, validArgs())
+	if err != nil {
+		t.Fatalf("first add failed: %v", err)
+	}
+	originalSecret, err := os.ReadFile(out1.SecretPath)
+	if err != nil {
+		t.Fatalf("failed to read original secret: %v", err)
+	}
+
+	// Second call without --force must error and must NOT touch the secret.
+	if _, err := runTransactionPolicyAdd(endpointDir, validArgs()); err == nil {
+		t.Fatal("expected error on second add without --force, got nil")
+	}
+
+	currentSecret, err := os.ReadFile(out1.SecretPath)
+	if err != nil {
+		t.Fatalf("failed to re-read secret: %v", err)
+	}
+	if string(currentSecret) != string(originalSecret) {
+		t.Error("secret was regenerated despite no --force flag")
+	}
+}
+
+func TestPolicyAddTransaction_AlreadyExists_WithForce(t *testing.T) {
+	endpointDir := t.TempDir()
+
+	out1, err := runTransactionPolicyAdd(endpointDir, validArgs())
+	if err != nil {
+		t.Fatalf("first add failed: %v", err)
+	}
+	originalSecret, err := os.ReadFile(out1.SecretPath)
+	if err != nil {
+		t.Fatalf("failed to read original secret: %v", err)
+	}
+
+	forced := validArgs()
+	forced.Force = true
+	if _, err := runTransactionPolicyAdd(endpointDir, forced); err != nil {
+		t.Fatalf("forced add failed: %v", err)
+	}
+
+	currentSecret, err := os.ReadFile(out1.SecretPath)
+	if err != nil {
+		t.Fatalf("failed to re-read secret: %v", err)
+	}
+	if string(currentSecret) == string(originalSecret) {
+		t.Error("secret was NOT regenerated despite --force")
+	}
+}
+
+func TestPolicyAddTransaction_InvalidRecipient(t *testing.T) {
+	endpointDir := t.TempDir()
+	args := validArgs()
+	args.Recipient = "not-a-hex-address"
+
+	if _, err := runTransactionPolicyAdd(endpointDir, args); err == nil {
+		t.Fatal("expected validation error for invalid recipient, got nil")
+	}
+
+	// Nothing should have been written.
+	if _, err := os.Stat(filepath.Join(endpointDir, "policy")); !os.IsNotExist(err) {
+		t.Errorf("policy/ directory should not exist after validation failure (err=%v)", err)
+	}
+}
+
+func TestPolicyAddTransaction_GitignoreIdempotent(t *testing.T) {
+	endpointDir := t.TempDir()
+
+	if _, err := runTransactionPolicyAdd(endpointDir, validArgs()); err != nil {
+		t.Fatalf("first add failed: %v", err)
+	}
+
+	// Second call (with --force so the secret regen doesn't error first) must
+	// not duplicate the .gitignore entry.
+	forced := validArgs()
+	forced.Force = true
+	out2, err := runTransactionPolicyAdd(endpointDir, forced)
+	if err != nil {
+		t.Fatalf("forced add failed: %v", err)
+	}
+	if out2.GitignoreUpdated {
+		t.Error("expected GitignoreUpdated=false on second run (entry already present)")
+	}
+
+	gitignoreBytes, err := os.ReadFile(filepath.Join(endpointDir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("failed to read .gitignore: %v", err)
+	}
+	count := strings.Count(string(gitignoreBytes), "policy/.transaction_secret")
+	if count != 1 {
+		t.Errorf(".gitignore entry count = %d, want 1; contents:\n%s", count, string(gitignoreBytes))
+	}
+}
+
+func TestValidateTransactionArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*transactionPolicyArgs)
+		wantErr bool
+	}{
+		{"valid", func(a *transactionPolicyArgs) {}, false},
+		{"missing name", func(a *transactionPolicyArgs) { a.Name = "" }, true},
+		{"missing recipient", func(a *transactionPolicyArgs) { a.Recipient = "" }, true},
+		{"short recipient", func(a *transactionPolicyArgs) { a.Recipient = "0xabc" }, true},
+		{"non-hex recipient", func(a *transactionPolicyArgs) { a.Recipient = "0xZZZZd6e51aad88F6F4ce6aB8827279cffFb92266" }, true},
+		{"missing amount", func(a *transactionPolicyArgs) { a.Amount = "" }, true},
+		{"negative amount", func(a *transactionPolicyArgs) { a.Amount = "-1" }, true},
+		{"zero amount", func(a *transactionPolicyArgs) { a.Amount = "0" }, true},
+		{"zero decimal amount", func(a *transactionPolicyArgs) { a.Amount = "0.00" }, true},
+		{"missing rpc url", func(a *transactionPolicyArgs) { a.RPCURL = "" }, true},
+		{"http rpc url", func(a *transactionPolicyArgs) { a.RPCURL = "http://rpc.example" }, true},
+		{"non-positive ttl", func(a *transactionPolicyArgs) { a.TTLSeconds = 0 }, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := validArgs()
+			tt.mutate(&a)
+			err := validateTransactionArgs(a)
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("expected nil, got: %v", err)
+			}
+		})
+	}
+}

--- a/cli/internal/cmd/node_policy_transaction.go
+++ b/cli/internal/cmd/node_policy_transaction.go
@@ -1,0 +1,346 @@
+package cmd
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/OpenMined/syfthub/cli/internal/nodeconfig"
+	"github.com/OpenMined/syfthub/cli/internal/output"
+	"github.com/openmined/syfthub/sdk/golang/syfthubapi/nodeops"
+)
+
+// PolicyTypeTransaction is the type discriminator for on-chain payment policies
+// (MPP-over-NATS, Tempo passthrough). When this type is selected on
+// `syft node endpoint policy add`, dedicated flags drive the policy YAML and
+// an HMAC secret is provisioned alongside it.
+const PolicyTypeTransaction = "transaction"
+
+// transactionSecretFilename is the basename of the HMAC secret file written
+// inside the endpoint's policy/ directory. It is intentionally dot-prefixed so
+// existing tooling treats it as a hidden artifact, and it is added to the
+// endpoint's .gitignore on first creation.
+const transactionSecretFilename = ".transaction_secret"
+
+// transactionPolicyFilename is the basename of the per-policy YAML emitted by
+// the transaction-policy add flow. The plan calls for a per-file layout under
+// <endpoint_dir>/policy/, distinct from the legacy single-file policies.yaml.
+const transactionPolicyFilename = "transaction.yaml"
+
+// Defaults that match the on-chain Tempo PathUSD configuration documented in
+// the unit's plan. Override per-call via the corresponding flags.
+const (
+	defaultTxCurrency   = "0x20c0000000000000000000000000000000000000"
+	defaultTxMethod     = "tempo"
+	defaultTxIntent     = "charge"
+	defaultTxChainID    = 42431
+	defaultTxTTLSeconds = 600
+)
+
+// recipientPattern validates a 0x-prefixed Ethereum address (40 hex chars).
+var recipientPattern = regexp.MustCompile(`^0x[a-fA-F0-9]{40}$`)
+
+// amountPattern validates a positive decimal expressed as a string. Using a
+// regex keeps the dependency surface minimal vs. pulling in a decimal lib.
+var amountPattern = regexp.MustCompile(`^\d+(\.\d+)?$`)
+
+// transaction-specific flag values populated by cobra. They live alongside
+// `nodePolicyAdd*` so the existing single command can branch on --type.
+var (
+	nodePolicyAddRecipient  string
+	nodePolicyAddAmount     string
+	nodePolicyAddCurrency   string
+	nodePolicyAddMethod     string
+	nodePolicyAddIntent     string
+	nodePolicyAddChainID    int64
+	nodePolicyAddRPCURL     string
+	nodePolicyAddTTLSeconds int
+	nodePolicyAddForce      bool
+)
+
+// registerTransactionPolicyFlags wires the transaction-only flags onto the
+// shared `policy add` cobra command. They are intentionally not marked
+// required at the cobra level because non-transaction policy types do not use
+// them — validation is deferred to runtime when --type=transaction.
+func registerTransactionPolicyFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&nodePolicyAddRecipient, "recipient", "", "Payment recipient address (0x-prefixed, transaction policies only)")
+	cmd.Flags().StringVar(&nodePolicyAddAmount, "amount", "", "Payment amount as decimal string (transaction policies only)")
+	cmd.Flags().StringVar(&nodePolicyAddCurrency, "currency", defaultTxCurrency, "Currency contract address (transaction policies only)")
+	cmd.Flags().StringVar(&nodePolicyAddMethod, "method", defaultTxMethod, "Payment method (transaction policies only)")
+	cmd.Flags().StringVar(&nodePolicyAddIntent, "intent", defaultTxIntent, "Payment intent (transaction policies only)")
+	cmd.Flags().Int64Var(&nodePolicyAddChainID, "chain-id", defaultTxChainID, "Chain ID (transaction policies only)")
+	cmd.Flags().StringVar(&nodePolicyAddRPCURL, "rpc-url", "", "RPC URL for the chain (transaction policies only)")
+	cmd.Flags().IntVar(&nodePolicyAddTTLSeconds, "ttl-seconds", defaultTxTTLSeconds, "Payment challenge TTL in seconds (transaction policies only)")
+	cmd.Flags().BoolVar(&nodePolicyAddForce, "force", false, "Overwrite an existing transaction secret (transaction policies only)")
+}
+
+// transactionPolicyArgs is a value-type snapshot of the transaction-only
+// flags so the helper is testable without spinning up cobra.
+type transactionPolicyArgs struct {
+	Name       string
+	Recipient  string
+	Amount     string
+	Currency   string
+	Method     string
+	Intent     string
+	ChainID    int64
+	RPCURL     string
+	TTLSeconds int
+	Force      bool
+}
+
+// validateTransactionArgs enforces the per-flag invariants documented in the
+// plan: recipient must be a 0x address, amount a positive decimal, rpc-url a
+// well-formed https URL. Returns a user-facing error message on the first
+// violation; callers print it via output.ReplyErrorSoft.
+func validateTransactionArgs(a transactionPolicyArgs) error {
+	if a.Name == "" {
+		return fmt.Errorf("--name is required")
+	}
+	if a.Recipient == "" {
+		return fmt.Errorf("--recipient is required for transaction policies")
+	}
+	if !recipientPattern.MatchString(a.Recipient) {
+		return fmt.Errorf("--recipient must be a 0x-prefixed Ethereum address (got %q)", a.Recipient)
+	}
+	if a.Amount == "" {
+		return fmt.Errorf("--amount is required for transaction policies")
+	}
+	if !amountPattern.MatchString(a.Amount) {
+		return fmt.Errorf("--amount must be a positive decimal (got %q)", a.Amount)
+	}
+	// Reject "0" / "0.0" / "0.00..." — the regex permits them but a zero
+	// payment is meaningless and almost certainly a user mistake.
+	if isZeroAmount(a.Amount) {
+		return fmt.Errorf("--amount must be greater than zero (got %q)", a.Amount)
+	}
+	if a.RPCURL == "" {
+		return fmt.Errorf("--rpc-url is required for transaction policies")
+	}
+	parsed, err := url.Parse(a.RPCURL)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return fmt.Errorf("--rpc-url must be an https:// URL (got %q)", a.RPCURL)
+	}
+	if a.TTLSeconds <= 0 {
+		return fmt.Errorf("--ttl-seconds must be positive (got %d)", a.TTLSeconds)
+	}
+	return nil
+}
+
+// isZeroAmount returns true if the decimal string represents zero. Cheaper
+// than parsing and avoids pulling in math/big for a one-shot check.
+func isZeroAmount(s string) bool {
+	for _, r := range s {
+		if r != '0' && r != '.' {
+			return false
+		}
+	}
+	return true
+}
+
+// transactionPolicyOutcome captures the side effects of a successful
+// transaction-policy add for both human and JSON output paths.
+type transactionPolicyOutcome struct {
+	PolicyPath       string
+	SecretPath       string
+	GitignoreUpdated bool
+}
+
+// runTransactionPolicyAdd performs the full per-endpoint side effect set:
+//  1. Write policy/transaction.yaml with the validated config.
+//  2. Generate (or refuse to overwrite) the .transaction_secret file.
+//  3. Append the secret path to the endpoint's .gitignore.
+//
+// It is decoupled from cobra so tests can drive it directly with a tmp dir.
+func runTransactionPolicyAdd(endpointDir string, a transactionPolicyArgs) (*transactionPolicyOutcome, error) {
+	if err := validateTransactionArgs(a); err != nil {
+		return nil, err
+	}
+
+	if _, err := os.Stat(endpointDir); os.IsNotExist(err) {
+		return nil, fmt.Errorf("endpoint directory does not exist: %s", endpointDir)
+	}
+
+	policyDir := filepath.Join(endpointDir, "policy")
+	if err := os.MkdirAll(policyDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create policy directory: %w", err)
+	}
+
+	policyPath := filepath.Join(policyDir, transactionPolicyFilename)
+	if err := writeTransactionPolicyYAML(policyPath, a); err != nil {
+		return nil, err
+	}
+
+	secretPath := filepath.Join(policyDir, transactionSecretFilename)
+	if err := generateTransactionSecret(secretPath, a.Force); err != nil {
+		return nil, err
+	}
+
+	gitignorePath := filepath.Join(endpointDir, ".gitignore")
+	gitignoreUpdated, err := ensureGitignoreEntry(gitignorePath, "policy/"+transactionSecretFilename)
+	if err != nil {
+		return nil, err
+	}
+
+	return &transactionPolicyOutcome{
+		PolicyPath:       policyPath,
+		SecretPath:       secretPath,
+		GitignoreUpdated: gitignoreUpdated,
+	}, nil
+}
+
+// writeTransactionPolicyYAML serialises the policy to disk in the per-policy
+// file layout. Reuses nodeops.Policy so the on-disk shape stays consistent
+// with the legacy policies.yaml entries and a future nodeops.SavePolicy that
+// supports per-file layout becomes a drop-in replacement.
+func writeTransactionPolicyYAML(path string, a transactionPolicyArgs) error {
+	policy := nodeops.Policy{
+		Name: a.Name,
+		Type: PolicyTypeTransaction,
+		Config: map[string]interface{}{
+			"recipient":   a.Recipient,
+			"amount":      a.Amount,
+			"currency":    a.Currency,
+			"method":      a.Method,
+			"intent":      a.Intent,
+			"chain_id":    a.ChainID,
+			"rpc_url":     a.RPCURL,
+			"ttl_seconds": a.TTLSeconds,
+		},
+	}
+
+	content, err := yaml.Marshal(&policy)
+	if err != nil {
+		return fmt.Errorf("failed to marshal transaction policy: %w", err)
+	}
+
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		return fmt.Errorf("failed to write transaction policy: %w", err)
+	}
+	return nil
+}
+
+// generateTransactionSecret writes 32 random bytes (base64url-encoded) to path
+// with mode 0600. Without force, O_EXCL ensures we never silently overwrite an
+// existing secret — overwriting would invalidate in-flight payment challenges.
+func generateTransactionSecret(path string, force bool) error {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return fmt.Errorf("failed to generate random bytes: %w", err)
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(buf)
+
+	flags := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
+	if !force {
+		flags |= os.O_EXCL
+	}
+	f, err := os.OpenFile(path, flags, 0600)
+	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("transaction secret already exists at %s; pass --force to regenerate (this will invalidate in-flight payment challenges)", path)
+		}
+		return fmt.Errorf("failed to open transaction secret: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write([]byte(encoded)); err != nil {
+		return fmt.Errorf("failed to write transaction secret: %w", err)
+	}
+	return nil
+}
+
+// ensureGitignoreEntry idempotently appends entry to the .gitignore at path.
+// Creates the file if missing. Returns true iff the file was modified (or
+// created), so callers can report it in the JSON envelope.
+func ensureGitignoreEntry(path, entry string) (bool, error) {
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return false, fmt.Errorf("failed to read .gitignore: %w", err)
+	}
+
+	if err == nil {
+		// Idempotency: skip if a matching line is already present (any of
+		// the lines, not just whole-file substring, to avoid false positives
+		// from comments).
+		for _, line := range strings.Split(string(existing), "\n") {
+			if strings.TrimSpace(line) == entry {
+				return false, nil
+			}
+		}
+	}
+
+	var buf strings.Builder
+	if len(existing) > 0 {
+		buf.Write(existing)
+		if !strings.HasSuffix(string(existing), "\n") {
+			buf.WriteString("\n")
+		}
+	}
+	buf.WriteString(entry)
+	buf.WriteString("\n")
+
+	if err := os.WriteFile(path, []byte(buf.String()), 0644); err != nil {
+		return false, fmt.Errorf("failed to write .gitignore: %w", err)
+	}
+	return true, nil
+}
+
+// printTransactionPolicySuccess emits the human-readable warning + tip block
+// described in the plan. Kept here (vs. inlined in runNodePolicyAdd) so the
+// JSON branch can share the outcome type without duplicating any text.
+func printTransactionPolicySuccess(slug string, out *transactionPolicyOutcome) {
+	output.Success("Added transaction policy to endpoint '%s'.", slug)
+	fmt.Printf("  Policy file: %s\n", out.PolicyPath)
+	fmt.Println()
+
+	absSecret, err := filepath.Abs(out.SecretPath)
+	if err != nil {
+		absSecret = out.SecretPath
+	}
+	output.Yellow.Println("⚠  WARNING: A new HMAC secret was generated at:")
+	fmt.Printf("     %s\n", absSecret)
+	output.Yellow.Println("   DO NOT COMMIT THIS FILE.")
+	if out.GitignoreUpdated {
+		fmt.Println("   It has been added to your endpoint's .gitignore.")
+	} else {
+		fmt.Println("   It is already covered by your endpoint's .gitignore.")
+	}
+	fmt.Println("   Losing this secret invalidates all in-flight payment challenges.")
+	fmt.Println()
+
+	output.Info("Tip: paid endpoints benefit from container mode (~10x faster policy hot path).")
+	fmt.Println("     Add `runtime: { mode: container }` to your README.md frontmatter.")
+}
+
+// transactionArgsFromFlags snapshots the cobra flag globals into a value type
+// so RunE stays narrow and tests can build args without touching the globals.
+func transactionArgsFromFlags() transactionPolicyArgs {
+	return transactionPolicyArgs{
+		Name:       nodePolicyAddName,
+		Recipient:  nodePolicyAddRecipient,
+		Amount:     nodePolicyAddAmount,
+		Currency:   nodePolicyAddCurrency,
+		Method:     nodePolicyAddMethod,
+		Intent:     nodePolicyAddIntent,
+		ChainID:    nodePolicyAddChainID,
+		RPCURL:     nodePolicyAddRPCURL,
+		TTLSeconds: nodePolicyAddTTLSeconds,
+		Force:      nodePolicyAddForce,
+	}
+}
+
+// resolveTransactionEndpointDir centralises the cfg.EndpointsPath/<slug> join
+// so the cobra handler in node_policy.go stays free of nodeconfig coupling
+// for the transaction branch.
+func resolveTransactionEndpointDir(slug string) string {
+	cfg := nodeconfig.Load()
+	return filepath.Join(cfg.EndpointsPath, slug)
+}


### PR DESCRIPTION
## Summary
- Adds a `--type transaction` branch to `syft node policy add` that writes a per-policy YAML at `<endpoint_dir>/policy/transaction.yaml` (distinct from the legacy `policies.yaml` flow, which is preserved verbatim for non-transaction types).
- Generates a 32-byte HMAC secret at `<endpoint_dir>/policy/.transaction_secret` (mode 0600, `O_EXCL` so existing secrets are never silently overwritten — pass `--force` to regenerate).
- Idempotently appends `policy/.transaction_secret` to the endpoint's `.gitignore`, prints a bold warning + container-mode hint in non-JSON mode, and includes `policy_path`, `secret_path`, and `gitignore_updated` in the JSON envelope.

## Test plan
- [x] `cd cli && go test ./...` — 155 tests pass (includes 6 new tests covering happy path, no-overwrite, --force, invalid recipient, gitignore idempotency, and full validation matrix).
- [x] `cd cli && make build` — builds clean.
- [x] `cd cli && make lint` — go vet passes (golangci-lint not installed locally; CI will run it).
- [x] E2E: built `syft` binary against an isolated `XDG_CONFIG_HOME` — verified happy path, double-add error, invalid recipient, http rpc-url rejection, `--force` regeneration, and that legacy non-transaction policies still write to `policies.yaml`.

Plan: `/home/junior/.claude/plans/nifty-skipping-rainbow.md` (unit 7 of 15).