### PR TITLE
feat(frontend): link endpoint owner usernames to user profile

### DIFF
--- a/components/frontend/src/components/browse-view.tsx
+++ b/components/frontend/src/components/browse-view.tsx
@@ -457,8 +457,14 @@ export function BrowseView({ initialQuery = '' }: Readonly<BrowseViewProperties>
                       </button>
                     )}
 
-                    {/* Card content is a Link for navigation */}
-                    <Link to={detailHref} className='block'>
+                    {/* Stretched link makes the whole card navigable to the detail page,
+                        while leaving room for nested interactive elements (e.g. username link). */}
+                    <Link
+                      to={detailHref}
+                      aria-label={`View ${endpoint.name}`}
+                      className='absolute inset-0 z-0 rounded-xl'
+                    />
+                    <div className='pointer-events-none relative'>
                       {/* Header */}
                       <div className='mb-3 flex items-start justify-between'>
                         <div className='min-w-0 flex-1 pr-8'>
@@ -468,7 +474,13 @@ export function BrowseView({ initialQuery = '' }: Readonly<BrowseViewProperties>
                           </h3>
                           {endpoint.owner_username && (
                             <p className='font-inter text-muted-foreground mt-0.5 truncate text-xs'>
-                              by @{endpoint.owner_username}
+                              by{' '}
+                              <Link
+                                to={`/${endpoint.owner_username}`}
+                                className='hover:text-primary pointer-events-auto hover:underline'
+                              >
+                                @{endpoint.owner_username}
+                              </Link>
                             </p>
                           )}
                           <p className='font-inter text-muted-foreground mt-1.5 line-clamp-2 text-sm'>
@@ -520,7 +532,7 @@ export function BrowseView({ initialQuery = '' }: Readonly<BrowseViewProperties>
                           </div>
                         </div>
                       </div>
-                    </Link>
+                    </div>
                   </div>
                 );
               })}

--- a/components/frontend/src/components/endpoint/endpoint-detail.tsx
+++ b/components/frontend/src/components/endpoint/endpoint-detail.tsx
@@ -8,6 +8,7 @@ import ExternalLink from 'lucide-react/dist/esm/icons/external-link';
 import Package from 'lucide-react/dist/esm/icons/package';
 import Star from 'lucide-react/dist/esm/icons/star';
 import Users from 'lucide-react/dist/esm/icons/users';
+import { Link } from 'react-router-dom';
 
 import { ConnectionCard } from '@/components/connection-card';
 import { Markdown } from '@/components/prompt-kit/markdown';
@@ -341,16 +342,32 @@ export const EndpointDetail = memo(function EndpointDetail({
               <div className='space-y-4'>
                 <div>
                   <p className='font-inter text-muted-foreground mb-1 text-xs'>Owner</p>
-                  <div className='flex items-center gap-2'>
-                    <div
-                      className='from-secondary to-chart-3 h-6 w-6 rounded-full bg-gradient-to-br'
-                      role='img'
-                      aria-label={`Avatar for ${endpoint.owner_username ?? 'anonymous'}`}
-                    />
-                    <span className='font-inter text-foreground text-sm font-medium'>
-                      @{endpoint.owner_username ?? 'anonymous'}
-                    </span>
-                  </div>
+                  {endpoint.owner_username ? (
+                    <Link
+                      to={`/${endpoint.owner_username}`}
+                      className='hover:text-primary group flex items-center gap-2 transition-colors'
+                    >
+                      <div
+                        className='from-secondary to-chart-3 h-6 w-6 rounded-full bg-gradient-to-br'
+                        role='img'
+                        aria-label={`Avatar for ${endpoint.owner_username}`}
+                      />
+                      <span className='font-inter text-foreground group-hover:text-primary text-sm font-medium group-hover:underline'>
+                        @{endpoint.owner_username}
+                      </span>
+                    </Link>
+                  ) : (
+                    <div className='flex items-center gap-2'>
+                      <div
+                        className='from-secondary to-chart-3 h-6 w-6 rounded-full bg-gradient-to-br'
+                        role='img'
+                        aria-label='Avatar for anonymous'
+                      />
+                      <span className='font-inter text-foreground text-sm font-medium'>
+                        @anonymous
+                      </span>
+                    </div>
+                  )}
                 </div>
 
                 <div>


### PR DESCRIPTION
## Summary
- Owner `@username` on the endpoint detail page (sidebar **About** card) is now a `<Link>` pointing to `/:username`, matching the existing public user profile route.
- The `by @username` line under each card title on `/browse` is also linked. Browse cards were refactored to a stretched-link pattern so the username link can sit inside the card without nesting `<a>` elements.
- Avatar + username row hover styles updated to give clear affordance; the `anonymous` (no owner) case is rendered as plain text.

## Test plan
- [ ] Open an endpoint detail page — clicking the owner avatar/username navigates to `/<username>`
- [ ] On `/browse`, clicking anywhere on a card (except `@username` and the data-source toggle) opens the endpoint detail page
- [ ] On `/browse`, clicking `by @<username>` navigates to `/<username>` instead of opening the endpoint
- [ ] Middle-click / cmd-click on both targets opens them in a new tab
- [ ] Endpoint with no owner still renders `@anonymous` without a link