### PR TITLE
feat(transaction-policy): unit 15 — MCP surfaces PAYMENT_REQUIRED as structured tool error

### DIFF
--- a/components/mcp/pyproject.toml
+++ b/components/mcp/pyproject.toml
@@ -32,6 +32,18 @@ dependencies = [
     "syfthub-sdk",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.24.0",
+    "respx>=0.21.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["."]
+python_files = ["test_*.py"]
+
 [tool.setuptools]
 py-modules = ["server", "syfthub_client"]
 

--- a/components/mcp/server.py
+++ b/components/mcp/server.py
@@ -31,7 +31,12 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.backends import default_backend
 import jwt
-from syfthub_client import SyftHubClient, AuthenticationError, SyftHubError
+from syfthub_client import (
+    SyftHubClient,
+    AuthenticationError,
+    SyftHubError,
+    PaymentRequiredError,
+)
 
 # Import SyftHub SDK for endpoint discovery and chat
 try:
@@ -1758,6 +1763,46 @@ def update_router_paths(syftbox_data: Dict[str, Dict[str, Dict]]) -> None:
 
     logger.info(f"Updated router paths mapping with {len(syftbox_router_paths)} entries")
 
+
+# TRANSACTION POLICY HELPERS
+
+def _find_transaction_policy(policies: Any) -> Optional[Dict[str, Any]]:
+    """Return the transaction policy dict if one is enabled on the endpoint.
+
+    Accepts either a list of Policy pydantic models (from the SDK) or a
+    list of plain dicts (raw hub payload), so the same helper works in
+    both production and tests.
+    """
+    if not policies:
+        return None
+    for policy in policies:
+        if hasattr(policy, "type"):
+            ptype = policy.type
+            penabled = getattr(policy, "enabled", True)
+            pconfig = getattr(policy, "config", {}) or {}
+        elif isinstance(policy, dict):
+            ptype = policy.get("type")
+            penabled = policy.get("enabled", True)
+            pconfig = policy.get("config", {}) or {}
+        else:
+            continue
+        if ptype == "transaction" and penabled:
+            return {"type": ptype, "config": pconfig}
+    return None
+
+
+def _format_pricing_hint(transaction_policy: Dict[str, Any]) -> Optional[str]:
+    """Return a human-readable pricing hint from a transaction policy config."""
+    config = transaction_policy.get("config") or {}
+    amount = config.get("amount")
+    currency = config.get("currency", "PathUSD")
+    intent = config.get("intent", "charge")
+    if amount is None:
+        return None
+    suffix = "per session" if intent == "session" else "per call"
+    return f"{amount} {currency} {suffix}"
+
+
 # DISCOVERY & NETWORK TOOLS
 
 @mcp.tool(
@@ -1853,6 +1898,18 @@ def discover_syfthub_endpoints() -> Dict[str, Any]:
                     endpoint_url = conn.config.get("url")
                     break
 
+            # Detect transaction policies (paid endpoints) so MCP callers
+            # can surface pricing alongside discovery. The hub returns the
+            # endpoint's policy list (post-unit-11); pre-unit-11 backends
+            # simply omit it, which falls through to payment_required=False.
+            txn_policy = _find_transaction_policy(
+                getattr(endpoint, "policies", None)
+            )
+            payment_required = txn_policy is not None
+            pricing_hint = (
+                _format_pricing_hint(txn_policy) if txn_policy else None
+            )
+
             entry = {
                 "path": endpoint.path,
                 "name": endpoint.name,
@@ -1862,6 +1919,8 @@ def discover_syfthub_endpoints() -> Dict[str, Any]:
                 "url": endpoint_url,
                 "slug": endpoint.slug,
                 "tenant_name": endpoint.owner_username,
+                "payment_required": payment_required,
+                "pricing_hint": pricing_hint,
             }
 
             if endpoint.type == EndpointType.MODEL:
@@ -1872,24 +1931,31 @@ def discover_syfthub_endpoints() -> Dict[str, Any]:
         # Format output as markdown
         output_lines = ["## Available SyftHub Endpoints\n"]
 
+        def _pricing_cell(entry: Dict[str, Any]) -> str:
+            return entry["pricing_hint"] if entry.get("payment_required") else "Free"
+
         if models:
             output_lines.append("### Models (AI/ML)\n")
-            output_lines.append("| Path | Name | Description | Status |")
-            output_lines.append("|------|------|-------------|--------|")
+            output_lines.append("| Path | Name | Description | Status | Pricing |")
+            output_lines.append("|------|------|-------------|--------|---------|")
             for m in models:
                 status = "✅ Ready" if m["has_url"] else "⚠️ No URL"
                 desc = m["description"][:50] + "..." if len(m["description"]) > 50 else m["description"]
-                output_lines.append(f"| `{m['path']}` | {m['name']} | {desc} | {status} |")
+                output_lines.append(
+                    f"| `{m['path']}` | {m['name']} | {desc} | {status} | {_pricing_cell(m)} |"
+                )
             output_lines.append("")
 
         if data_sources:
             output_lines.append("### Data Sources (RAG)\n")
-            output_lines.append("| Path | Name | Description | Status |")
-            output_lines.append("|------|------|-------------|--------|")
+            output_lines.append("| Path | Name | Description | Status | Pricing |")
+            output_lines.append("|------|------|-------------|--------|---------|")
             for ds in data_sources:
                 status = "✅ Ready" if ds["has_url"] else "⚠️ No URL"
                 desc = ds["description"][:50] + "..." if len(ds["description"]) > 50 else ds["description"]
-                output_lines.append(f"| `{ds['path']}` | {ds['name']} | {desc} | {status} |")
+                output_lines.append(
+                    f"| `{ds['path']}` | {ds['name']} | {desc} | {status} | {_pricing_cell(ds)} |"
+                )
             output_lines.append("")
 
         if not models and not data_sources:
@@ -2109,6 +2175,32 @@ def chat_with_syfthub(
             "timestamp": datetime.now().isoformat()
         }
 
+    except PaymentRequiredError as e:
+        # MCP clients have no wallet — surface the challenge as a structured
+        # tool result so the LLM can route the user to the CLI / desktop app.
+        logger.info(
+            f"Endpoint {e.endpoint_slug} requires payment "
+            f"({e.amount} {e.currency} to {e.recipient}); "
+            f"returning structured payment_required error to MCP client"
+        )
+        return {
+            "success": False,
+            "ok": False,
+            "error_type": "payment_required",
+            **e.to_dict(),
+            "message": (
+                f"This endpoint requires payment of {e.amount} {e.currency} "
+                f"to {e.recipient}.\n\n"
+                f"MCP cannot complete this payment for you. To pay, please "
+                f"use the SyftHub desktop app or the `syft` CLI:\n"
+                f"  $ syft wallet init\n"
+                f"  $ syft query {e.endpoint_slug} '<your prompt>'\n\n"
+                f"Challenge ID: {e.challenge_id}"
+            ),
+            "prompt": prompt,
+            "model": model,
+            "timestamp": datetime.now().isoformat(),
+        }
     except AggregatorError as e:
         logger.error(f"Aggregator error in chat: {e}")
         return {

--- a/components/mcp/syfthub_client.py
+++ b/components/mcp/syfthub_client.py
@@ -9,10 +9,23 @@ The client handles:
 - User authentication (login with email/password)
 - User profile retrieval
 - Accounting credentials retrieval for paid service access
+- Aggregator chat streaming with payment-required event detection
+
+# MCP and paid endpoints
+#
+# MCP tool callers (Claude, ChatGPT, IDE assistants) do not have wallets
+# and cannot sign Tempo transactions. When a paid endpoint is invoked
+# through MCP, the chat_with_syfthub tool returns a structured error
+# explaining that the user must pay via the syft CLI or desktop app.
+#
+# This is a known v1 limitation. v2 may introduce a paired-wallet flow
+# where the MCP server proxies challenges to a long-lived CLI wallet
+# daemon, but that is out of scope for now.
 """
 
+import json
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, AsyncIterator, Dict, Optional
 
 import httpx
 
@@ -35,6 +48,73 @@ class ConnectionError(SyftHubError):
     """Raised when connection to SyftHub fails."""
 
     pass
+
+
+class PaymentRequiredError(Exception):
+    """Raised when an aggregator chat call requires payment that the MCP
+    layer cannot provide (no wallet)."""
+
+    def __init__(
+        self,
+        *,
+        endpoint_slug: str,
+        challenge: str,
+        amount: str,
+        currency: str,
+        recipient: str,
+        challenge_id: str,
+        intent: str,
+    ):
+        self.endpoint_slug = endpoint_slug
+        self.challenge = challenge
+        self.amount = amount
+        self.currency = currency
+        self.recipient = recipient
+        self.challenge_id = challenge_id
+        self.intent = intent
+        super().__init__(
+            f"Endpoint {endpoint_slug} requires payment of {amount} "
+            f"{currency} to {recipient}; MCP cannot complete this payment."
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "error": "payment_required",
+            "endpoint_slug": self.endpoint_slug,
+            "amount": self.amount,
+            "currency": self.currency,
+            "recipient": self.recipient,
+            "challenge_id": self.challenge_id,
+            "intent": self.intent,
+            "hint": (
+                "Use the syft CLI ('syft wallet' + 'syft query') or the "
+                "SyftHub desktop app to pay this endpoint."
+            ),
+        }
+
+
+def _build_payment_required_error(data: Dict[str, Any]) -> "PaymentRequiredError":
+    """Construct a :class:`PaymentRequiredError` from an SSE event payload.
+
+    The aggregator emits (per plan unit 10)::
+
+        event: payment_required
+        data: {chat_session_id, endpoint_slug, challenge, amount, currency,
+               recipient, challenge_id, intent}
+
+    Missing fields default to empty strings so the error is always raisable
+    even if the aggregator omits a field; callers can still inspect what
+    was present.
+    """
+    return PaymentRequiredError(
+        endpoint_slug=str(data.get("endpoint_slug", "")),
+        challenge=str(data.get("challenge", "")),
+        amount=str(data.get("amount", "")),
+        currency=str(data.get("currency", "")),
+        recipient=str(data.get("recipient", "")),
+        challenge_id=str(data.get("challenge_id", "")),
+        intent=str(data.get("intent", "")),
+    )
 
 
 class SyftHubClient:
@@ -276,6 +356,107 @@ class SyftHubClient:
             error_msg = f"Unexpected error fetching accounting credentials: {e}"
             logger.error(error_msg)
             raise SyftHubError(error_msg) from e
+
+    async def chat_stream(
+        self,
+        *,
+        aggregator_url: str,
+        request_body: Dict[str, Any],
+        access_token: Optional[str] = None,
+    ) -> AsyncIterator[Dict[str, Any]]:
+        """
+        Stream chat events from the aggregator's SSE endpoint, detecting
+        ``payment_required`` events.
+
+        This is a thin wrapper around the aggregator's ``POST /chat/stream``
+        SSE endpoint. It does its own SSE parsing so it can recognise the
+        ``payment_required`` event added by the transaction-policy work
+        (plan unit 10) and raise :class:`PaymentRequiredError` on the
+        FIRST such event — even if multiple endpoints in the same chat
+        require payment, the LLM caller only needs to know one is required.
+
+        All other events are yielded verbatim as ``{"type": str, "data": dict}``
+        for callers that want to consume the stream (e.g. accumulating tokens
+        for a non-streaming response).
+
+        Args:
+            aggregator_url: Base aggregator URL (e.g. ``http://aggregator:8001``).
+                The ``/chat/stream`` path is appended.
+            request_body: Aggregator request body (already shaped by the SDK
+                or caller — model_ref, ds_refs, tokens, etc.).
+            access_token: Optional bearer token for the aggregator request.
+
+        Yields:
+            Dicts with ``type`` (event name) and ``data`` (parsed JSON payload).
+
+        Raises:
+            PaymentRequiredError: If a ``payment_required`` SSE event is seen.
+            ConnectionError: If the aggregator cannot be reached.
+            SyftHubError: For other aggregator errors.
+        """
+        url = f"{aggregator_url.rstrip('/')}/chat/stream"
+        headers: Dict[str, str] = {
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+        }
+        if access_token:
+            headers["Authorization"] = f"Bearer {access_token}"
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                async with client.stream(
+                    "POST", url, json=request_body, headers=headers
+                ) as response:
+                    if response.status_code >= 400:
+                        body = await response.aread()
+                        raise SyftHubError(
+                            f"Aggregator returned {response.status_code}: "
+                            f"{body.decode('utf-8', errors='replace')[:500]}"
+                        )
+
+                    current_event: Optional[str] = None
+                    current_data: str = ""
+
+                    async for line in response.aiter_lines():
+                        line = line.strip()
+
+                        if not line:
+                            if current_event and current_data:
+                                try:
+                                    data = json.loads(current_data)
+                                except json.JSONDecodeError as exc:
+                                    logger.warning(
+                                        f"Failed to parse SSE data for "
+                                        f"event={current_event}: {exc}"
+                                    )
+                                    current_event = None
+                                    current_data = ""
+                                    continue
+
+                                if current_event == "payment_required":
+                                    raise _build_payment_required_error(data)
+
+                                yield {"type": current_event, "data": data}
+
+                            current_event = None
+                            current_data = ""
+                            continue
+
+                        if line.startswith("event:"):
+                            current_event = line[len("event:") :].strip()
+                        elif line.startswith("data:"):
+                            current_data = line[len("data:") :].strip()
+
+        except httpx.ConnectError as e:
+            raise ConnectionError(
+                f"Failed to connect to aggregator at {url}: {e}"
+            ) from e
+        except httpx.TimeoutException as e:
+            raise ConnectionError(f"Aggregator request timed out: {e}") from e
+        except (PaymentRequiredError, SyftHubError, ConnectionError):
+            raise
+        except Exception as e:
+            raise SyftHubError(f"Unexpected error during chat stream: {e}") from e
 
     async def check_health(self) -> bool:
         """

--- a/components/mcp/test_payment_required.py
+++ b/components/mcp/test_payment_required.py
@@ -1,0 +1,379 @@
+"""
+Tests for the transaction-policy MCP integration (plan unit 15).
+
+Covers:
+1. ``chat_stream`` raises :class:`PaymentRequiredError` when the aggregator
+   emits a ``payment_required`` SSE event.
+2. ``chat_with_syfthub`` translates :class:`PaymentRequiredError` into a
+   structured, LLM-friendly tool result.
+3. ``discover_syfthub_endpoints`` annotates paid endpoints with
+   ``payment_required: True`` and a non-null ``pricing_hint``.
+4. Non-paid endpoints round-trip with ``payment_required: False`` and
+   ``pricing_hint: None``.
+
+Run from the ``components/mcp`` directory::
+
+    uv run pytest -v
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+import syfthub_client
+from syfthub_client import (
+    PaymentRequiredError,
+    SyftHubClient,
+    _build_payment_required_error,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+PAYMENT_EVENT_DATA = {
+    "chat_session_id": "sess-abc",
+    "endpoint_slug": "alice/paid-model",
+    "challenge": "Payment id=ch-1, amount=0.10, currency=PathUSD",
+    "amount": "0.10",
+    "currency": "PathUSD",
+    "recipient": "0xRECIPIENT",
+    "challenge_id": "ch-1",
+    "intent": "charge",
+}
+
+
+def _sse_bytes(events: list[tuple[str, dict]]) -> bytes:
+    """Encode a list of (event_name, data_dict) into raw SSE bytes."""
+    parts = []
+    for name, data in events:
+        parts.append(f"event: {name}\n")
+        parts.append(f"data: {json.dumps(data)}\n")
+        parts.append("\n")
+    return "".join(parts).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Test 1: chat_stream raises PaymentRequiredError on the SSE event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_raises_payment_required():
+    """The first ``payment_required`` SSE event must raise the typed error
+    with all metadata fields populated, even if other events follow."""
+    body = _sse_bytes(
+        [
+            ("retrieval_start", {"sources": 1}),
+            ("payment_required", PAYMENT_EVENT_DATA),
+            # This token event must NOT be observed: the stream stops
+            # at the first payment_required event.
+            ("token", {"content": "should never see this"}),
+        ]
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=body,
+            headers={"content-type": "text/event-stream"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = SyftHubClient(base_url="http://aggregator:8001")
+
+    seen_events: list[dict] = []
+
+    real_async_client = httpx.AsyncClient
+
+    def make_async_client(*_args, **_kwargs):
+        return real_async_client(transport=transport)
+
+    with patch.object(syfthub_client.httpx, "AsyncClient", side_effect=make_async_client):
+        with pytest.raises(PaymentRequiredError) as excinfo:
+            async for ev in client.chat_stream(
+                aggregator_url="http://aggregator:8001",
+                request_body={"prompt": "hi", "model_ref": "alice/paid-model"},
+            ):
+                seen_events.append(ev)
+
+    err = excinfo.value
+    assert err.endpoint_slug == "alice/paid-model"
+    assert err.challenge == PAYMENT_EVENT_DATA["challenge"]
+    assert err.amount == "0.10"
+    assert err.currency == "PathUSD"
+    assert err.recipient == "0xRECIPIENT"
+    assert err.challenge_id == "ch-1"
+    assert err.intent == "charge"
+
+    # Pre-payment events are still streamed; post-payment ones are not.
+    assert seen_events == [{"type": "retrieval_start", "data": {"sources": 1}}]
+
+    # to_dict() carries the full payload + a CLI hint for the LLM.
+    payload = err.to_dict()
+    assert payload["error"] == "payment_required"
+    assert payload["amount"] == "0.10"
+    assert "syft" in payload["hint"]
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_raises_on_first_of_multiple_payment_events():
+    """Multi-endpoint chats may emit several ``payment_required`` events;
+    we only need to surface the first to the LLM."""
+    second = dict(PAYMENT_EVENT_DATA)
+    second["endpoint_slug"] = "bob/other-paid-endpoint"
+    second["challenge_id"] = "ch-2"
+
+    body = _sse_bytes(
+        [
+            ("payment_required", PAYMENT_EVENT_DATA),
+            ("payment_required", second),
+        ]
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=body)
+
+    transport = httpx.MockTransport(handler)
+    client = SyftHubClient(base_url="http://aggregator:8001")
+
+    real_async_client = httpx.AsyncClient
+
+    def make_async_client(*_args, **_kwargs):
+        return real_async_client(transport=transport)
+
+    with patch.object(syfthub_client.httpx, "AsyncClient", side_effect=make_async_client):
+        with pytest.raises(PaymentRequiredError) as excinfo:
+            async for _ in client.chat_stream(
+                aggregator_url="http://aggregator:8001",
+                request_body={},
+            ):
+                pass
+
+    # First event wins.
+    assert excinfo.value.challenge_id == "ch-1"
+    assert excinfo.value.endpoint_slug == "alice/paid-model"
+
+
+def test_build_payment_required_error_handles_missing_fields():
+    """Defensive defaults: empty strings rather than KeyError."""
+    err = _build_payment_required_error({"endpoint_slug": "x/y"})
+    assert err.endpoint_slug == "x/y"
+    assert err.amount == ""
+    assert err.currency == ""
+    assert err.challenge_id == ""
+
+
+# ---------------------------------------------------------------------------
+# Test 2: chat_with_syfthub returns the friendly structured error
+# ---------------------------------------------------------------------------
+
+
+def _make_payment_required_error() -> PaymentRequiredError:
+    return PaymentRequiredError(
+        endpoint_slug="alice/paid-model",
+        challenge="Payment id=ch-1, amount=0.10",
+        amount="0.10",
+        currency="PathUSD",
+        recipient="0xRECIPIENT",
+        challenge_id="ch-1",
+        intent="charge",
+    )
+
+
+def test_chat_with_syfthub_returns_friendly_error(monkeypatch):
+    """When the underlying SDK call raises ``PaymentRequiredError``, the
+    MCP tool must return a structured dict with the amount, recipient,
+    and CLI hint formatted for an LLM caller."""
+    import server
+
+    # Stub the auth + SDK client plumbing so we exercise only the catch.
+    monkeypatch.setattr(server, "SDK_AVAILABLE", True)
+    monkeypatch.setattr(
+        server, "get_current_user_email", lambda: "alice@example.com"
+    )
+
+    fake_client = MagicMock()
+    fake_client.chat.complete.side_effect = _make_payment_required_error()
+    monkeypatch.setattr(
+        server, "get_sdk_client_for_user", lambda email: fake_client
+    )
+
+    result = server.chat_with_syfthub(
+        prompt="What is 2+2?",
+        model="alice/paid-model",
+        data_sources=None,
+    )
+
+    assert result["success"] is False
+    assert result["ok"] is False
+    assert result["error_type"] == "payment_required"
+    assert result["amount"] == "0.10"
+    assert result["currency"] == "PathUSD"
+    assert result["recipient"] == "0xRECIPIENT"
+    assert result["challenge_id"] == "ch-1"
+    assert result["intent"] == "charge"
+    assert "syft wallet init" in result["message"]
+    assert "alice/paid-model" in result["message"]
+    assert "0.10 PathUSD" in result["message"]
+    assert "0xRECIPIENT" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# Test 3: discover_syfthub_endpoints marks paid endpoints
+# ---------------------------------------------------------------------------
+
+
+def _fake_endpoint(
+    *,
+    slug: str,
+    name: str,
+    owner: str,
+    endpoint_type,
+    policies: list,
+    has_url: bool = True,
+):
+    """Build a minimal endpoint object that quacks like an ``EndpointPublic``."""
+    conn_config = {"url": "https://example.com"} if has_url else {}
+    return SimpleNamespace(
+        path=f"{owner}/{slug}",
+        name=name,
+        slug=slug,
+        owner_username=owner,
+        description="desc",
+        type=endpoint_type,
+        connect=[
+            SimpleNamespace(enabled=has_url, config=conn_config),
+        ],
+        policies=policies,
+    )
+
+
+def test_discover_endpoints_marks_paid(monkeypatch):
+    """Endpoints with an enabled ``transaction`` policy must be flagged
+    as paid in the discovery response."""
+    import server
+    from syfthub_sdk.models import EndpointType, Policy
+
+    monkeypatch.setattr(server, "SDK_AVAILABLE", True)
+    monkeypatch.setattr(
+        server, "get_current_user_email", lambda: "alice@example.com"
+    )
+
+    txn_policy = Policy(
+        type="transaction",
+        config={
+            "amount": "0.10",
+            "currency": "PathUSD",
+            "intent": "charge",
+            "recipient": "0xRECIPIENT",
+        },
+    )
+
+    paid = _fake_endpoint(
+        slug="paid-model",
+        name="Paid Model",
+        owner="alice",
+        endpoint_type=EndpointType.MODEL,
+        policies=[txn_policy],
+    )
+
+    fake_client = MagicMock()
+    fake_client.hub.browse.return_value = iter([paid])
+    monkeypatch.setattr(
+        server, "get_sdk_client_for_user", lambda email: fake_client
+    )
+
+    result = server.discover_syfthub_endpoints()
+
+    assert result["success"] is True
+    models = result["models"]
+    assert len(models) == 1
+    entry = models[0]
+    assert entry["payment_required"] is True
+    assert entry["pricing_hint"] == "0.10 PathUSD per call"
+    # And the markdown rendering surfaces it
+    assert "0.10 PathUSD per call" in result["formatted_output"]
+
+
+def test_discover_endpoints_normal_endpoint_unaffected(monkeypatch):
+    """Endpoints without a transaction policy must be reported as free."""
+    import server
+    from syfthub_sdk.models import EndpointType
+
+    monkeypatch.setattr(server, "SDK_AVAILABLE", True)
+    monkeypatch.setattr(
+        server, "get_current_user_email", lambda: "alice@example.com"
+    )
+
+    free = _fake_endpoint(
+        slug="free-model",
+        name="Free Model",
+        owner="bob",
+        endpoint_type=EndpointType.MODEL,
+        policies=[],
+    )
+
+    fake_client = MagicMock()
+    fake_client.hub.browse.return_value = iter([free])
+    monkeypatch.setattr(
+        server, "get_sdk_client_for_user", lambda email: fake_client
+    )
+
+    result = server.discover_syfthub_endpoints()
+
+    assert result["success"] is True
+    entry = result["models"][0]
+    assert entry["payment_required"] is False
+    assert entry["pricing_hint"] is None
+    assert "Free" in result["formatted_output"]
+
+
+def test_find_transaction_policy_with_dict_input():
+    """The helper accepts plain-dict policies (used by the hub raw payload)."""
+    from server import _find_transaction_policy, _format_pricing_hint
+
+    policies = [
+        {"type": "rate_limit", "enabled": True, "config": {}},
+        {
+            "type": "transaction",
+            "enabled": True,
+            "config": {"amount": "5", "currency": "USDC", "intent": "session"},
+        },
+    ]
+    found = _find_transaction_policy(policies)
+    assert found is not None
+    assert _format_pricing_hint(found) == "5 USDC per session"
+
+
+def test_find_transaction_policy_skips_disabled():
+    from server import _find_transaction_policy
+
+    policies = [
+        {
+            "type": "transaction",
+            "enabled": False,
+            "config": {"amount": "1", "currency": "PathUSD"},
+        }
+    ]
+    assert _find_transaction_policy(policies) is None
+
+
+def test_find_transaction_policy_handles_none_and_empty():
+    from server import _find_transaction_policy
+
+    assert _find_transaction_policy(None) is None
+    assert _find_transaction_policy([]) is None
+
+
+def test_format_pricing_hint_returns_none_without_amount():
+    from server import _format_pricing_hint
+
+    assert _format_pricing_hint({"config": {"currency": "USD"}}) is None

--- a/components/mcp/uv.lock
+++ b/components/mcp/uv.lock
@@ -671,6 +671,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1050,6 +1059,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1300,6 +1318,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1415,6 +1462,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]
@@ -1607,6 +1666,13 @@ dependencies = [
     { name = "werkzeug" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "respx" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
@@ -1618,15 +1684,19 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.23.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pyjwt", specifier = ">=2.12.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = ">=0.0.26" },
     { name = "requests", specifier = ">=2.32.4" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "starlette", specifier = ">=0.49.1" },
     { name = "syft-accounting-sdk", git = "https://github.com/OpenMined/accounting-sdk.git" },
     { name = "syfthub-sdk", editable = "../../sdk/python" },
     { name = "urllib3", specifier = ">=2.6.3" },
     { name = "werkzeug", specifier = ">=3.1.6" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "syfthub-sdk"


### PR DESCRIPTION
## Summary
- Adds `PaymentRequiredError` + `chat_stream` SSE parser to `components/mcp/syfthub_client.py`. The streamer raises on the first `event: payment_required` (introduced in plan unit 10), so multi-endpoint chats only surface one challenge to the LLM caller.
- `chat_with_syfthub` MCP tool catches `PaymentRequiredError` and returns a structured tool result (`error_type: "payment_required"`, amount/currency/recipient/challenge_id) plus a human-readable message that walks the user through `syft wallet init` + `syft query`.
- `discover_syfthub_endpoints` annotates each endpoint with `payment_required` + a `pricing_hint` (e.g. `"0.10 PathUSD per call"`) derived from any enabled `transaction` policy on the endpoint, and adds a Pricing column to the markdown listing.
- Adds 10 new tests in `components/mcp/test_payment_required.py` covering SSE parsing, multi-event handling, missing-field defaults, the tool's friendly error translation, and discovery for both paid and free endpoints.
- Adds `[project.optional-dependencies].dev` (pytest + pytest-asyncio + respx) and a pytest config block in `components/mcp/pyproject.toml`.

This is unit 15 of the 15-unit transaction-policy batch (plan: `/home/junior/.claude/plans/nifty-skipping-rainbow.md`). Strictly additive: existing free-endpoint chat calls and discovery output are unaffected (pre-unit-11 backends omit `policies` → `payment_required: False`).

## MCP v1 limitation, by design
MCP clients (Claude / ChatGPT / IDE assistants) have no wallet, so paying through MCP is impossible. This unit makes that explicit: instead of failing with an opaque error, the LLM gets a structured payload it can use to instruct the human user to pay via the syft CLI or desktop app. v2 may proxy challenges to a long-lived wallet daemon — out of scope here.

## Test plan
- [x] `cd components/mcp && uv sync --extra dev && uv run pytest -v` — 10/10 pass
- [x] `uv run python -c "import server; import syfthub_client; print('ok')"` — clean import
- [ ] Once aggregator unit 10 lands, verify e2e: aggregator emits `event: payment_required` → MCP tool returns `error_type: "payment_required"` payload to the LLM client.