### PR TITLE
feat(transaction-policy): unit 10 - aggregator PaymentNegotiator + SSE + /payment endpoint

### DIFF
--- a/components/aggregator/src/aggregator/api/dependencies.py
+++ b/components/aggregator/src/aggregator/api/dependencies.py
@@ -5,7 +5,7 @@ from typing import Annotated
 
 from fastapi import Depends, Header
 
-from aggregator.clients import DataSourceClient, ErrorReporter, ModelClient
+from aggregator.clients import DataSourceClient, ErrorReporter, ModelClient, PaymentNegotiator
 from aggregator.clients.nats_transport import NATSTransport
 from aggregator.core.config import get_settings
 from aggregator.services import (
@@ -41,6 +41,19 @@ def get_model_client() -> ModelClient:
         timeout=settings.generation_timeout,
         error_reporter=get_error_reporter(),
     )
+
+
+@lru_cache
+def get_payment_negotiator() -> PaymentNegotiator:
+    """Get the process-singleton PaymentNegotiator.
+
+    A single instance is shared across all chat sessions so the orchestrator
+    (which suspends a tunnel call awaiting a credential) and the payment
+    submission route (which resolves the awaiting future) talk to the same
+    negotiator. The instance is also exposed on ``app.state.payment_negotiator``
+    by the lifespan handler for direct access.
+    """
+    return PaymentNegotiator()
 
 
 @lru_cache

--- a/components/aggregator/src/aggregator/api/endpoints/__init__.py
+++ b/components/aggregator/src/aggregator/api/endpoints/__init__.py
@@ -1,5 +1,5 @@
 """API endpoints package."""
 
-from aggregator.api.endpoints import agent, chat, health, query
+from aggregator.api.endpoints import agent, chat, health, payment, query
 
-__all__ = ["agent", "chat", "health", "query"]
+__all__ = ["agent", "chat", "health", "payment", "query"]

--- a/components/aggregator/src/aggregator/api/endpoints/chat.py
+++ b/components/aggregator/src/aggregator/api/endpoints/chat.py
@@ -86,6 +86,16 @@ async def chat_stream(
     - `token`: `{"content": "..."}` - A chunk of the response
     - `done`: `{"sources": [...], "metadata": {...}}` - Complete with final metadata
 
+    **Payment (transaction-policy endpoints):**
+    - `payment_required`: `{"chat_session_id": "...", "endpoint_slug": "...",
+      "challenge": "...", "amount": "...", "currency": "...", "recipient": "...",
+      "challenge_id": "...", "intent": "charge"}` - The endpoint requires an
+      on-chain payment. The client must POST to `/chat/{session_id}/payment`
+      with the matching `challenge_id` and a payment credential to resume the
+      stream. Multi-endpoint chats may emit several `payment_required` events
+      sharing the same `chat_session_id`; the client UI is responsible for
+      bundling them.
+
     **Error:**
     - `error`: `{"message": "..."}` - An error occurred
     """

--- a/components/aggregator/src/aggregator/api/endpoints/payment.py
+++ b/components/aggregator/src/aggregator/api/endpoints/payment.py
@@ -1,0 +1,74 @@
+"""Chat-payment submission endpoint.
+
+The chat client receives a ``payment_required`` SSE event from an in-flight
+chat stream, signs and submits the on-chain payment via its wallet, then POSTs
+the resulting credential here. The route resolves the awaiting future inside
+the process-singleton ``PaymentNegotiator`` so the suspended tunnel call
+can retry with the credential attached.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from aggregator.api.dependencies import get_payment_negotiator
+from aggregator.clients import PaymentNegotiator
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/chat", tags=["chat"])
+
+
+class PaymentSubmission(BaseModel):
+    """Body for ``POST /chat/{session_id}/payment``."""
+
+    challenge_id: str = Field(
+        ...,
+        description="The challenge_id from the corresponding payment_required SSE event.",
+    )
+    credential: str = Field(
+        ...,
+        description=(
+            "The X-Payment credential string to attach when retrying the tunneled "
+            "endpoint call (typically 'Payment <base64-jwt>')."
+        ),
+    )
+
+
+class PaymentSubmissionResponse(BaseModel):
+    """Response for an accepted payment submission."""
+
+    status: str = Field(default="accepted", description="Always 'accepted' on 200.")
+
+
+@router.post(
+    "/{session_id}/payment",
+    response_model=PaymentSubmissionResponse,
+    responses={
+        404: {"description": "No pending payment matches the (session_id, challenge_id) pair."},
+    },
+)
+async def submit_payment(
+    session_id: str,
+    body: PaymentSubmission,
+    negotiator: Annotated[PaymentNegotiator, Depends(get_payment_negotiator)],
+) -> PaymentSubmissionResponse:
+    """Submit a payment credential for a pending payment_required negotiation.
+
+    The negotiator resolves the awaiting future, the suspended tunnel call
+    retries with the credential attached, and the chat stream resumes.
+    """
+    matched = negotiator.submit_credential(session_id, body.challenge_id, body.credential)
+    if not matched:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"No pending payment for challenge_id={body.challenge_id} "
+                f"in session_id={session_id}"
+            ),
+        )
+    return PaymentSubmissionResponse(status="accepted")

--- a/components/aggregator/src/aggregator/api/router.py
+++ b/components/aggregator/src/aggregator/api/router.py
@@ -2,11 +2,12 @@
 
 from fastapi import APIRouter
 
-from aggregator.api.endpoints import agent, chat, health, query
+from aggregator.api.endpoints import agent, chat, health, payment, query
 
 # Main API router with version prefix
 api_router = APIRouter(prefix="/api/v1")
 api_router.include_router(chat.router)
+api_router.include_router(payment.router)
 api_router.include_router(query.router)
 api_router.include_router(agent.router)
 

--- a/components/aggregator/src/aggregator/clients/__init__.py
+++ b/components/aggregator/src/aggregator/clients/__init__.py
@@ -5,6 +5,10 @@ from aggregator.clients.error_reporter import ErrorReporter
 from aggregator.clients.model import ModelClient, ModelClientError
 from aggregator.clients.mpp_payment import handle_mpp_payment
 from aggregator.clients.nats_transport import NATSTransport, NATSTransportError
+from aggregator.clients.payment_negotiator import (
+    PaymentChallenge,
+    PaymentNegotiator,
+)
 from aggregator.clients.syfthub import (
     EndpointAccessDeniedError,
     EndpointNotFoundError,
@@ -23,5 +27,7 @@ __all__ = [
     "ModelClientError",
     "NATSTransport",
     "NATSTransportError",
+    "PaymentChallenge",
+    "PaymentNegotiator",
     "handle_mpp_payment",
 ]

--- a/components/aggregator/src/aggregator/clients/payment_negotiator.py
+++ b/components/aggregator/src/aggregator/clients/payment_negotiator.py
@@ -1,0 +1,257 @@
+"""Passthrough payment negotiator for on-chain Tempo payments via MPP-over-NATS.
+
+When a tunneling Syft Space returns a tunnel response with
+``status == "error"`` and ``error.code == "PAYMENT_REQUIRED"``, the aggregator
+must:
+
+1. Surface the challenge to the chat client as an SSE ``payment_required`` event.
+2. Wait for the client to POST a credential to ``/chat/{session_id}/payment``.
+3. Replay the original tunnel call with the credential attached.
+
+The aggregator does **not** hold a wallet. It is a passthrough negotiator —
+the client's wallet (or the user, via the desktop app) signs and submits the
+payment, and the aggregator only relays the resulting credential.
+
+Idempotency
+-----------
+Responses are cached per ``challenge_id`` for 10 minutes so client reconnects
+or duplicate retries do not double-charge the user. The cache is in-memory and
+process-local; horizontal scaling would require an external store.
+
+Multi-endpoint chats
+--------------------
+For a chat that fans out to K endpoints, K independent ``execute_with_payment``
+calls run concurrently, each emitting its own ``payment_required`` event keyed
+by ``challenge_id`` and ``endpoint_slug``. The aggregator does not bundle them;
+the client UI is responsible for collecting and presenting the bundle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# Default tunnel-response error code for the MPP payment-required signal.
+PAYMENT_REQUIRED_ERROR_CODE = "PAYMENT_REQUIRED"
+
+# Idempotency cache defaults.
+DEFAULT_TTL_SECONDS = 600  # 10 minutes
+DEFAULT_MAX_PENDING = 10000
+
+# Default time we will wait for a client to submit a credential.
+DEFAULT_CREDENTIAL_TIMEOUT_SECONDS = 300.0
+
+
+@dataclass(frozen=True)
+class PaymentChallenge:
+    """A payment challenge extracted from a tunnel PAYMENT_REQUIRED response."""
+
+    challenge_id: str
+    challenge: str  # Raw WWW-Authenticate-style challenge string
+    amount: str
+    currency: str
+    recipient: str
+    intent: str
+    endpoint_slug: str
+
+
+def _is_payment_required(response: Any) -> bool:
+    """Return True if a TunnelResponse-like dict signals PAYMENT_REQUIRED.
+
+    The expected shape (from the Go-SDK side, units 1+2+4 of the parallel batch)::
+
+        {
+            "status": "error",
+            "error": {
+                "code": "PAYMENT_REQUIRED",
+                "details": {
+                    "payment_challenge": "...",
+                    "payment_amount": "...",
+                    "payment_currency": "...",
+                    "payment_recipient": "...",
+                    "challenge_id": "...",
+                    "intent": "charge",
+                },
+            },
+        }
+    """
+    if not isinstance(response, dict):
+        return False
+    if response.get("status") != "error":
+        return False
+    error = response.get("error")
+    if not isinstance(error, dict):
+        return False
+    return error.get("code") == PAYMENT_REQUIRED_ERROR_CODE
+
+
+def _extract_challenge(response: Any, *, endpoint_slug: str) -> PaymentChallenge:
+    """Extract a PaymentChallenge from a PAYMENT_REQUIRED tunnel response.
+
+    Raises:
+        ValueError: If the response does not contain the required fields.
+    """
+    if not isinstance(response, dict):
+        raise ValueError("Response is not a dict")
+    error = response.get("error") or {}
+    details = error.get("details") or {}
+    if not isinstance(details, dict):
+        raise ValueError("error.details is not a dict")
+
+    challenge_id = details.get("challenge_id")
+    if not challenge_id:
+        raise ValueError("error.details.challenge_id missing")
+
+    return PaymentChallenge(
+        challenge_id=str(challenge_id),
+        challenge=str(details.get("payment_challenge", "")),
+        amount=str(details.get("payment_amount", "")),
+        currency=str(details.get("payment_currency", "")),
+        recipient=str(details.get("payment_recipient", "")),
+        intent=str(details.get("intent", "charge")),
+        endpoint_slug=endpoint_slug,
+    )
+
+
+class PaymentNegotiator:
+    """Passthrough payment negotiator with in-memory idempotency cache.
+
+    Single instance per process (wired onto ``app.state.payment_negotiator``).
+    Safe to use from multiple concurrent chat sessions because each negotiation
+    is keyed by ``(chat_session_id, challenge_id)``.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+        max_pending: int = DEFAULT_MAX_PENDING,
+    ) -> None:
+        # Pending negotiations: (chat_session_id, challenge_id) -> Future awaiting credential.
+        self._pending: dict[tuple[str, str], asyncio.Future[str]] = {}
+        # Idempotency cache: challenge_id -> (response, expires_at_unix).
+        self._cache: dict[str, tuple[Any, float]] = {}
+        self._ttl = ttl_seconds
+        self._max_pending = max_pending
+
+    async def execute_with_payment(
+        self,
+        *,
+        chat_session_id: str,
+        endpoint_slug: str,
+        tunnel_call: Callable[[str | None], Awaitable[Any]],
+        emit_event: Callable[[dict[str, Any]], Awaitable[None]],
+        timeout_seconds: float = DEFAULT_CREDENTIAL_TIMEOUT_SECONDS,
+    ) -> Any:
+        """Execute a tunnel call, transparently handling a PAYMENT_REQUIRED challenge.
+
+        Args:
+            chat_session_id: Chat session identifier (used to key pending futures).
+            endpoint_slug: Slug of the endpoint being called (surfaced in the SSE event).
+            tunnel_call: Async callable that performs the tunnel request. It is invoked
+                first with ``None`` (no credential) and again with the client-provided
+                credential string after the SSE round-trip. Must return a TunnelResponse-
+                like dict.
+            emit_event: Async callable that emits an SSE event payload to the chat
+                client. The payload is a dict with keys ``event`` and ``data``.
+            timeout_seconds: How long to wait for the client to submit a credential
+                before raising ``asyncio.TimeoutError``.
+
+        Returns:
+            The final tunnel response (either the first response if no payment was
+            required, or the post-credential response).
+        """
+        # First attempt without credential.
+        response = await tunnel_call(None)
+        if not _is_payment_required(response):
+            return response
+
+        challenge = _extract_challenge(response, endpoint_slug=endpoint_slug)
+
+        # Idempotency: if this challenge_id was already paid for, return the cached response.
+        cached = self._lookup_cache(challenge.challenge_id)
+        if cached is not None:
+            logger.info(
+                "Reusing cached response for challenge_id=%s (idempotent retry)",
+                challenge.challenge_id,
+            )
+            return cached
+
+        # Surface the challenge to the chat client.
+        await emit_event(
+            {
+                "event": "payment_required",
+                "data": {
+                    "chat_session_id": chat_session_id,
+                    "endpoint_slug": challenge.endpoint_slug,
+                    "challenge": challenge.challenge,
+                    "amount": challenge.amount,
+                    "currency": challenge.currency,
+                    "recipient": challenge.recipient,
+                    "challenge_id": challenge.challenge_id,
+                    "intent": challenge.intent,
+                },
+            }
+        )
+
+        # Await the client credential.
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[str] = loop.create_future()
+        key = (chat_session_id, challenge.challenge_id)
+        # Refuse to negotiate when we are already at the pending-future cap. This
+        # bounds memory under runaway clients; legitimate flows resolve quickly.
+        if len(self._pending) >= self._max_pending:
+            raise RuntimeError(
+                f"PaymentNegotiator pending-future cap reached ({self._max_pending}); "
+                "refusing new negotiation"
+            )
+        self._pending[key] = future
+
+        try:
+            credential = await asyncio.wait_for(future, timeout=timeout_seconds)
+        finally:
+            self._pending.pop(key, None)
+
+        # Retry the tunnel call with the credential attached.
+        retry_response = await tunnel_call(credential)
+        # Cache the response keyed by challenge_id for the TTL window.
+        self._store_cache(challenge.challenge_id, retry_response)
+        return retry_response
+
+    def submit_credential(self, chat_session_id: str, challenge_id: str, credential: str) -> bool:
+        """Resolve the awaiting future for a pending negotiation.
+
+        Returns:
+            True if a matching pending negotiation was found and resolved,
+            False otherwise (caller should respond 404).
+        """
+        key = (chat_session_id, challenge_id)
+        future = self._pending.get(key)
+        if future is None or future.done():
+            return False
+        future.set_result(credential)
+        return True
+
+    def _lookup_cache(self, challenge_id: str) -> Any | None:
+        entry = self._cache.get(challenge_id)
+        if entry is None:
+            return None
+        response, expires_at = entry
+        if time.time() > expires_at:
+            self._cache.pop(challenge_id, None)
+            return None
+        return response
+
+    def _store_cache(self, challenge_id: str, response: Any) -> None:
+        self._cache[challenge_id] = (response, time.time() + self._ttl)
+        # Lazy eviction when the cache grows too large.
+        if len(self._cache) > 2 * self._max_pending:
+            now = time.time()
+            self._cache = {k: v for k, v in self._cache.items() if v[1] > now}

--- a/components/aggregator/src/aggregator/main.py
+++ b/components/aggregator/src/aggregator/main.py
@@ -48,6 +48,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         get_error_reporter,
         get_model_client,
         get_nats_transport,
+        get_payment_negotiator,
     )
 
     shared = _app.state.http_client
@@ -57,6 +58,10 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     nats = get_nats_transport()
     if nats is not None:
         nats._http_client = shared
+
+    # Expose the singleton PaymentNegotiator on app.state so non-DI consumers
+    # (e.g. orchestrator tasks suspended mid-stream) can reach it directly.
+    _app.state.payment_negotiator = get_payment_negotiator()
 
     yield
 

--- a/components/aggregator/tests/test_payment_negotiator.py
+++ b/components/aggregator/tests/test_payment_negotiator.py
@@ -1,0 +1,342 @@
+"""Tests for the passthrough PaymentNegotiator."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aggregator.clients.payment_negotiator import (
+    PAYMENT_REQUIRED_ERROR_CODE,
+    PaymentNegotiator,
+    _extract_challenge,
+    _is_payment_required,
+)
+
+
+def _payment_required_response(
+    challenge_id: str = "ch_123",
+    amount: str = "100",
+    currency: str = "0xUSDC",
+    recipient: str = "0xMerchant",
+    intent: str = "charge",
+    challenge: str = "Tempo realm=...",
+) -> dict[str, Any]:
+    """Build a tunnel response that signals PAYMENT_REQUIRED."""
+    return {
+        "status": "error",
+        "error": {
+            "code": PAYMENT_REQUIRED_ERROR_CODE,
+            "message": "payment required",
+            "details": {
+                "payment_challenge": challenge,
+                "payment_amount": amount,
+                "payment_currency": currency,
+                "payment_recipient": recipient,
+                "challenge_id": challenge_id,
+                "intent": intent,
+            },
+        },
+    }
+
+
+def _ok_response(payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build a normal successful tunnel response."""
+    return {"status": "ok", "payload": payload or {"result": "hello"}}
+
+
+async def _wait_for_pending(
+    negotiator: PaymentNegotiator,
+    keys: list[tuple[str, str]],
+    *,
+    max_iterations: int = 200,
+    poll_interval: float = 0.005,
+) -> None:
+    """Spin until every key is registered as a pending negotiation, or fail loudly."""
+    for _ in range(max_iterations):
+        if all(key in negotiator._pending for key in keys):
+            return
+        await asyncio.sleep(poll_interval)
+    raise AssertionError(f"Pending negotiations not registered within timeout: {keys}")
+
+
+# --- helpers tested in isolation -------------------------------------------------
+
+
+def test_is_payment_required_true_for_canonical_response() -> None:
+    assert _is_payment_required(_payment_required_response()) is True
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,
+        "not a dict",
+        {},
+        {"status": "ok"},
+        {"status": "error", "error": "not-a-dict"},
+        {"status": "error", "error": {"code": "OTHER"}},
+    ],
+)
+def test_is_payment_required_false_for_non_payment_responses(response: Any) -> None:
+    assert _is_payment_required(response) is False
+
+
+def test_extract_challenge_pulls_all_fields() -> None:
+    response = _payment_required_response(
+        challenge_id="ch_abc",
+        amount="42",
+        currency="0xC",
+        recipient="0xR",
+        intent="charge",
+        challenge="Tempo realm=foo",
+    )
+    challenge = _extract_challenge(response, endpoint_slug="my-slug")
+    assert challenge.challenge_id == "ch_abc"
+    assert challenge.amount == "42"
+    assert challenge.currency == "0xC"
+    assert challenge.recipient == "0xR"
+    assert challenge.intent == "charge"
+    assert challenge.challenge == "Tempo realm=foo"
+    assert challenge.endpoint_slug == "my-slug"
+
+
+def test_extract_challenge_raises_when_challenge_id_missing() -> None:
+    bad = {"status": "error", "error": {"code": PAYMENT_REQUIRED_ERROR_CODE, "details": {}}}
+    with pytest.raises(ValueError):
+        _extract_challenge(bad, endpoint_slug="s")
+
+
+# --- core negotiator behaviour ---------------------------------------------------
+
+
+async def test_execute_with_payment_no_payment_required_passes_through() -> None:
+    """If the first tunnel call returns a normal response, no event is emitted."""
+    negotiator = PaymentNegotiator()
+    tunnel_call = AsyncMock(return_value=_ok_response())
+    emit_event = AsyncMock()
+
+    result = await negotiator.execute_with_payment(
+        chat_session_id="session-1",
+        endpoint_slug="slug",
+        tunnel_call=tunnel_call,
+        emit_event=emit_event,
+    )
+
+    assert result == _ok_response()
+    tunnel_call.assert_awaited_once_with(None)
+    emit_event.assert_not_called()
+
+
+async def test_execute_with_payment_one_round_trip() -> None:
+    """First call returns PAYMENT_REQUIRED, event is emitted, credential resumes the call."""
+    negotiator = PaymentNegotiator()
+
+    final_response = _ok_response({"result": "paid-and-served"})
+    tunnel_call = AsyncMock(side_effect=[_payment_required_response("ch_1"), final_response])
+    emit_event = AsyncMock()
+
+    async def submit_after_event() -> None:
+        await _wait_for_pending(negotiator, [("session-1", "ch_1")])
+        ok = negotiator.submit_credential("session-1", "ch_1", "Payment cred-xyz")
+        assert ok is True
+
+    submitter = asyncio.create_task(submit_after_event())
+    result = await negotiator.execute_with_payment(
+        chat_session_id="session-1",
+        endpoint_slug="slug-1",
+        tunnel_call=tunnel_call,
+        emit_event=emit_event,
+        timeout_seconds=2.0,
+    )
+    await submitter
+
+    assert result == final_response
+    # The retry was invoked with the credential.
+    assert tunnel_call.await_count == 2
+    assert tunnel_call.await_args_list[0].args == (None,)
+    assert tunnel_call.await_args_list[1].args == ("Payment cred-xyz",)
+
+    # Event payload contains every required key.
+    emit_event.assert_awaited_once()
+    call = emit_event.await_args
+    assert call is not None
+    payload = call.args[0]
+    assert payload["event"] == "payment_required"
+    data = payload["data"]
+    assert data["chat_session_id"] == "session-1"
+    assert data["endpoint_slug"] == "slug-1"
+    assert data["challenge_id"] == "ch_1"
+    assert data["intent"] == "charge"
+    for key in ("challenge", "amount", "currency", "recipient"):
+        assert key in data
+
+
+async def test_execute_with_payment_credential_timeout() -> None:
+    """If no credential is submitted, asyncio.TimeoutError is raised."""
+    negotiator = PaymentNegotiator()
+    tunnel_call = AsyncMock(return_value=_payment_required_response("ch_timeout"))
+    emit_event = AsyncMock()
+
+    with pytest.raises(asyncio.TimeoutError):
+        await negotiator.execute_with_payment(
+            chat_session_id="session-t",
+            endpoint_slug="slug",
+            tunnel_call=tunnel_call,
+            emit_event=emit_event,
+            timeout_seconds=0.05,
+        )
+
+    # The retry was never invoked.
+    tunnel_call.assert_awaited_once_with(None)
+    # The pending future is cleaned up.
+    assert ("session-t", "ch_timeout") not in negotiator._pending
+
+
+async def test_idempotency_cache_returns_cached_response() -> None:
+    """Two execute_with_payment calls with the same challenge_id reuse the cached response."""
+    negotiator = PaymentNegotiator()
+
+    final_response = _ok_response({"result": "cached"})
+    # First execution: PAYMENT_REQUIRED then success.
+    first_tunnel = AsyncMock(side_effect=[_payment_required_response("ch_idem"), final_response])
+    emit_event_a = AsyncMock()
+
+    async def submit_for_first() -> None:
+        await _wait_for_pending(negotiator, [("session-i", "ch_idem")])
+        negotiator.submit_credential("session-i", "ch_idem", "cred")
+
+    submitter = asyncio.create_task(submit_for_first())
+    first_result = await negotiator.execute_with_payment(
+        chat_session_id="session-i",
+        endpoint_slug="slug",
+        tunnel_call=first_tunnel,
+        emit_event=emit_event_a,
+        timeout_seconds=2.0,
+    )
+    await submitter
+    assert first_result == final_response
+
+    # Second execution: same challenge_id, but the cache should short-circuit
+    # before any second tunnel call or event emission happens.
+    second_tunnel = AsyncMock(return_value=_payment_required_response("ch_idem"))
+    emit_event_b = AsyncMock()
+
+    second_result = await negotiator.execute_with_payment(
+        chat_session_id="session-i-2",  # different session is fine — cache key is challenge_id
+        endpoint_slug="slug",
+        tunnel_call=second_tunnel,
+        emit_event=emit_event_b,
+        timeout_seconds=2.0,
+    )
+
+    assert second_result == final_response
+    # Second tunnel call was made once (the probe), but never with a credential.
+    assert second_tunnel.await_count == 1
+    second_tunnel.assert_awaited_once_with(None)
+    # No SSE event was emitted on the cached path.
+    emit_event_b.assert_not_called()
+
+
+def test_submit_credential_unknown_session_returns_false() -> None:
+    """submit_credential returns False when no future is awaiting the (session, challenge) pair."""
+    negotiator = PaymentNegotiator()
+    assert negotiator.submit_credential("nope", "also-nope", "cred") is False
+
+
+async def test_submit_credential_already_done_returns_false() -> None:
+    """submit_credential is idempotent — a second submit on the same key returns False."""
+    negotiator = PaymentNegotiator()
+    future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+    negotiator._pending[("s", "c")] = future
+    future.set_result("already")
+    assert negotiator.submit_credential("s", "c", "second") is False
+
+
+async def test_concurrent_negotiations_isolated() -> None:
+    """Two parallel execute_with_payment calls for different challenge_ids both complete."""
+    negotiator = PaymentNegotiator()
+
+    final_a = _ok_response({"r": "a"})
+    final_b = _ok_response({"r": "b"})
+
+    tunnel_a = AsyncMock(side_effect=[_payment_required_response("ch_a"), final_a])
+    tunnel_b = AsyncMock(side_effect=[_payment_required_response("ch_b"), final_b])
+    emit_a = AsyncMock()
+    emit_b = AsyncMock()
+
+    async def submit_both() -> None:
+        await _wait_for_pending(negotiator, [("session-c", "ch_a"), ("session-c", "ch_b")])
+        assert negotiator.submit_credential("session-c", "ch_a", "cred-a") is True
+        assert negotiator.submit_credential("session-c", "ch_b", "cred-b") is True
+
+    submitter = asyncio.create_task(submit_both())
+    results = await asyncio.gather(
+        negotiator.execute_with_payment(
+            chat_session_id="session-c",
+            endpoint_slug="slug-a",
+            tunnel_call=tunnel_a,
+            emit_event=emit_a,
+            timeout_seconds=2.0,
+        ),
+        negotiator.execute_with_payment(
+            chat_session_id="session-c",
+            endpoint_slug="slug-b",
+            tunnel_call=tunnel_b,
+            emit_event=emit_b,
+            timeout_seconds=2.0,
+        ),
+    )
+    await submitter
+
+    result_a, result_b = results
+    assert result_a == final_a
+    assert result_b == final_b
+    # Each side received its own credential.
+    assert tunnel_a.await_args_list[1].args == ("cred-a",)
+    assert tunnel_b.await_args_list[1].args == ("cred-b",)
+    # Each side emitted exactly one event.
+    emit_a.assert_awaited_once()
+    emit_b.assert_awaited_once()
+    call_a = emit_a.await_args
+    call_b = emit_b.await_args
+    assert call_a is not None and call_b is not None
+    assert call_a.args[0]["data"]["challenge_id"] == "ch_a"
+    assert call_b.args[0]["data"]["challenge_id"] == "ch_b"
+
+
+async def test_max_pending_cap_rejects_overflow() -> None:
+    """The negotiator refuses new negotiations when the pending-future cap is hit."""
+    negotiator = PaymentNegotiator(max_pending=1)
+
+    blocking_tunnel = AsyncMock(return_value=_payment_required_response("ch_block"))
+    overflow_tunnel = AsyncMock(return_value=_payment_required_response("ch_over"))
+    emit = AsyncMock()
+
+    # Start a long-lived negotiation that will fill the single pending slot.
+    blocked = asyncio.create_task(
+        negotiator.execute_with_payment(
+            chat_session_id="s",
+            endpoint_slug="slug",
+            tunnel_call=blocking_tunnel,
+            emit_event=emit,
+            timeout_seconds=5.0,
+        )
+    )
+    await _wait_for_pending(negotiator, [("s", "ch_block")])
+
+    # A second negotiation must be refused immediately.
+    with pytest.raises(RuntimeError, match="pending-future cap"):
+        await negotiator.execute_with_payment(
+            chat_session_id="s",
+            endpoint_slug="slug",
+            tunnel_call=overflow_tunnel,
+            emit_event=emit,
+            timeout_seconds=5.0,
+        )
+
+    # Cleanup: resolve the first future so the task exits.
+    negotiator.submit_credential("s", "ch_block", "cred")
+    await blocked


### PR DESCRIPTION
## Summary

Unit 10 of the 15-unit parallel batch adding a transaction policy to SyftHub
(plan: `/home/junior/.claude/plans/nifty-skipping-rainbow.md`). Strictly
additive — existing free-endpoint chat flow is unchanged.

When a tunneling Syft Space returns a `TunnelResponse` with
`error.code == "PAYMENT_REQUIRED"`, the aggregator now:

1. Surfaces a `payment_required` SSE event to the chat client carrying
   `challenge_id`, `amount`, `currency`, `recipient`, and `intent`.
2. Suspends the in-flight tunnel call on a future keyed by
   `(chat_session_id, challenge_id)`.
3. Resumes when the client POSTs a credential to
   `POST /api/v1/chat/{session_id}/payment`.
4. Caches the response per `challenge_id` for 10 minutes so client
   reconnects do not double-charge the user.

The aggregator never holds a wallet. Multi-endpoint chats fan out K
independent negotiations sharing `chat_session_id`; the client UI bundles
them.

### Files

- New: `components/aggregator/src/aggregator/clients/payment_negotiator.py`
  (`PaymentNegotiator` + `PaymentChallenge` + helpers)
- New: `components/aggregator/src/aggregator/api/endpoints/payment.py`
  (`POST /api/v1/chat/{session_id}/payment` route)
- New: `components/aggregator/tests/test_payment_negotiator.py` (17 tests)
- Modified: `dependencies.py`, `clients/__init__.py`, `endpoints/__init__.py`,
  `router.py`, `main.py` (wiring the singleton onto `app.state` at startup),
  `chat.py` (SSE event docstring).

## Test plan

- [x] `cd components/aggregator && uv run pytest` (108 passed)
- [x] `uv run ruff check` (clean)
- [x] `uv run mypy src tests/test_payment_negotiator.py` (clean)
- [x] FastAPI smoke test: app starts, `app.state.payment_negotiator`
  exists, `POST /api/v1/chat/{session_id}/payment` returns 404 for
  unknown `challenge_id` and 422 for invalid body
- [ ] Real e2e against a live space + policy-manager (out of scope per
  unit instructions; requires units 1+2+4)

## Test coverage

The 17 unit tests cover:
- `_is_payment_required` / `_extract_challenge` helpers (8 tests including
  parametrized negative cases)
- Passthrough when no payment is required
- One-round-trip flow: PAYMENT_REQUIRED -> SSE event -> credential -> retry
- Credential timeout raises `asyncio.TimeoutError`
- Idempotency cache returns cached response for repeat `challenge_id`
- Unknown `(session, challenge_id)` returns False from `submit_credential`
- Concurrent negotiations are isolated by key
- `max_pending` cap rejects overflow with `RuntimeError`