### PR TITLE
feat(transaction-policy): unit 14 — frontend paid-endpoint badge + payment history

### DIFF
--- a/components/frontend/src/components/__tests__/settings-modal.test.tsx
+++ b/components/frontend/src/components/__tests__/settings-modal.test.tsx
@@ -28,6 +28,10 @@ vi.mock('@/components/settings/payment-settings-tab', () => ({
   PaymentSettingsTab: () => <div data-testid='payment-tab'>Payment Content</div>
 }));
 
+vi.mock('@/components/settings/payment-history-tab', () => ({
+  PaymentHistoryTab: () => <div data-testid='payment-history-tab'>Payment History Content</div>
+}));
+
 vi.mock('@/components/settings/aggregator-settings-tab', () => ({
   AggregatorSettingsTab: () => <div data-testid='aggregator-tab'>Aggregator Content</div>
 }));

--- a/components/frontend/src/components/browse-view.tsx
+++ b/components/frontend/src/components/browse-view.tsx
@@ -21,7 +21,7 @@ import X from 'lucide-react/dist/esm/icons/x';
 import { Link } from 'react-router-dom';
 
 import { usePaginatedPublicEndpoints } from '@/hooks/use-endpoint-queries';
-import { isDataSourceEndpoint } from '@/lib/endpoint-utils';
+import { formatPricingBadge, getPricing, isDataSourceEndpoint } from '@/lib/endpoint-utils';
 import { useContextSelectionStore } from '@/stores/context-selection-store';
 
 import {
@@ -71,6 +71,23 @@ const TAB_CONFIG: Record<
   models: { endpointType: 'model', entityName: 'models', icon: Sparkles, label: 'Models' }
   // agents: { endpointType: 'agent', entityName: 'agents', icon: Bot, label: 'Agents' }
 };
+
+// Renders the on-chain pricing badge when an endpoint has a transaction policy.
+// Renders nothing for free endpoints, so it is safe to drop into any header.
+function PricingBadge({ endpoint }: Readonly<{ endpoint: ChatSource }>) {
+  const pricing = getPricing(endpoint);
+  if (!pricing) return null;
+  const label = formatPricingBadge(pricing);
+  return (
+    <Badge
+      variant='outline'
+      className='font-inter shrink-0 border-amber-500/40 bg-amber-100 px-1.5 py-0 text-[0.65rem] font-bold text-amber-900 dark:bg-amber-500/15 dark:text-amber-300'
+      title={`Costs ${label} per call to ${pricing.recipient.slice(0, 6)}…`}
+    >
+      {label}
+    </Badge>
+  );
+}
 
 // ============================================================================
 // Main Component
@@ -465,6 +482,7 @@ export function BrowseView({ initialQuery = '' }: Readonly<BrowseViewProperties>
                           <h3 className='font-inter text-foreground group-hover:text-primary flex items-center gap-1.5 text-base font-semibold'>
                             <EndpointTypeIcon type={endpoint.type} />
                             <span className='truncate'>{endpoint.name}</span>
+                            <PricingBadge endpoint={endpoint} />
                           </h3>
                           {endpoint.owner_username && (
                             <p className='font-inter text-muted-foreground mt-0.5 truncate text-xs'>

--- a/components/frontend/src/components/settings/__tests__/payment-history-tab.test.tsx
+++ b/components/frontend/src/components/settings/__tests__/payment-history-tab.test.tsx
@@ -1,0 +1,128 @@
+import type { PaymentHistoryEntry } from '../payment-history-tab';
+
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { PAYMENT_HISTORY_STORAGE_KEY, PaymentHistoryTab } from '../payment-history-tab';
+
+const ENTRY_OLD: PaymentHistoryEntry = {
+  timestamp: '2026-04-01T10:00:00.000Z',
+  endpoint_slug: 'alice/old',
+  amount: '0.10',
+  currency: '0x20c0000000000000000000000000000000000000',
+  tx_hash: '0xdeadbeef0000000000000000000000000000000000000000000000000000aaaa',
+  status: 'verified'
+};
+
+const ENTRY_NEW: PaymentHistoryEntry = {
+  timestamp: '2026-05-01T12:00:00.000Z',
+  endpoint_slug: 'bob/new',
+  amount: '0.50',
+  currency: '0x20c0000000000000000000000000000000000000',
+  tx_hash: '0xfeed00000000000000000000000000000000000000000000000000000000bbbb',
+  status: 'failed'
+};
+
+function seed(entries: PaymentHistoryEntry[]): void {
+  localStorage.setItem(PAYMENT_HISTORY_STORAGE_KEY, JSON.stringify(entries));
+}
+
+describe('PaymentHistoryTab', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders the empty state when localStorage is empty', () => {
+    render(<PaymentHistoryTab />);
+    expect(screen.getByTestId('payment-history-empty')).toBeInTheDocument();
+    expect(screen.getByText(/No payments yet/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('payment-history-table')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty state when localStorage holds invalid JSON', () => {
+    localStorage.setItem(PAYMENT_HISTORY_STORAGE_KEY, '{not json');
+    render(<PaymentHistoryTab />);
+    expect(screen.getByTestId('payment-history-empty')).toBeInTheDocument();
+  });
+
+  it('renders entries from localStorage in reverse-chronological order', () => {
+    seed([ENTRY_OLD, ENTRY_NEW]);
+
+    render(<PaymentHistoryTab />);
+
+    const rows = screen.getAllByTestId('payment-history-row');
+    expect(rows).toHaveLength(2);
+    // Newer entry first
+    expect(rows[0]).toHaveTextContent('bob/new');
+    expect(rows[1]).toHaveTextContent('alice/old');
+  });
+
+  it('shows the correct status badges for each entry', () => {
+    seed([ENTRY_OLD, ENTRY_NEW]);
+    render(<PaymentHistoryTab />);
+    expect(screen.getByTestId('payment-status-verified')).toBeInTheDocument();
+    expect(screen.getByTestId('payment-status-failed')).toBeInTheDocument();
+  });
+
+  it('renders a transaction explorer link with the truncated tx hash', () => {
+    seed([ENTRY_OLD]);
+    render(<PaymentHistoryTab />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', `https://explorer.tempo.example/tx/${ENTRY_OLD.tx_hash}`);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveTextContent(`${ENTRY_OLD.tx_hash.slice(0, 10)}…`);
+  });
+
+  it('updates when a storage event fires for the payment history key', () => {
+    render(<PaymentHistoryTab />);
+    expect(screen.getByTestId('payment-history-empty')).toBeInTheDocument();
+
+    const newValue = JSON.stringify([ENTRY_NEW]);
+    localStorage.setItem(PAYMENT_HISTORY_STORAGE_KEY, newValue);
+
+    act(() => {
+      globalThis.dispatchEvent(
+        new StorageEvent('storage', {
+          key: PAYMENT_HISTORY_STORAGE_KEY,
+          newValue
+        })
+      );
+    });
+
+    expect(screen.getByTestId('payment-history-table')).toBeInTheDocument();
+    expect(screen.getByText('bob/new')).toBeInTheDocument();
+  });
+
+  it('ignores storage events for unrelated keys', () => {
+    seed([ENTRY_NEW]);
+    render(<PaymentHistoryTab />);
+    expect(screen.getByText('bob/new')).toBeInTheDocument();
+
+    act(() => {
+      globalThis.dispatchEvent(
+        new StorageEvent('storage', { key: 'something_else', newValue: '[]' })
+      );
+    });
+
+    // Existing entry still rendered, untouched.
+    expect(screen.getByText('bob/new')).toBeInTheDocument();
+  });
+
+  it('clears history when the clear button is clicked', async () => {
+    const user = userEvent.setup();
+    seed([ENTRY_OLD, ENTRY_NEW]);
+
+    render(<PaymentHistoryTab />);
+    expect(screen.getAllByTestId('payment-history-row')).toHaveLength(2);
+
+    await user.click(screen.getByTestId('payment-history-clear'));
+
+    expect(screen.getByTestId('payment-history-empty')).toBeInTheDocument();
+    expect(localStorage.getItem(PAYMENT_HISTORY_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/components/frontend/src/components/settings/payment-history-tab.tsx
+++ b/components/frontend/src/components/settings/payment-history-tab.tsx
@@ -1,0 +1,225 @@
+/**
+ * Payment History Settings Tab
+ *
+ * Renders the user's local on-chain payment history (Tempo via MPP-over-NATS).
+ * Entries are written purely client-side by the payment modal (unit 13) into
+ * `localStorage["syft_payment_history_v1"]`. This tab never makes a hub call.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+import ExternalLink from 'lucide-react/dist/esm/icons/external-link';
+import Trash2 from 'lucide-react/dist/esm/icons/trash-2';
+
+import { Button } from '@/components/ui/button';
+import { formatRelativeTime } from '@/lib/date-utils';
+import { cn } from '@/lib/utils';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+export const PAYMENT_HISTORY_STORAGE_KEY = 'syft_payment_history_v1';
+
+const TX_EXPLORER_URL = 'https://explorer.tempo.example/tx';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type PaymentHistoryStatus = 'verified' | 'failed' | 'required';
+
+export interface PaymentHistoryEntry {
+  timestamp: string;
+  endpoint_slug: string;
+  amount: string;
+  currency: string;
+  tx_hash: string;
+  status: PaymentHistoryStatus;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function isValidEntry(entry: PaymentHistoryEntry | null | undefined): entry is PaymentHistoryEntry {
+  return (
+    entry !== null &&
+    entry !== undefined &&
+    typeof entry.timestamp === 'string' &&
+    typeof entry.endpoint_slug === 'string' &&
+    typeof entry.tx_hash === 'string'
+  );
+}
+
+function parseEntries(raw: string | null): PaymentHistoryEntry[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    // Filter out malformed entries; sort newest first.
+    return (parsed as PaymentHistoryEntry[])
+      .filter((entry) => isValidEntry(entry))
+      .toSorted((a, b) => b.timestamp.localeCompare(a.timestamp));
+  } catch (error) {
+    console.error('invalid payment history', error);
+    return [];
+  }
+}
+
+function truncate(value: string, head: number, tail = 0): string {
+  if (value.length <= head + tail + 1) return value;
+  if (tail === 0) return `${value.slice(0, head)}…`;
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
+// =============================================================================
+// Status Badge
+// =============================================================================
+
+const STATUS_LABEL: Record<PaymentHistoryStatus, string> = {
+  verified: 'Verified',
+  failed: 'Failed',
+  required: 'Required'
+};
+
+const STATUS_CLASS: Record<PaymentHistoryStatus, string> = {
+  verified: 'bg-emerald-100 text-emerald-900 dark:bg-emerald-500/15 dark:text-emerald-300',
+  failed: 'bg-red-100 text-red-900 dark:bg-red-500/15 dark:text-red-300',
+  required: 'bg-amber-100 text-amber-900 dark:bg-amber-500/15 dark:text-amber-300'
+};
+
+function StatusBadge({ status }: Readonly<{ status: PaymentHistoryStatus }>) {
+  const label = STATUS_LABEL[status];
+  const cls = STATUS_CLASS[status];
+  return (
+    <span
+      className={cn('inline-flex rounded-md px-2 py-0.5 text-xs font-semibold', cls)}
+      data-testid={`payment-status-${status}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+// =============================================================================
+// Main Component
+// =============================================================================
+
+export function PaymentHistoryTab() {
+  const [entries, setEntries] = useState<PaymentHistoryEntry[]>([]);
+
+  // Initial load
+  useEffect(() => {
+    setEntries(parseEntries(localStorage.getItem(PAYMENT_HISTORY_STORAGE_KEY)));
+  }, []);
+
+  // Cross-tab sync: refresh when another tab writes a payment.
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key !== PAYMENT_HISTORY_STORAGE_KEY) return;
+      setEntries(parseEntries(e.newValue));
+    };
+    globalThis.addEventListener('storage', handler);
+    return () => {
+      globalThis.removeEventListener('storage', handler);
+    };
+  }, []);
+
+  const handleClear = useCallback(() => {
+    localStorage.removeItem(PAYMENT_HISTORY_STORAGE_KEY);
+    setEntries([]);
+  }, []);
+
+  return (
+    <div className='space-y-6'>
+      <div>
+        <h3 className='text-foreground text-lg font-semibold'>Payment History</h3>
+        <p className='text-muted-foreground mt-1 text-sm'>
+          On-chain payments you&apos;ve made for paid endpoints. Stored locally in this browser
+          only.
+        </p>
+      </div>
+
+      {entries.length === 0 ? (
+        <div
+          className='border-border bg-muted/30 rounded-lg border border-dashed p-8 text-center'
+          data-testid='payment-history-empty'
+        >
+          <p className='text-foreground text-sm font-medium'>No payments yet.</p>
+          <p className='text-muted-foreground mt-1 text-sm'>
+            When you pay for a paid endpoint, it&apos;ll appear here.
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className='border-border overflow-hidden rounded-lg border'>
+            <table className='w-full text-left text-sm' data-testid='payment-history-table'>
+              <thead className='bg-muted text-muted-foreground text-xs uppercase'>
+                <tr>
+                  <th className='px-3 py-2 font-medium'>Time</th>
+                  <th className='px-3 py-2 font-medium'>Endpoint</th>
+                  <th className='px-3 py-2 font-medium'>Amount</th>
+                  <th className='px-3 py-2 font-medium'>Currency</th>
+                  <th className='px-3 py-2 font-medium'>Tx</th>
+                  <th className='px-3 py-2 font-medium'>Status</th>
+                </tr>
+              </thead>
+              <tbody className='divide-border divide-y'>
+                {entries.map((entry) => (
+                  <tr
+                    key={`${entry.tx_hash}-${entry.timestamp}`}
+                    className='hover:bg-muted/40'
+                    data-testid='payment-history-row'
+                  >
+                    <td
+                      className='text-muted-foreground px-3 py-2 whitespace-nowrap'
+                      title={entry.timestamp}
+                    >
+                      {formatRelativeTime(entry.timestamp)}
+                    </td>
+                    <td className='text-foreground px-3 py-2 font-medium'>{entry.endpoint_slug}</td>
+                    <td className='text-foreground px-3 py-2'>{entry.amount}</td>
+                    <td
+                      className='text-muted-foreground px-3 py-2 font-mono text-xs'
+                      title={entry.currency}
+                    >
+                      {truncate(entry.currency, 8)}
+                    </td>
+                    <td className='px-3 py-2'>
+                      <a
+                        href={`${TX_EXPLORER_URL}/${entry.tx_hash}`}
+                        target='_blank'
+                        rel='noreferrer'
+                        className='text-primary hover:text-primary/80 inline-flex items-center gap-1 font-mono text-xs'
+                        title={entry.tx_hash}
+                      >
+                        {truncate(entry.tx_hash, 10)}
+                        <ExternalLink className='h-3 w-3' aria-hidden='true' />
+                      </a>
+                    </td>
+                    <td className='px-3 py-2'>
+                      <StatusBadge status={entry.status} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className='flex justify-end'>
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={handleClear}
+              data-testid='payment-history-clear'
+            >
+              <Trash2 className='mr-2 h-3.5 w-3.5' aria-hidden='true' />
+              Clear history
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/frontend/src/components/settings/settings-modal.tsx
+++ b/components/frontend/src/components/settings/settings-modal.tsx
@@ -7,6 +7,7 @@ import AlertTriangle from 'lucide-react/dist/esm/icons/alert-triangle';
 import CreditCard from 'lucide-react/dist/esm/icons/credit-card';
 import Key from 'lucide-react/dist/esm/icons/key';
 import Lock from 'lucide-react/dist/esm/icons/lock';
+import Receipt from 'lucide-react/dist/esm/icons/receipt';
 import Server from 'lucide-react/dist/esm/icons/server';
 import User from 'lucide-react/dist/esm/icons/user';
 import WalletIcon from 'lucide-react/dist/esm/icons/wallet';
@@ -20,6 +21,7 @@ import { useSettingsModalStore } from '@/stores/settings-modal-store';
 import { AggregatorSettingsTab } from './aggregator-settings-tab';
 import { APITokensSettingsTab } from './api-tokens-settings-tab';
 import { DangerZoneTab } from './danger-zone-tab';
+import { PaymentHistoryTab } from './payment-history-tab';
 import { PaymentSettingsTab } from './payment-settings-tab';
 import { ProfileSettingsTab } from './profile-settings-tab';
 import { SecuritySettingsTab } from './security-settings-tab';
@@ -46,6 +48,11 @@ const TABS: TabItem[] = [
     icon: <WalletIcon className='h-4 w-4' aria-hidden='true' />
   },
   {
+    id: 'payment-history',
+    label: 'Payments',
+    icon: <Receipt className='h-4 w-4' aria-hidden='true' />
+  },
+  {
     id: 'subscriptions',
     label: 'Top up credits',
     icon: <CreditCard className='h-4 w-4' aria-hidden='true' />
@@ -68,6 +75,7 @@ const TAB_CONTENT: Record<SettingsTab, React.ComponentType> = {
   security: SecuritySettingsTab,
   'api-tokens': APITokensSettingsTab,
   payment: PaymentSettingsTab,
+  'payment-history': PaymentHistoryTab,
   subscriptions: SubscriptionsSettingsTab,
   aggregator: AggregatorSettingsTab,
   'danger-zone': DangerZoneTab

--- a/components/frontend/src/lib/__tests__/endpoint-pricing.test.ts
+++ b/components/frontend/src/lib/__tests__/endpoint-pricing.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_TRANSACTION_CHAIN_ID,
+  formatPricingBadge,
+  getPricing,
+  PATHUSD_ADDRESS
+} from '../endpoint-utils';
+
+describe('getPricing', () => {
+  it('returns null when endpoint has no policies field', () => {
+    expect(getPricing({})).toBeNull();
+  });
+
+  it('returns null when policies array is empty', () => {
+    expect(getPricing({ policies: [] })).toBeNull();
+  });
+
+  it('returns null when only non-transaction policies are present', () => {
+    expect(
+      getPricing({
+        policies: [
+          { type: 'access', config: { foo: 'bar' } },
+          { type: 'rate-limit', config: { rps: 5 } }
+        ]
+      })
+    ).toBeNull();
+  });
+
+  it('returns null when transaction policy is explicitly disabled', () => {
+    expect(
+      getPricing({
+        policies: [
+          {
+            type: 'transaction',
+            enabled: false,
+            config: {
+              amount: '0.10',
+              currency: PATHUSD_ADDRESS,
+              recipient: '0xBEEF000000000000000000000000000000000000'
+            }
+          }
+        ]
+      })
+    ).toBeNull();
+  });
+
+  it('returns pricing for a charge-intent transaction policy', () => {
+    const result = getPricing({
+      policies: [
+        { type: 'access', config: {} },
+        {
+          type: 'transaction',
+          config: {
+            amount: '0.10',
+            currency: PATHUSD_ADDRESS,
+            recipient: '0xBEEF000000000000000000000000000000000000',
+            intent: 'charge',
+            chain_id: 12_345
+          }
+        }
+      ]
+    });
+    expect(result).toEqual({
+      amount: '0.10',
+      currency: PATHUSD_ADDRESS,
+      recipient: '0xBEEF000000000000000000000000000000000000',
+      intent: 'charge',
+      chainID: 12_345
+    });
+  });
+
+  it('coerces unknown intent values to "charge"', () => {
+    const result = getPricing({
+      policies: [
+        {
+          type: 'transaction',
+          config: {
+            amount: '1',
+            currency: PATHUSD_ADDRESS,
+            recipient: '0xBEEF000000000000000000000000000000000000',
+            intent: 'something-else'
+          }
+        }
+      ]
+    });
+    expect(result?.intent).toBe('charge');
+  });
+
+  it('preserves session intent', () => {
+    const result = getPricing({
+      policies: [
+        {
+          type: 'transaction',
+          config: {
+            amount: '5',
+            currency: PATHUSD_ADDRESS,
+            recipient: '0xBEEF000000000000000000000000000000000000',
+            intent: 'session'
+          }
+        }
+      ]
+    });
+    expect(result?.intent).toBe('session');
+  });
+
+  it('falls back to default chain id when chain_id is missing', () => {
+    const result = getPricing({
+      policies: [
+        {
+          type: 'transaction',
+          config: {
+            amount: '0.05',
+            currency: PATHUSD_ADDRESS,
+            recipient: '0xBEEF000000000000000000000000000000000000'
+          }
+        }
+      ]
+    });
+    expect(result?.chainID).toBe(DEFAULT_TRANSACTION_CHAIN_ID);
+  });
+
+  it('returns the first transaction policy when multiple are present', () => {
+    const result = getPricing({
+      policies: [
+        {
+          type: 'transaction',
+          config: { amount: '1', currency: PATHUSD_ADDRESS, recipient: '0xAAA' }
+        },
+        {
+          type: 'transaction',
+          config: { amount: '2', currency: PATHUSD_ADDRESS, recipient: '0xBBB' }
+        }
+      ]
+    });
+    expect(result?.amount).toBe('1');
+  });
+});
+
+describe('formatPricingBadge', () => {
+  it('returns dollar-prefixed amount for PathUSD currency', () => {
+    expect(
+      formatPricingBadge({
+        amount: '0.10',
+        currency: PATHUSD_ADDRESS,
+        recipient: '0xBEEF000000000000000000000000000000000000',
+        intent: 'charge',
+        chainID: DEFAULT_TRANSACTION_CHAIN_ID
+      })
+    ).toBe('$0.10');
+  });
+
+  it('matches PathUSD case-insensitively', () => {
+    expect(
+      formatPricingBadge({
+        amount: '0.42',
+        currency: PATHUSD_ADDRESS.toUpperCase(),
+        recipient: '0xBEEF000000000000000000000000000000000000',
+        intent: 'charge',
+        chainID: DEFAULT_TRANSACTION_CHAIN_ID
+      })
+    ).toBe('$0.42');
+  });
+
+  it('returns truncated currency for non-PathUSD addresses', () => {
+    expect(
+      formatPricingBadge({
+        amount: '1.5',
+        currency: '0xABCDEF1234567890ABCDEF1234567890ABCDEF12',
+        recipient: '0xBEEF000000000000000000000000000000000000',
+        intent: 'charge',
+        chainID: DEFAULT_TRANSACTION_CHAIN_ID
+      })
+    ).toBe('1.5 0xABCD…');
+  });
+});

--- a/components/frontend/src/lib/endpoint-utils.ts
+++ b/components/frontend/src/lib/endpoint-utils.ts
@@ -1235,3 +1235,91 @@ export function analyzeQueryForSources(
     relevantSources: availableSources
   };
 }
+
+// ============================================================================
+// Endpoint Pricing (transaction policy)
+// ============================================================================
+
+/**
+ * Canonical PathUSD currency address (Tempo on-chain stablecoin).
+ * When the currency on a transaction policy matches this address (case-insensitive),
+ * the pricing badge renders as "$<amount>" rather than the raw currency string.
+ */
+export const PATHUSD_ADDRESS = '0x20c0000000000000000000000000000000000000';
+
+/**
+ * Default chain ID used when a transaction policy omits chain_id.
+ * Matches the Tempo chain ID used by the MPP-over-NATS payment flow.
+ */
+export const DEFAULT_TRANSACTION_CHAIN_ID = 42_431;
+
+/**
+ * Pricing info extracted from an endpoint's transaction policy.
+ *
+ * `currency` is a string so it can hold either a 0x-prefixed token address or
+ * a non-address currency symbol; `recipient` is always a 0x-prefixed address.
+ */
+export interface EndpointPricing {
+  amount: string;
+  currency: string;
+  recipient: string;
+  intent: 'charge' | 'session';
+  chainID: number;
+}
+
+/**
+ * Coerce an unknown config value to a string. Returns '' for objects/null/undefined
+ * so the caller never gets the "[object Object]" stringification footgun.
+ */
+function configString(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  return '';
+}
+
+/**
+ * Returns pricing info for a paid endpoint, or null if the endpoint is free.
+ *
+ * Looks up the first policy of type "transaction" in `endpoint.policies`.
+ * Disabled policies are ignored. Returns null when no such policy is present
+ * (which is the normal "free endpoint" case).
+ */
+export function getPricing(endpoint: {
+  policies?: Array<{ type: string; enabled?: boolean; config: Record<string, unknown> }>;
+}): EndpointPricing | null {
+  const policy = endpoint.policies?.find((p) => p.type === 'transaction' && p.enabled !== false);
+  if (!policy) return null;
+  const c = policy.config;
+  return {
+    amount: configString(c.amount),
+    currency: configString(c.currency),
+    recipient: configString(c.recipient),
+    intent: c.intent === 'session' ? 'session' : 'charge',
+    chainID: parseChainID(c.chain_id)
+  };
+}
+
+function parseChainID(raw: unknown): number {
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  if (typeof raw === 'string' && raw.trim() !== '') {
+    const n = Number(raw);
+    if (Number.isFinite(n)) return n;
+  }
+  return DEFAULT_TRANSACTION_CHAIN_ID;
+}
+
+/**
+ * Render pricing as a short human-readable badge label.
+ *
+ * For PathUSD (the canonical currency address) returns `"$<amount>"`.
+ * Otherwise returns `"<amount> <truncated-currency>…"`.
+ */
+export function formatPricingBadge(pricing: EndpointPricing): string {
+  if (pricing.currency.toLowerCase() === PATHUSD_ADDRESS.toLowerCase()) {
+    return `$${pricing.amount}`;
+  }
+  return `${pricing.amount} ${pricing.currency.slice(0, 6)}…`;
+}

--- a/components/frontend/src/stores/settings-modal-store.ts
+++ b/components/frontend/src/stores/settings-modal-store.ts
@@ -5,6 +5,7 @@ export type SettingsTab =
   | 'security'
   | 'api-tokens'
   | 'payment'
+  | 'payment-history'
   | 'subscriptions'
   | 'aggregator'
   | 'danger-zone';


### PR DESCRIPTION
## Summary

Unit 14 of the 15-unit transaction-policy batch (plan: `/home/junior/.claude/plans/nifty-skipping-rainbow.md`).

- Add `getPricing` / `formatPricingBadge` helpers in `lib/endpoint-utils.ts` that read the first enabled `transaction` policy on an endpoint.
- Render a small amber pricing `Badge` on every browse-view endpoint card when the endpoint has a transaction policy. Free endpoints render unchanged.
- New `PaymentHistoryTab` settings panel that reads `localStorage[\"syft_payment_history_v1\"]` (written client-side by unit 13's payment modal), renders entries reverse-chronologically with explorer links + status badges, listens for cross-tab `storage` events, and offers a clear button. Purely client-side: no hub call.
- Registers the new tab in `settings-modal-store` and `settings-modal` alongside the existing Wallet tab.

Strictly additive: existing browse view and settings panels are untouched on the free-endpoint path.

## Test plan

- [x] `npm run test` (271 tests passing across 13 files)
- [x] `npm run lint` (0 errors; only pre-existing warnings)
- [x] `npm run typecheck` (clean)
- [ ] Manual: seed `localStorage[\"syft_payment_history_v1\"]` and verify the new Payments tab renders rows in reverse-chronological order
- [ ] Manual: inject a `transaction` policy on an endpoint via React DevTools and verify the amber badge appears on the browse card