### PR TITLE
feat(transaction-policy): unit 9 — interactive payment_required handler in syft query/agent

### DIFF
--- a/cli/internal/cmd/agent.go
+++ b/cli/internal/cmd/agent.go
@@ -114,6 +114,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 	prompt := args[1]
 
 	cfg := config.Load()
+	aggregatorURL := cfg.GetAggregatorURL(agentAggregator)
 
 	client, err := clientutil.NewClient(cfg, agentAggregator, 0)
 	if err != nil {
@@ -244,6 +245,41 @@ func runAgent(cmd *cobra.Command, args []string) error {
 				fmt.Printf("\n⚠ Error [%s]: %s\n", e.Code, e.Message)
 				if !e.Recoverable {
 					return fmt.Errorf("agent error: %s", e.Message)
+				}
+
+			case *syfthub.AgentPaymentRequiredEvent:
+				// Bridge SDK event to CLI handler. The agent flow may emit
+				// payment_required at session start (only once); the handler
+				// is called once and the session continues.
+				// See unit 9 of the transaction-policy plan
+				// (nifty-skipping-rainbow.md).
+				cliEvent := PaymentRequiredEvent{
+					ChatSessionID: e.ChatSessionID,
+					EndpointSlug:  e.EndpointSlug,
+					Challenge:     e.Challenge,
+					Amount:        e.Amount,
+					Currency:      e.Currency,
+					Recipient:     e.Recipient,
+					ChallengeID:   e.ChallengeID,
+					Intent:        e.Intent,
+					RPCURL:        e.RPCURL,
+				}
+				sessionID := e.ChatSessionID
+				if sessionID == "" {
+					sessionID = session.SessionID
+				}
+				if err := HandlePaymentRequired(
+					ctx,
+					false, // agent command has no --json flag today
+					aggregatorURL,
+					cfg.APIToken,
+					sessionID,
+					cfg.TempoRPCURL,
+					cliEvent,
+				); err != nil {
+					output.Error("%v", err)
+					session.Cancel(context.Background())
+					return err
 				}
 			}
 

--- a/cli/internal/cmd/payment_handler.go
+++ b/cli/internal/cmd/payment_handler.go
@@ -1,0 +1,238 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/OpenMined/syfthub/cli/internal/output"
+)
+
+// PaymentRequiredEvent mirrors the SSE/WebSocket "payment_required" event
+// emitted by the aggregator (unit 10 of the transaction-policy plan,
+// nifty-skipping-rainbow.md). All fields are strings to match the wire
+// format exactly so that --json mode round-trips losslessly.
+type PaymentRequiredEvent struct {
+	ChatSessionID string `json:"chat_session_id"`
+	EndpointSlug  string `json:"endpoint_slug"`
+	Challenge     string `json:"challenge"`
+	Amount        string `json:"amount"`
+	Currency      string `json:"currency"`
+	Recipient     string `json:"recipient"`
+	ChallengeID   string `json:"challenge_id"`
+	Intent        string `json:"intent"`
+	RPCURL        string `json:"rpc_url,omitempty"`
+}
+
+// ErrPaymentDeclined is returned by HandlePaymentRequired when the user
+// declines the payment prompt. Callers should abort the chat/agent stream.
+var ErrPaymentDeclined = errors.New("payment declined by user")
+
+// ── Injected helpers (overridable in tests) ─────────────────────────────────
+//
+// The real implementations of these helpers live in unit 6 (mppx-go) and
+// unit 8 (wallet). Those units are not yet merged on main; the placeholders
+// below are stubs that return a clear error. Tests swap them out via the
+// package vars so the CLI is fully covered today and the production wiring
+// becomes a one-line swap once units 6 + 8 land.
+
+// promptPassphrase reads a passphrase from stdin/tty without echoing.
+// TODO: requires unit 8 (wallet) — replace with wallet.PromptPassphrase.
+var promptPassphrase = func(prompt string) (string, error) {
+	return "", errors.New("wallet passphrase prompt not implemented (requires unit 8)")
+}
+
+// loadAndDecryptWallet loads the local wallet file and decrypts the active
+// account using the supplied passphrase. Returns an opaque account handle
+// that signCredential knows how to use.
+//
+// TODO: requires unit 8 (wallet) — replace with wallet.LoadWallet +
+// wallet.DecryptWallet.
+var loadAndDecryptWallet = func(passphrase string) (any, error) {
+	return nil, errors.New("wallet loading not implemented (requires unit 8)")
+}
+
+// signCredential signs the given challenge with the supplied account and
+// broadcasts the resulting credential via the given JSON-RPC URL. Returns
+// the credential blob (sent back to the aggregator) and the on-chain tx
+// hash for display.
+//
+// TODO: requires unit 6 (mppx-go) — replace with mppx.tempo.SignCredential.
+var signCredential = func(ctx context.Context, challenge string, account any, rpcURL string) (credential string, txHash string, err error) {
+	return "", "", errors.New("credential signing not implemented (requires unit 6)")
+}
+
+// ── stdin reader (overridable in tests) ─────────────────────────────────────
+
+// readLine reads a single line from the given reader, trimming the trailing
+// newline. We use a 1-byte read loop so the function works with both pipes
+// (tests) and ttys without a separate bufio.Reader leaking bytes meant for
+// the next prompt.
+func readLine(r io.Reader) (string, error) {
+	var buf bytes.Buffer
+	one := make([]byte, 1)
+	for {
+		n, err := r.Read(one)
+		if n > 0 {
+			if one[0] == '\n' {
+				return strings.TrimRight(buf.String(), "\r"), nil
+			}
+			buf.WriteByte(one[0])
+		}
+		if err != nil {
+			if err == io.EOF && buf.Len() > 0 {
+				return strings.TrimRight(buf.String(), "\r"), nil
+			}
+			return "", err
+		}
+	}
+}
+
+// ── HTTP submitter (overridable in tests) ───────────────────────────────────
+
+// httpPostCredential POSTs the signed credential to the aggregator's
+// /chat/{session_id}/payment endpoint. Overridable for tests.
+//
+// TODO: requires unit 10 (aggregator endpoint) — once merged the endpoint
+// URL and any required headers may need to be revised.
+var httpPostCredential = func(ctx context.Context, url, apiToken string, body []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+apiToken)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("aggregator returned %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	return nil
+}
+
+// ── Handler I/O (overridable in tests) ──────────────────────────────────────
+
+var paymentStdin io.Reader = os.Stdin
+var paymentStdout io.Writer = os.Stdout
+
+// ── Handler ─────────────────────────────────────────────────────────────────
+
+// HandlePaymentRequired receives a payment_required event, prompts the user
+// (or in --json mode emits the structured event), signs a credential via the
+// local wallet, and POSTs it back to the aggregator at
+// /chat/{chatSessionID}/payment.
+//
+// In jsonMode the function emits the event payload to stdout via output.JSON
+// and returns nil immediately — external tooling is responsible for signing
+// and POSTing the credential. The chat stream will block on the aggregator
+// until the credential arrives or the aggregator times out.
+//
+// In interactive mode the function:
+//  1. prints the price + recipient and prompts y/N,
+//  2. reads the wallet passphrase,
+//  3. signs + broadcasts the credential,
+//  4. POSTs {challenge_id, credential} to the aggregator.
+//
+// Returns ErrPaymentDeclined when the user declines so callers can abort
+// the stream cleanly.
+func HandlePaymentRequired(
+	ctx context.Context,
+	jsonMode bool,
+	aggregatorURL string,
+	apiToken string,
+	chatSessionID string,
+	defaultRPCURL string,
+	event PaymentRequiredEvent,
+) error {
+	// Resolve the chat session id: prefer the caller's value, fall back to
+	// the event payload (the aggregator always populates it but the CLI may
+	// have a more authoritative id from the request kickoff).
+	sessionID := chatSessionID
+	if sessionID == "" {
+		sessionID = event.ChatSessionID
+	}
+
+	if jsonMode {
+		output.JSON(map[string]any{
+			"event":           "payment_required",
+			"chat_session_id": sessionID,
+			"endpoint_slug":   event.EndpointSlug,
+			"challenge":       event.Challenge,
+			"amount":          event.Amount,
+			"currency":        event.Currency,
+			"recipient":       event.Recipient,
+			"challenge_id":    event.ChallengeID,
+			"intent":          event.Intent,
+			"rpc_url":         event.RPCURL,
+		})
+		return nil
+	}
+
+	// Interactive prompt.
+	fmt.Fprintf(paymentStdout,
+		"\nEndpoint %s requires payment of %s %s to %s.\nApprove? [y/N]: ",
+		event.EndpointSlug, event.Amount, event.Currency, event.Recipient,
+	)
+	answer, err := readLine(paymentStdin)
+	if err != nil {
+		return fmt.Errorf("failed to read approval: %w", err)
+	}
+	answer = strings.TrimSpace(answer)
+	if answer != "y" && answer != "Y" {
+		fmt.Fprintln(paymentStdout, "Payment declined.")
+		return ErrPaymentDeclined
+	}
+
+	passphrase, err := promptPassphrase("Wallet passphrase: ")
+	if err != nil {
+		return fmt.Errorf("failed to read passphrase: %w", err)
+	}
+
+	account, err := loadAndDecryptWallet(passphrase)
+	if err != nil {
+		return fmt.Errorf("failed to unlock wallet: %w", err)
+	}
+
+	rpcURL := event.RPCURL
+	if rpcURL == "" {
+		rpcURL = defaultRPCURL
+	}
+	if rpcURL == "" {
+		return errors.New("no Tempo RPC URL configured (set tempo_rpc_url in settings.json or include rpc_url in the event)")
+	}
+
+	fmt.Fprintln(paymentStdout, "Submitting credential…")
+
+	credential, txHash, err := signCredential(ctx, event.Challenge, account, rpcURL)
+	if err != nil {
+		return fmt.Errorf("failed to sign credential: %w", err)
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"challenge_id": event.ChallengeID,
+		"credential":   credential,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal credential: %w", err)
+	}
+
+	url := strings.TrimRight(aggregatorURL, "/") + "/chat/" + sessionID + "/payment"
+	if err := httpPostCredential(ctx, url, apiToken, body); err != nil {
+		return fmt.Errorf("failed to submit credential: %w", err)
+	}
+
+	fmt.Fprintf(paymentStdout, "Payment confirmed — tx %s\n", txHash)
+	return nil
+}

--- a/cli/internal/cmd/payment_handler_test.go
+++ b/cli/internal/cmd/payment_handler_test.go
@@ -1,0 +1,345 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// withInjectedHelpers swaps the package-level injection points and returns a
+// restore func. Keeps each test hermetic.
+func withInjectedHelpers(
+	t *testing.T,
+	stdin io.Reader,
+	stdout io.Writer,
+	pp func(string) (string, error),
+	wallet func(string) (any, error),
+	sign func(context.Context, string, any, string) (string, string, error),
+	post func(context.Context, string, string, []byte) error,
+) func() {
+	t.Helper()
+	origStdin := paymentStdin
+	origStdout := paymentStdout
+	origPP := promptPassphrase
+	origWallet := loadAndDecryptWallet
+	origSign := signCredential
+	origPost := httpPostCredential
+
+	if stdin != nil {
+		paymentStdin = stdin
+	}
+	if stdout != nil {
+		paymentStdout = stdout
+	}
+	if pp != nil {
+		promptPassphrase = pp
+	}
+	if wallet != nil {
+		loadAndDecryptWallet = wallet
+	}
+	if sign != nil {
+		signCredential = sign
+	}
+	if post != nil {
+		httpPostCredential = post
+	}
+
+	return func() {
+		paymentStdin = origStdin
+		paymentStdout = origStdout
+		promptPassphrase = origPP
+		loadAndDecryptWallet = origWallet
+		signCredential = origSign
+		httpPostCredential = origPost
+	}
+}
+
+func sampleEvent() PaymentRequiredEvent {
+	return PaymentRequiredEvent{
+		ChatSessionID: "sess-123",
+		EndpointSlug:  "alice/paid-model",
+		Challenge:     "0xchallenge",
+		Amount:        "0.05",
+		Currency:      "PathUSD",
+		Recipient:     "0xRecipient",
+		ChallengeID:   "ch-abc",
+		Intent:        "chat.completion",
+		RPCURL:        "https://rpc.tempo.example",
+	}
+}
+
+// TestHandlePaymentRequired_JSONMode asserts that --json mode emits the event
+// payload to stdout and returns nil without prompting or touching the wallet.
+func TestHandlePaymentRequired_JSONMode(t *testing.T) {
+	walletCalled := false
+	signCalled := false
+	postCalled := false
+	stdout := &bytes.Buffer{}
+
+	restore := withInjectedHelpers(t,
+		strings.NewReader(""), // stdin should never be read
+		// Note: output.JSON writes to os.Stdout directly via fmt.Println,
+		// so we redirect os.Stdout for this test alone.
+		stdout,
+		func(string) (string, error) {
+			t.Fatal("promptPassphrase must not be called in JSON mode")
+			return "", nil
+		},
+		func(string) (any, error) {
+			walletCalled = true
+			return nil, nil
+		},
+		func(context.Context, string, any, string) (string, string, error) {
+			signCalled = true
+			return "", "", nil
+		},
+		func(context.Context, string, string, []byte) error {
+			postCalled = true
+			return nil
+		},
+	)
+	defer restore()
+
+	// output.JSON writes to os.Stdout via fmt — capture it.
+	captured := captureStdout(t, func() {
+		err := HandlePaymentRequired(
+			context.Background(),
+			true, // jsonMode
+			"https://aggregator.example",
+			"api-token",
+			"sess-123",
+			"https://default-rpc.example",
+			sampleEvent(),
+		)
+		if err != nil {
+			t.Fatalf("HandlePaymentRequired returned error: %v", err)
+		}
+	})
+
+	if walletCalled || signCalled || postCalled {
+		t.Errorf("wallet/sign/post unexpectedly called in JSON mode: wallet=%v sign=%v post=%v",
+			walletCalled, signCalled, postCalled)
+	}
+
+	// Captured stdout should be valid JSON containing the event fields.
+	var got map[string]any
+	if err := json.Unmarshal([]byte(captured), &got); err != nil {
+		t.Fatalf("captured stdout is not valid JSON: %v\nraw=%q", err, captured)
+	}
+	if got["event"] != "payment_required" {
+		t.Errorf("event field = %v, want payment_required", got["event"])
+	}
+	if got["challenge_id"] != "ch-abc" {
+		t.Errorf("challenge_id = %v, want ch-abc", got["challenge_id"])
+	}
+	if got["endpoint_slug"] != "alice/paid-model" {
+		t.Errorf("endpoint_slug = %v, want alice/paid-model", got["endpoint_slug"])
+	}
+}
+
+// TestHandlePaymentRequired_InteractiveDenied asserts that answering "n" at
+// the approval prompt returns ErrPaymentDeclined and does NOT touch the
+// wallet or HTTP client.
+func TestHandlePaymentRequired_InteractiveDenied(t *testing.T) {
+	walletCalled := false
+	signCalled := false
+	postCalled := false
+
+	stdout := &bytes.Buffer{}
+	restore := withInjectedHelpers(t,
+		strings.NewReader("n\n"),
+		stdout,
+		func(string) (string, error) {
+			t.Fatal("promptPassphrase must not be called when user declines")
+			return "", nil
+		},
+		func(string) (any, error) {
+			walletCalled = true
+			return nil, nil
+		},
+		func(context.Context, string, any, string) (string, string, error) {
+			signCalled = true
+			return "", "", nil
+		},
+		func(context.Context, string, string, []byte) error {
+			postCalled = true
+			return nil
+		},
+	)
+	defer restore()
+
+	err := HandlePaymentRequired(
+		context.Background(),
+		false,
+		"https://aggregator.example",
+		"api-token",
+		"sess-123",
+		"https://default-rpc.example",
+		sampleEvent(),
+	)
+	if !errors.Is(err, ErrPaymentDeclined) {
+		t.Fatalf("expected ErrPaymentDeclined, got %v", err)
+	}
+	if walletCalled || signCalled || postCalled {
+		t.Errorf("wallet/sign/post unexpectedly called after denial: wallet=%v sign=%v post=%v",
+			walletCalled, signCalled, postCalled)
+	}
+	if !strings.Contains(stdout.String(), "Payment declined") {
+		t.Errorf("expected 'Payment declined' in stdout, got: %q", stdout.String())
+	}
+}
+
+// TestHandlePaymentRequired_InteractiveApproved drives the full happy path:
+// "y\n" approval, mocked wallet + sign, and a real httptest server to
+// validate the POST body shape.
+func TestHandlePaymentRequired_InteractiveApproved(t *testing.T) {
+	stdout := &bytes.Buffer{}
+
+	var gotURL string
+	var gotAuth string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	signCalls := 0
+	restore := withInjectedHelpers(t,
+		strings.NewReader("y\n"),
+		stdout,
+		func(prompt string) (string, error) { return "secret-passphrase", nil },
+		func(passphrase string) (any, error) {
+			if passphrase != "secret-passphrase" {
+				t.Errorf("wallet got passphrase %q, want secret-passphrase", passphrase)
+			}
+			return "mock-account", nil
+		},
+		func(_ context.Context, challenge string, account any, rpcURL string) (string, string, error) {
+			signCalls++
+			if challenge != "0xchallenge" {
+				t.Errorf("sign got challenge %q, want 0xchallenge", challenge)
+			}
+			if account != "mock-account" {
+				t.Errorf("sign got account %v, want mock-account", account)
+			}
+			if rpcURL != "https://rpc.tempo.example" {
+				t.Errorf("sign got rpcURL %q, want event override", rpcURL)
+			}
+			return "0xCREDENTIAL", "0xTXHASH", nil
+		},
+		// Use the real HTTP client against httptest — restore stub afterwards.
+		nil,
+	)
+	defer restore()
+
+	err := HandlePaymentRequired(
+		context.Background(),
+		false,
+		server.URL,
+		"api-token",
+		"sess-123",
+		"https://default-rpc.example",
+		sampleEvent(),
+	)
+	if err != nil {
+		t.Fatalf("HandlePaymentRequired returned error: %v", err)
+	}
+	if signCalls != 1 {
+		t.Errorf("signCredential called %d times, want 1", signCalls)
+	}
+
+	if gotURL != "/chat/sess-123/payment" {
+		t.Errorf("POST URL = %q, want /chat/sess-123/payment", gotURL)
+	}
+	if gotAuth != "Bearer api-token" {
+		t.Errorf("Authorization header = %q, want Bearer api-token", gotAuth)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(gotBody, &body); err != nil {
+		t.Fatalf("POST body is not JSON: %v\nraw=%q", err, gotBody)
+	}
+	if body["challenge_id"] != "ch-abc" {
+		t.Errorf("body.challenge_id = %q, want ch-abc", body["challenge_id"])
+	}
+	if body["credential"] != "0xCREDENTIAL" {
+		t.Errorf("body.credential = %q, want 0xCREDENTIAL", body["credential"])
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Payment confirmed") || !strings.Contains(out, "0xTXHASH") {
+		t.Errorf("expected 'Payment confirmed' + tx hash in stdout, got: %q", out)
+	}
+}
+
+// TestHandlePaymentRequired_FallsBackToConfigRPCURL asserts that when the
+// event omits rpc_url, the configured default is used.
+func TestHandlePaymentRequired_FallsBackToConfigRPCURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	gotRPC := ""
+	restore := withInjectedHelpers(t,
+		strings.NewReader("y\n"),
+		&bytes.Buffer{},
+		func(string) (string, error) { return "p", nil },
+		func(string) (any, error) { return "acct", nil },
+		func(_ context.Context, _ string, _ any, rpcURL string) (string, string, error) {
+			gotRPC = rpcURL
+			return "cred", "tx", nil
+		},
+		nil,
+	)
+	defer restore()
+
+	ev := sampleEvent()
+	ev.RPCURL = "" // force fallback
+
+	if err := HandlePaymentRequired(
+		context.Background(),
+		false,
+		server.URL,
+		"tok",
+		"sess-1",
+		"https://config-default-rpc.example",
+		ev,
+	); err != nil {
+		t.Fatalf("HandlePaymentRequired error: %v", err)
+	}
+	if gotRPC != "https://config-default-rpc.example" {
+		t.Errorf("signCredential rpcURL = %q, want config default", gotRPC)
+	}
+}
+
+// captureStdout temporarily redirects os.Stdout while fn runs and returns
+// what was written. Used because output.JSON writes via fmt.Println.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stdout = orig
+	return <-done
+}

--- a/cli/internal/cmd/query.go
+++ b/cli/internal/cmd/query.go
@@ -193,6 +193,35 @@ func queryStream(ctx context.Context, client *syfthub.Client, target, prompt, ag
 				output.StreamDone()
 				output.Error("%s", e.Error)
 				return fmt.Errorf("%s", e.Error)
+
+			case *syfthub.PaymentRequiredEvent:
+				// Bridge SDK event to CLI handler. See unit 9 of the
+				// transaction-policy plan (nifty-skipping-rainbow.md).
+				cliEvent := PaymentRequiredEvent{
+					ChatSessionID: e.ChatSessionID,
+					EndpointSlug:  e.EndpointSlug,
+					Challenge:     e.Challenge,
+					Amount:        e.Amount,
+					Currency:      e.Currency,
+					Recipient:     e.Recipient,
+					ChallengeID:   e.ChallengeID,
+					Intent:        e.Intent,
+					RPCURL:        e.RPCURL,
+				}
+				cfg := config.Load()
+				if err := HandlePaymentRequired(
+					ctx,
+					queryJSONOutput,
+					aggregatorURL,
+					cfg.APIToken,
+					e.ChatSessionID,
+					cfg.TempoRPCURL,
+					cliEvent,
+				); err != nil {
+					output.StreamDone()
+					output.Error("%v", err)
+					return err
+				}
 			}
 
 		case err := <-errs:

--- a/cli/internal/nodeconfig/config.go
+++ b/cli/internal/nodeconfig/config.go
@@ -112,6 +112,13 @@ type NodeConfig struct {
 	ContainerEnabled bool   `json:"container_enabled,omitempty"`
 	ContainerRuntime string `json:"container_runtime,omitempty"` // "docker", "podman", or "auto"
 	ContainerImage   string `json:"container_image,omitempty"`   // default: "syfthub/endpoint-runner:latest"
+
+	// Transaction policy / Tempo settings.
+	// TempoRPCURL is the JSON-RPC URL used to broadcast payment credentials
+	// when an endpoint's transaction policy emits a payment_required event.
+	// May be overridden per-event when the aggregator includes rpc_url.
+	// See unit 9 of the transaction-policy plan (nifty-skipping-rainbow.md).
+	TempoRPCURL string `json:"tempo_rpc_url,omitempty"`
 }
 
 const (

--- a/sdk/golang/syfthub/agent_session.go
+++ b/sdk/golang/syfthub/agent_session.go
@@ -94,6 +94,26 @@ type AgentErrorEvent struct {
 
 func (e *AgentErrorEvent) EventType() string { return "agent.error" }
 
+// AgentPaymentRequiredEvent indicates the agent endpoint's transaction policy
+// requires the caller to sign + submit an on-chain payment credential before
+// the session can proceed. Mirrors the chat SDK's PaymentRequiredEvent but
+// flows over the agent WebSocket envelope ("payment_required" / "agent.payment_required").
+//
+// See unit 10 of the transaction-policy plan (nifty-skipping-rainbow.md).
+type AgentPaymentRequiredEvent struct {
+	ChatSessionID string `json:"chat_session_id"`
+	EndpointSlug  string `json:"endpoint_slug"`
+	Challenge     string `json:"challenge"`
+	Amount        string `json:"amount"`
+	Currency      string `json:"currency"`
+	Recipient     string `json:"recipient"`
+	ChallengeID   string `json:"challenge_id"`
+	Intent        string `json:"intent"`
+	RPCURL        string `json:"rpc_url,omitempty"`
+}
+
+func (e *AgentPaymentRequiredEvent) EventType() string { return "agent.payment_required" }
+
 // AgentSessionClient wraps a WebSocket connection with typed send/receive
 // methods for agent sessions.
 type AgentSessionClient struct {
@@ -308,6 +328,10 @@ func (c *AgentSessionClient) parseEvent(eventType string, payload json.RawMessag
 		event = &e
 	case "agent.error":
 		var e AgentErrorEvent
+		err = json.Unmarshal(payload, &e)
+		event = &e
+	case "agent.payment_required", "payment_required":
+		var e AgentPaymentRequiredEvent
 		err = json.Unmarshal(payload, &e)
 		event = &e
 	default:

--- a/sdk/golang/syfthub/chat.go
+++ b/sdk/golang/syfthub/chat.go
@@ -416,6 +416,19 @@ func (c *ChatResource) parseSSEEvent(eventType, dataStr string) ChatEvent {
 			Error: getString(data, "message"),
 		}
 
+	case "payment_required":
+		return &PaymentRequiredEvent{
+			ChatSessionID: getString(data, "chat_session_id"),
+			EndpointSlug:  getString(data, "endpoint_slug"),
+			Challenge:     getString(data, "challenge"),
+			Amount:        getString(data, "amount"),
+			Currency:      getString(data, "currency"),
+			Recipient:     getString(data, "recipient"),
+			ChallengeID:   getString(data, "challenge_id"),
+			Intent:        getString(data, "intent"),
+			RPCURL:        getString(data, "rpc_url"),
+		}
+
 	default:
 		slog.Warn("unknown SSE event type received from aggregator", "event_type", eventType)
 		return &ErrorEvent{Error: fmt.Sprintf("Unknown event type: %s", eventType)}

--- a/sdk/golang/syfthub/models.go
+++ b/sdk/golang/syfthub/models.go
@@ -549,6 +549,11 @@ const (
 	ChatEventTypeToken               ChatEventType = "token"
 	ChatEventTypeDone                ChatEventType = "done"
 	ChatEventTypeError               ChatEventType = "error"
+	// ChatEventTypePaymentRequired is emitted by the aggregator when an endpoint's
+	// transaction policy requires the caller to sign and submit an on-chain
+	// payment credential before the request can proceed. See unit 10 of the
+	// transaction-policy plan (nifty-skipping-rainbow.md).
+	ChatEventTypePaymentRequired ChatEventType = "payment_required"
 )
 
 // ChatEvent is the interface for all chat streaming events.
@@ -631,6 +636,28 @@ type ErrorEvent struct {
 }
 
 func (e *ErrorEvent) EventType() ChatEventType { return ChatEventTypeError }
+
+// PaymentRequiredEvent indicates the endpoint's transaction policy requires
+// the caller to sign + submit an on-chain payment credential before the
+// request can proceed. The CLI/SDK consumer is expected to (a) prompt the
+// user, (b) sign the challenge with a local wallet, and (c) POST the
+// resulting credential to <aggregator>/chat/{chat_session_id}/payment.
+//
+// All fields mirror the SSE event payload defined by the aggregator
+// (unit 10 of the transaction-policy plan, nifty-skipping-rainbow.md).
+type PaymentRequiredEvent struct {
+	ChatSessionID string `json:"chat_session_id"`
+	EndpointSlug  string `json:"endpoint_slug"`
+	Challenge     string `json:"challenge"`
+	Amount        string `json:"amount"`
+	Currency      string `json:"currency"`
+	Recipient     string `json:"recipient"`
+	ChallengeID   string `json:"challenge_id"`
+	Intent        string `json:"intent"`
+	RPCURL        string `json:"rpc_url,omitempty"`
+}
+
+func (e *PaymentRequiredEvent) EventType() ChatEventType { return ChatEventTypePaymentRequired }
 
 // =============================================================================
 // Transaction Tokens Models


### PR DESCRIPTION
## Summary

Implements unit 9 of the transaction-policy plan (`.claude/plans/nifty-skipping-rainbow.md`).

When the aggregator emits a `payment_required` SSE/WS event:

- **`--json` mode** emits the structured event payload to stdout for external tooling to sign and POST.
- **Interactive mode** prompts y/N, asks for the wallet passphrase, signs the challenge, and POSTs `{challenge_id, credential}` to the aggregator's `/chat/{session_id}/payment` endpoint.

### What's added

- `cli/internal/cmd/payment_handler.go` — `HandlePaymentRequired` plus injectable helpers (`promptPassphrase`, `loadAndDecryptWallet`, `signCredential`, `httpPostCredential`).
- `cli/internal/cmd/payment_handler_test.go` — 4 hermetic tests (JSON mode, denied, approved happy-path, RPC fallback).
- `cli/internal/cmd/query.go` / `agent.go` — wire the new SDK event into each command's stream switch.
- `cli/internal/nodeconfig/config.go` — adds `TempoRPCURL` setting (used as fallback when the event omits `rpc_url`).
- `sdk/golang/syfthub/models.go` + `chat.go` — `PaymentRequiredEvent` + SSE parser case.
- `sdk/golang/syfthub/agent_session.go` — `AgentPaymentRequiredEvent` + WebSocket parser case.

### Dependencies on other units

This unit depends on units 6 (mppx-go) and 8 (wallet) for the real wallet-load + sign primitives. Those aren't merged yet, so the helpers here are stubbed via package-level vars and clearly marked with `// TODO: requires unit 6 / unit 8`. Tests inject mocks; production wiring will be a one-line swap once those units land.

The aggregator endpoint (unit 10) defines the SSE event shape this PR consumes; URL/auth conventions match the plan.

### Constraints

- Strictly additive — existing free-endpoint flows are untouched.
- `--json` mode never prompts; it emits the structured event so external tooling can drive the signing externally.

## Test plan

- [x] `cd cli && go test ./...` — 141 tests pass
- [x] `cd cli && make build && make lint` — passes (lint falls back to `go vet`; clean)
- [x] `cd sdk/golang && go test ./syfthub/...` — 422 tests pass
- [x] Handler tests cover JSON mode, denied prompt, approved happy-path with httptest server (verifies POST URL, Authorization header, and body shape), and RPC URL fallback to config
- [ ] Real e2e against a live aggregator — out of scope here (requires units 6, 8, 10 merged together)