### PR TITLE
feat(transaction-policy): unit 4 — agent session threads PaymentCredential to CheckPolicies

### DIFF
--- a/sdk/golang/syfthubapi/agent.go
+++ b/sdk/golang/syfthubapi/agent.go
@@ -21,6 +21,24 @@ type ToolCall = agenttypes.ToolCall
 // Kept for backward compatibility so callers can continue using syfthubapi.ToolResult.
 type ToolResult = agenttypes.ToolResult
 
+// PaymentRequiredError signals that an agent session start was blocked by a
+// transaction-style policy and the caller must obtain a payment credential
+// (e.g. a Tempo on-chain payment) and retry. The NATS bridge maps this error
+// to a TunnelResponse with TunnelErrorCodePaymentRequired so the aggregator /
+// client can surface a payment challenge to the user.
+type PaymentRequiredError struct {
+	// Challenge is the WWW-Authenticate-style "Payment …" challenge string
+	// returned by the policy, e.g. `Payment id="…", realm="…", amount="…"`.
+	Challenge string
+
+	// Details is a copy of the safe payment_* keys from the policy metadata,
+	// suitable for placing into TunnelError.Details.
+	Details map[string]any
+}
+
+// Error implements the error interface.
+func (e *PaymentRequiredError) Error() string { return "payment required" }
+
 // AgentHandler is the function signature for agent endpoint handlers.
 // The handler receives a context (cancelled on user cancel or timeout) and
 // an AgentSession for bidirectional communication with the user.

--- a/sdk/golang/syfthubapi/schemas.go
+++ b/sdk/golang/syfthubapi/schemas.go
@@ -120,6 +120,11 @@ type RequestContext struct {
 	// TransactionToken is the pre-authorized billing token for this request.
 	// Used by TransactionPolicy to verify billing authorization before execution.
 	TransactionToken string
+
+	// PaymentCredential is the on-chain (e.g. Tempo) payment credential for this
+	// request, used by transaction-style policies. Populated from the inbound
+	// tunnel request or agent session start payload before policy evaluation.
+	PaymentCredential string
 }
 
 // NewRequestContext creates a new RequestContext with initialized fields.
@@ -392,6 +397,7 @@ const (
 	TunnelErrorCodeEndpointDisabled  TunnelErrorCode = "ENDPOINT_DISABLED"
 	TunnelErrorCodeRateLimitExceeded TunnelErrorCode = "RATE_LIMIT_EXCEEDED"
 	TunnelErrorCodeDecryptionFailed  TunnelErrorCode = "DECRYPTION_FAILED"
+	TunnelErrorCodePaymentRequired   TunnelErrorCode = "PAYMENT_REQUIRED"
 )
 
 // EndpointInfo contains metadata about a registered endpoint.
@@ -519,6 +525,10 @@ type ExecutorInput struct {
 	// TransactionToken is the pre-authorized billing token for this request.
 	// Used by TransactionPolicy to verify billing authorization before execution.
 	TransactionToken string `json:"transaction_token,omitempty"`
+
+	// PaymentCredential is an optional on-chain payment credential carried with
+	// the request, forwarded to transaction-style policies for verification.
+	PaymentCredential string `json:"payment_credential,omitempty"`
 }
 
 // ExecutorOutput is the output format from subprocess execution.

--- a/sdk/golang/syfthubapi/session_manager.go
+++ b/sdk/golang/syfthubapi/session_manager.go
@@ -80,6 +80,48 @@ func (m *AgentSessionManager) deregisterSession(sessionID string) {
 	}
 }
 
+// paymentMetadataKeys lists the policy-metadata keys that are safe to forward
+// to the caller as part of a PAYMENT_REQUIRED tunnel response.
+var paymentMetadataKeys = []string{
+	"payment_challenge",
+	"payment_amount",
+	"payment_currency",
+	"payment_recipient",
+	"challenge_id",
+	"intent",
+}
+
+// paymentChallengeFromMetadata returns the payment_challenge string from a
+// policy-result metadata map, and true iff present and non-empty.
+func paymentChallengeFromMetadata(meta map[string]any) (string, bool) {
+	if meta == nil {
+		return "", false
+	}
+	s, ok := meta["payment_challenge"].(string)
+	if !ok || s == "" {
+		return "", false
+	}
+	return s, true
+}
+
+// copyPaymentMetadata returns a copy of the safe payment_* keys from a policy
+// metadata map. Returns nil when no safe keys are present.
+func copyPaymentMetadata(meta map[string]any) map[string]any {
+	if meta == nil {
+		return nil
+	}
+	var out map[string]any
+	for _, k := range paymentMetadataKeys {
+		if v, ok := meta[k]; ok {
+			if out == nil {
+				out = make(map[string]any, len(paymentMetadataKeys))
+			}
+			out[k] = v
+		}
+	}
+	return out
+}
+
 // AgentSessionStartPayload is the decrypted payload of an agent_session_start message.
 type AgentSessionStartPayload struct {
 	SessionID    string      `json:"session_id"`
@@ -87,6 +129,11 @@ type AgentSessionStartPayload struct {
 	EndpointSlug string      `json:"endpoint_slug"`
 	Messages     []Message   `json:"messages,omitempty"`
 	Config       AgentConfig `json:"config"`
+
+	// PaymentCredential is an optional on-chain payment credential carried with
+	// the session start. Forwarded into the RequestContext used for policy
+	// evaluation so transaction-style policies can authorize the session.
+	PaymentCredential string `json:"payment_credential,omitempty"`
 }
 
 // AgentUserMessagePayload is the decrypted payload of an agent_user_message.
@@ -117,22 +164,42 @@ func (m *AgentSessionManager) StartSession(
 
 	// Enforce policies before starting session.
 	reqCtx := &RequestContext{
-		User:         user,
-		EndpointSlug: payload.EndpointSlug,
-		EndpointType: EndpointTypeAgent,
+		User:              user,
+		EndpointSlug:      payload.EndpointSlug,
+		EndpointType:      EndpointTypeAgent,
+		PaymentCredential: payload.PaymentCredential,
 	}
 	policyResult, err := ep.CheckPolicies(context.Background(), reqCtx)
 	if err != nil {
 		return nil, fmt.Errorf("policy check failed: %w", err)
 	}
-	if policyResult != nil && !policyResult.Allowed {
-		m.logger.Warn("[AGENT] Session denied by policy",
-			"endpoint", payload.EndpointSlug,
-			"user", user.Username,
-			"policy_name", policyResult.PolicyName,
-			"reason", policyResult.Reason,
-		)
-		return nil, fmt.Errorf("access denied by policy %q: %s", policyResult.PolicyName, policyResult.Reason)
+	if policyResult != nil {
+		// A "pending" result with a payment_challenge means a transaction-style
+		// policy is asking the caller to obtain a payment credential and retry.
+		// Surface this as a typed error so the NATS bridge can emit a
+		// PAYMENT_REQUIRED tunnel response with the challenge details.
+		if policyResult.Pending {
+			if challenge, ok := paymentChallengeFromMetadata(policyResult.Metadata); ok {
+				m.logger.Info("[AGENT] Session pending payment",
+					"endpoint", payload.EndpointSlug,
+					"user", user.Username,
+					"policy_name", policyResult.PolicyName,
+				)
+				return nil, &PaymentRequiredError{
+					Challenge: challenge,
+					Details:   copyPaymentMetadata(policyResult.Metadata),
+				}
+			}
+		}
+		if !policyResult.Allowed {
+			m.logger.Warn("[AGENT] Session denied by policy",
+				"endpoint", payload.EndpointSlug,
+				"user", user.Username,
+				"policy_name", policyResult.PolicyName,
+				"reason", policyResult.Reason,
+			)
+			return nil, fmt.Errorf("access denied by policy %q: %s", policyResult.PolicyName, policyResult.Reason)
+		}
 	}
 
 	handler, err := ep.GetAgentHandler()

--- a/sdk/golang/syfthubapi/session_payment_test.go
+++ b/sdk/golang/syfthubapi/session_payment_test.go
@@ -1,0 +1,292 @@
+package syfthubapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// newTestSessionManager builds an AgentSessionManager with a discarded logger
+// suitable for unit tests.
+func newTestSessionManager(t *testing.T) (*AgentSessionManager, *EndpointRegistry) {
+	t.Helper()
+	registry := NewEndpointRegistry()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewAgentSessionManager(registry, logger, 0), registry
+}
+
+// registerAgentEndpoint adds an agent endpoint with the given handler and a
+// policy executor whose Execute is supplied by the caller.
+func registerAgentEndpoint(
+	t *testing.T,
+	registry *EndpointRegistry,
+	slug string,
+	handler AgentHandler,
+	policyExec func(ctx context.Context, input *ExecutorInput) (*ExecutorOutput, error),
+) *Endpoint {
+	t.Helper()
+	ep := &Endpoint{
+		Slug:    slug,
+		Type:    EndpointTypeAgent,
+		Enabled: true,
+	}
+	ep.SetAgentHandler(handler)
+	if policyExec != nil {
+		ep.SetPolicyExecutor(&mockExecutor{executeFunc: policyExec})
+	}
+	if err := registry.Register(ep); err != nil {
+		t.Fatalf("register endpoint: %v", err)
+	}
+	return ep
+}
+
+// noopAgentHandler is a benign handler that returns immediately without
+// emitting any events. Sessions using this handler complete cleanly.
+func noopAgentHandler(_ context.Context, _ *AgentSession) error { return nil }
+
+// drainSession blocks until the session's send channel closes, draining all
+// emitted events. Used in tests so the goroutine can finish cleanly before
+// the test exits.
+func drainSession(t *testing.T, session *AgentSession) {
+	t.Helper()
+	if session == nil {
+		return
+	}
+	for range session.SendCh() {
+		// drop
+	}
+}
+
+// TestStartSession_PaymentCredentialPassed confirms that StartSession reaches
+// the policy executor with the user identity intact and accepts a non-empty
+// PaymentCredential without erroring. The credential's path from
+// reqCtx.PaymentCredential into input.PaymentCredential is owned by
+// Endpoint.buildExecutorInput (unit 3) — this test only verifies the agent
+// session start does not regress when the field is set.
+func TestStartSession_PaymentCredentialPassed(t *testing.T) {
+	mgr, registry := newTestSessionManager(t)
+
+	var capturedUserID string
+	registerAgentEndpoint(t, registry, "agent-ep", noopAgentHandler,
+		func(_ context.Context, input *ExecutorInput) (*ExecutorOutput, error) {
+			if input != nil && input.Context != nil {
+				capturedUserID = input.Context.UserID
+			}
+			return &ExecutorOutput{
+				Success:      true,
+				PolicyResult: &PolicyResultOutput{Allowed: true},
+			}, nil
+		},
+	)
+
+	user := &UserContext{Sub: "user-1", Username: "alice", Email: "a@b"}
+	session, err := mgr.StartSession(AgentSessionStartPayload{
+		SessionID:         "sess-1",
+		Prompt:            "hi",
+		EndpointSlug:      "agent-ep",
+		PaymentCredential: "Payment xyz",
+	}, user)
+	if err != nil {
+		t.Fatalf("StartSession returned error: %v", err)
+	}
+	defer drainSession(t, session)
+
+	if capturedUserID != "alice" {
+		t.Errorf("ExecutionContext.UserID = %q, want %q", capturedUserID, "alice")
+	}
+}
+
+func TestStartSession_PaymentRequired_ReturnsTypedError(t *testing.T) {
+	mgr, registry := newTestSessionManager(t)
+
+	registerAgentEndpoint(t, registry, "agent-ep", noopAgentHandler,
+		func(_ context.Context, _ *ExecutorInput) (*ExecutorOutput, error) {
+			return &ExecutorOutput{
+				Success: true,
+				PolicyResult: &PolicyResultOutput{
+					Allowed:    false,
+					Pending:    true,
+					PolicyName: "transaction",
+					Reason:     "payment required",
+					Metadata: map[string]any{
+						"payment_challenge": `Payment id="abc", realm="syfthub", amount="0.10"`,
+						"payment_amount":    "0.10",
+						"payment_currency":  "PathUSD",
+						"payment_recipient": "0xfeed",
+						"challenge_id":      "abc",
+						"intent":            "charge",
+						// Unsafe key; should not be copied.
+						"_secret_nonce": "should-not-leak",
+					},
+				},
+			}, nil
+		},
+	)
+
+	user := &UserContext{Sub: "u", Username: "alice"}
+	_, err := mgr.StartSession(AgentSessionStartPayload{
+		SessionID: "s1", EndpointSlug: "agent-ep",
+	}, user)
+
+	if err == nil {
+		t.Fatal("StartSession should have returned an error")
+	}
+
+	var payErr *PaymentRequiredError
+	if !errors.As(err, &payErr) {
+		t.Fatalf("expected *PaymentRequiredError, got %T: %v", err, err)
+	}
+
+	wantChallenge := `Payment id="abc", realm="syfthub", amount="0.10"`
+	if payErr.Challenge != wantChallenge {
+		t.Errorf("Challenge = %q, want %q", payErr.Challenge, wantChallenge)
+	}
+	if payErr.Details["payment_amount"] != "0.10" {
+		t.Errorf("Details.payment_amount = %v, want %q", payErr.Details["payment_amount"], "0.10")
+	}
+	if payErr.Details["payment_currency"] != "PathUSD" {
+		t.Errorf("Details.payment_currency = %v, want %q", payErr.Details["payment_currency"], "PathUSD")
+	}
+	if payErr.Details["challenge_id"] != "abc" {
+		t.Errorf("Details.challenge_id = %v, want %q", payErr.Details["challenge_id"], "abc")
+	}
+	if payErr.Details["intent"] != "charge" {
+		t.Errorf("Details.intent = %v, want %q", payErr.Details["intent"], "charge")
+	}
+	if _, leaked := payErr.Details["_secret_nonce"]; leaked {
+		t.Errorf("Details should not contain unsafe key %q", "_secret_nonce")
+	}
+	if payErr.Error() != "payment required" {
+		t.Errorf("Error() = %q, want %q", payErr.Error(), "payment required")
+	}
+}
+
+func TestStartSession_PendingWithoutChallenge_FallsBackToDeny(t *testing.T) {
+	// A Pending result with no payment_challenge metadata is treated as a
+	// regular denial (existing behaviour) — it must NOT surface as a typed
+	// PaymentRequiredError.
+	mgr, registry := newTestSessionManager(t)
+
+	registerAgentEndpoint(t, registry, "agent-ep", noopAgentHandler,
+		func(_ context.Context, _ *ExecutorInput) (*ExecutorOutput, error) {
+			return &ExecutorOutput{
+				Success: true,
+				PolicyResult: &PolicyResultOutput{
+					Allowed:    false,
+					Pending:    true,
+					PolicyName: "manual_review",
+					Reason:     "awaiting reviewer",
+					// no payment_challenge
+				},
+			}, nil
+		},
+	)
+
+	user := &UserContext{Sub: "u", Username: "u"}
+	_, err := mgr.StartSession(AgentSessionStartPayload{
+		SessionID: "s1", EndpointSlug: "agent-ep",
+	}, user)
+
+	if err == nil {
+		t.Fatal("expected denial error")
+	}
+	var payErr *PaymentRequiredError
+	if errors.As(err, &payErr) {
+		t.Fatalf("did not expect *PaymentRequiredError, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "manual_review") {
+		t.Errorf("error %q should mention denying policy name", err.Error())
+	}
+}
+
+func TestStartSession_NormalPolicyDeny_StillReturnsGenericError(t *testing.T) {
+	mgr, registry := newTestSessionManager(t)
+
+	registerAgentEndpoint(t, registry, "agent-ep", noopAgentHandler,
+		func(_ context.Context, _ *ExecutorInput) (*ExecutorOutput, error) {
+			return &ExecutorOutput{
+				Success: true,
+				PolicyResult: &PolicyResultOutput{
+					Allowed:    false,
+					Pending:    false,
+					PolicyName: "rate_limit",
+					Reason:     "too many requests",
+				},
+			}, nil
+		},
+	)
+
+	user := &UserContext{Sub: "u", Username: "u"}
+	_, err := mgr.StartSession(AgentSessionStartPayload{
+		SessionID: "s1", EndpointSlug: "agent-ep",
+	}, user)
+	if err == nil {
+		t.Fatal("expected denial error")
+	}
+	var payErr *PaymentRequiredError
+	if errors.As(err, &payErr) {
+		t.Fatalf("did not expect *PaymentRequiredError for non-payment denial, got: %v", err)
+	}
+}
+
+func TestAgentSessionStartPayload_PaymentCredentialJSONRoundTrip(t *testing.T) {
+	in := AgentSessionStartPayload{
+		SessionID:         "s",
+		Prompt:            "hi",
+		EndpointSlug:      "ep",
+		PaymentCredential: "Payment xyz",
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"payment_credential":"Payment xyz"`) {
+		t.Errorf("missing payment_credential in JSON: %s", data)
+	}
+
+	var out AgentSessionStartPayload
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.PaymentCredential != "Payment xyz" {
+		t.Errorf("PaymentCredential = %q, want %q", out.PaymentCredential, "Payment xyz")
+	}
+
+	// Empty value must omit (omitempty).
+	emptyData, _ := json.Marshal(AgentSessionStartPayload{SessionID: "s"})
+	if strings.Contains(string(emptyData), "payment_credential") {
+		t.Errorf("payment_credential should be omitted when empty: %s", emptyData)
+	}
+}
+
+func TestCopyPaymentMetadata_NilAndEmpty(t *testing.T) {
+	if got := copyPaymentMetadata(nil); got != nil {
+		t.Errorf("copyPaymentMetadata(nil) = %v, want nil", got)
+	}
+	if got := copyPaymentMetadata(map[string]any{"unrelated": "x"}); got != nil {
+		t.Errorf("copyPaymentMetadata(no payment keys) = %v, want nil", got)
+	}
+}
+
+func TestPaymentChallengeFromMetadata(t *testing.T) {
+	if _, ok := paymentChallengeFromMetadata(nil); ok {
+		t.Error("nil metadata should return ok=false")
+	}
+	if _, ok := paymentChallengeFromMetadata(map[string]any{}); ok {
+		t.Error("missing key should return ok=false")
+	}
+	if _, ok := paymentChallengeFromMetadata(map[string]any{"payment_challenge": ""}); ok {
+		t.Error("empty challenge string should return ok=false")
+	}
+	if _, ok := paymentChallengeFromMetadata(map[string]any{"payment_challenge": 42}); ok {
+		t.Error("non-string challenge should return ok=false")
+	}
+	got, ok := paymentChallengeFromMetadata(map[string]any{"payment_challenge": "Payment id=x"})
+	if !ok || got != "Payment id=x" {
+		t.Errorf("got (%q, %v), want (%q, true)", got, ok, "Payment id=x")
+	}
+}

--- a/sdk/golang/syfthubapi/transport/nats.go
+++ b/sdk/golang/syfthubapi/transport/nats.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/ecdh"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -101,6 +102,17 @@ func (b *agentNATSBridge) handleSessionStart(msg *nats.Msg, req *syfthubapi.Tunn
 
 	session, err := b.handler.StartSession(startPayload, user)
 	if err != nil {
+		// Transaction-style policies surface a typed PaymentRequiredError so we
+		// can emit a structured PAYMENT_REQUIRED tunnel response carrying the
+		// payment challenge and amount/recipient details.
+		var payErr *syfthubapi.PaymentRequiredError
+		if errors.As(err, &payErr) {
+			b.logger.Info("[AGENT] session pending payment",
+				"endpoint", startPayload.EndpointSlug,
+				"user_sub", user.Sub, "username", user.Username)
+			b.transport.sendPaymentRequiredResponse(msg, req, payErr.Details)
+			return
+		}
 		b.logger.Error("[AGENT] failed to start session",
 			"endpoint", startPayload.EndpointSlug, "error", err)
 		b.transport.sendErrorResponse(msg, req, string(syfthubapi.TunnelErrorCodeExecutionFailed),
@@ -684,6 +696,32 @@ func (t *NATSTransport) sendErrorResponse(msg *nats.Msg, req *syfthubapi.TunnelR
 		Error: &syfthubapi.TunnelError{
 			Code:    syfthubapi.TunnelErrorCode(code),
 			Message: message,
+		},
+	}
+	t.sendResponse(msg, req, resp)
+}
+
+// sendPaymentRequiredResponse sends a PAYMENT_REQUIRED tunnel response with
+// the supplied payment-challenge details placed on TunnelError.Details so the
+// caller (aggregator / client) can surface the challenge to the user.
+func (t *NATSTransport) sendPaymentRequiredResponse(msg *nats.Msg, req *syfthubapi.TunnelRequest, details map[string]any) {
+	correlationID := ""
+	endpointSlug := ""
+	if req != nil {
+		correlationID = req.CorrelationID
+		endpointSlug = req.Endpoint.Slug
+	}
+
+	resp := &syfthubapi.TunnelResponse{
+		Protocol:      syfthubapi.TunnelProtocolV1,
+		Type:          syfthubapi.TunnelTypeResponse,
+		CorrelationID: correlationID,
+		Status:        syfthubapi.TunnelStatusError,
+		EndpointSlug:  endpointSlug,
+		Error: &syfthubapi.TunnelError{
+			Code:    syfthubapi.TunnelErrorCodePaymentRequired,
+			Message: "payment required",
+			Details: details,
 		},
 	}
 	t.sendResponse(msg, req, resp)


### PR DESCRIPTION
## Summary

Implements **unit 4** of the transaction-policy plan (`/home/junior/.claude/plans/nifty-skipping-rainbow.md`).

- `AgentSessionStartPayload` gains an optional `payment_credential` JSON field.
- `AgentSessionManager.StartSession` populates `RequestContext.PaymentCredential` before `Endpoint.CheckPolicies`, and recognises a `PolicyResultOutput` with `Pending=true` + `Metadata["payment_challenge"]` as a payment-required signal.
- New typed `PaymentRequiredError` (in `agent.go`) carries the challenge plus a copy of the safe `payment_*` metadata keys.
- `transport/nats.go` agent bridge maps `*PaymentRequiredError` into a `TunnelResponse` with `TunnelErrorCodePaymentRequired` and details, via a new `NATSTransport.sendPaymentRequiredResponse` helper.
- Defensively adds `RequestContext.PaymentCredential`, `ExecutorInput.payment_credential`, and `TunnelErrorCodePaymentRequired` in `schemas.go` so this PR compiles ahead of unit 1 landing on `main`. All additions are field-only and merge cleanly.

## Test plan

- [x] `go test ./...` — 835 tests pass in `sdk/golang/syfthubapi/...`
- [x] `make lint` — `go fmt` + `go vet` clean
- New `session_payment_test.go` covers:
  - typed `*PaymentRequiredError` returned on `Pending` + `payment_challenge` metadata, with safe-key filtering (no `_secret_*` leakage)
  - generic error returned on normal (non-pending) policy denial
  - generic error returned on `Pending` *without* `payment_challenge` (e.g. `manual_review`)
  - `PaymentCredential` round-trips through `AgentSessionStartPayload` JSON (`omitempty` honored)
  - metadata helper edge cases (nil, missing key, non-string, empty)