### PR TITLE
feat(uptime): per-endpoint uptime + latency telemetry

### DIFF
--- a/components/backend/alembic/versions/20260513_000000_add_endpoint_uptime_telemetry.py
+++ b/components/backend/alembic/versions/20260513_000000_add_endpoint_uptime_telemetry.py
@@ -1,0 +1,87 @@
+"""Add endpoint uptime telemetry table and last_latency_ms column.
+
+Adds a new ``endpoint_uptime_samples`` table that stores bucketed uptime
++ latency aggregates emitted by the health monitor once per cycle, and a
+``endpoints.last_latency_ms`` column populated by clients reporting through
+``POST /endpoints/health``.
+
+Bucket key is ``(endpoint_id, bucket_start)`` where ``bucket_start`` is
+``floor(epoch / uptime_bucket_seconds) * uptime_bucket_seconds`` (default
+1800s = 30 minutes, mirroring ``heartbeat_max_ttl_seconds``).
+
+Revision ID: 013_endpoint_uptime
+Revises: 012_user_public_profile
+Create Date: 2026-05-13 00:00:00.000000+00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "013_endpoint_uptime"
+down_revision: str | None = "012_user_public_profile"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "endpoints",
+        sa.Column("last_latency_ms", sa.Integer(), nullable=True),
+    )
+
+    op.create_table(
+        "endpoint_uptime_samples",
+        sa.Column("endpoint_id", sa.Integer(), nullable=False),
+        sa.Column("bucket_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "total_checks",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "healthy_checks",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "latency_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "latency_sum_ms",
+            sa.BigInteger(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("latency_min_ms", sa.Integer(), nullable=True),
+        sa.Column("latency_max_ms", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["endpoint_id"], ["endpoints.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("endpoint_id", "bucket_start"),
+    )
+    op.create_index(
+        "idx_endpoint_uptime_endpoint_bucket",
+        "endpoint_uptime_samples",
+        ["endpoint_id", sa.text("bucket_start DESC")],
+    )
+    op.create_index(
+        "idx_endpoint_uptime_bucket_start",
+        "endpoint_uptime_samples",
+        ["bucket_start"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_endpoint_uptime_bucket_start", table_name="endpoint_uptime_samples"
+    )
+    op.drop_index(
+        "idx_endpoint_uptime_endpoint_bucket", table_name="endpoint_uptime_samples"
+    )
+    op.drop_table("endpoint_uptime_samples")
+    op.drop_column("endpoints", "last_latency_ms")

--- a/components/backend/src/syfthub/api/endpoints/endpoints.py
+++ b/components/backend/src/syfthub/api/endpoints/endpoints.py
@@ -21,6 +21,7 @@ from syfthub.schemas.endpoint import (
     EndpointResponse,
     EndpointType,
     EndpointUpdate,
+    EndpointUptimeResponse,
     EndpointVisibility,
     GroupedEndpointsResponse,
     OwnersListResponse,
@@ -483,6 +484,49 @@ async def report_endpoint_health(
         url=health_data.url,
         current_user=current_user,
         ttl_seconds=health_data.ttl_seconds,
+    )
+
+
+@router.get(
+    "/{owner_username}/{slug}/uptime",
+    response_model=EndpointUptimeResponse,
+    summary="Get Endpoint Uptime Series",
+    description="""
+Return a bucketed uptime + latency time series for one endpoint.
+
+Each bucket aggregates the health monitor's per-cycle decisions over the
+configured ``uptime_bucket_seconds`` window (default 30 minutes, matching
+``heartbeat_max_ttl_seconds``). For each bucket the response includes:
+
+- ``uptime_pct`` — percentage of monitor cycles in which the endpoint was healthy
+- ``avg_latency_ms`` / ``min_latency_ms`` / ``max_latency_ms`` — derived from
+  ``EndpointHealthItem.latency_ms`` reported by the SDK alongside health status
+- ``samples`` / ``healthy_samples`` — raw counters for client-side aggregation
+
+Public endpoints are readable by anyone, including unauthenticated viewers.
+INTERNAL / PRIVATE endpoints require the viewer to be the owner or, for
+organization endpoints, a member of the org.
+""",
+    responses={404: {"description": "Endpoint not found"}},
+)
+async def get_endpoint_uptime(
+    owner_username: str,
+    slug: str,
+    current_user: Annotated[Optional[User], Depends(get_optional_current_user)],
+    endpoint_service: Annotated[EndpointService, Depends(get_endpoint_service)],
+    window_hours: int = Query(
+        24,
+        ge=1,
+        le=168,
+        description="Rolling time window (max 7 days)",
+    ),
+) -> EndpointUptimeResponse:
+    """Get bucketed uptime + latency time series for one endpoint."""
+    return endpoint_service.get_endpoint_uptime(
+        owner_username=owner_username,
+        slug=slug,
+        window_hours=window_hours,
+        current_user=current_user,
     )
 
 

--- a/components/backend/src/syfthub/core/config.py
+++ b/components/backend/src/syfthub/core/config.py
@@ -371,6 +371,28 @@ class Settings(BaseSettings):
     )
 
     # ===========================================
+    # ENDPOINT UPTIME TELEMETRY
+    # ===========================================
+    # Aggregates the health monitor's per-cycle decisions into time buckets
+    # so each endpoint can render an uptime chart with latency.
+
+    uptime_bucket_seconds: int = Field(
+        default=1800,
+        description=(
+            "Bucket size for endpoint uptime aggregates, in seconds. "
+            "Default 1800s (30 min) mirrors heartbeat_max_ttl_seconds so a "
+            "single missed report fills at most one bucket."
+        ),
+    )
+    uptime_retention_days: int = Field(
+        default=90,
+        description=(
+            "Number of days of uptime samples to retain. Older samples are "
+            "deleted once per day by the health monitor. Set to 0 to disable."
+        ),
+    )
+
+    # ===========================================
     # RAG / MEILISEARCH SETTINGS
     # ===========================================
 

--- a/components/backend/src/syfthub/jobs/health_monitor.py
+++ b/components/backend/src/syfthub/jobs/health_monitor.py
@@ -80,6 +80,7 @@ class EndpointHealthInfo:
     health_status: Optional[str] = None
     health_checked_at: Optional[datetime] = None
     health_ttl_seconds: Optional[int] = None
+    last_latency_ms: Optional[int] = None
 
 
 class EndpointHealthMonitor:
@@ -105,8 +106,19 @@ class EndpointHealthMonitor:
         self.enabled = settings.health_check_enabled
         self.interval = settings.health_check_interval_seconds
         self.failure_threshold = settings.health_check_failure_threshold
+        # ``getattr`` with defaults lets older test fixtures (which build
+        # ``Settings`` from MagicMock) instantiate the monitor without
+        # configuring the uptime fields. Production ``Settings`` always
+        # supplies real integers.
+        bucket = getattr(settings, "uptime_bucket_seconds", 1800)
+        retention = getattr(settings, "uptime_retention_days", 90)
+        self.bucket_seconds = max(1, bucket) if isinstance(bucket, int) else 1800
+        self.uptime_retention_days = retention if isinstance(retention, int) else 90
         self._running = False
         self._task: Optional[asyncio.Task[None]] = None
+        # Tracks the most recent date we ran the uptime retention sweep so we
+        # do it at most once per UTC day across cycles.
+        self._last_retention_sweep_date: Optional[str] = None
         # Note: Consecutive failure tracking is stored in the database
         # (endpoints.consecutive_failure_count) for multi-worker safety
 
@@ -176,6 +188,7 @@ class EndpointHealthMonitor:
             EndpointModel.health_status,
             EndpointModel.health_checked_at,
             EndpointModel.health_ttl_seconds,
+            EndpointModel.last_latency_ms,
         ).join(UserModel, EndpointModel.user_id == UserModel.id)
 
         # Query endpoints with organization domain (org-owned endpoints)
@@ -191,6 +204,7 @@ class EndpointHealthMonitor:
             EndpointModel.health_status,
             EndpointModel.health_checked_at,
             EndpointModel.health_ttl_seconds,
+            EndpointModel.last_latency_ms,
         ).join(OrganizationModel, EndpointModel.organization_id == OrganizationModel.id)
 
         endpoints: list[EndpointHealthInfo] = []
@@ -210,6 +224,7 @@ class EndpointHealthMonitor:
                 health_status,
                 health_checked_at,
                 health_ttl_seconds,
+                last_latency_ms,
             ) = row
             # Include endpoints with connections (even if domain is None)
             # Endpoints without domain will be marked unhealthy in health check
@@ -228,6 +243,7 @@ class EndpointHealthMonitor:
                         health_status=health_status,
                         health_checked_at=health_checked_at,
                         health_ttl_seconds=health_ttl_seconds,
+                        last_latency_ms=last_latency_ms,
                     )
                 )
 
@@ -246,6 +262,7 @@ class EndpointHealthMonitor:
                 health_status,
                 health_checked_at,
                 health_ttl_seconds,
+                last_latency_ms,
             ) = row
             # Include endpoints with connections (even if domain is None)
             # Endpoints without domain will be marked unhealthy in health check
@@ -264,6 +281,7 @@ class EndpointHealthMonitor:
                         health_status=health_status,
                         health_checked_at=health_checked_at,
                         health_ttl_seconds=health_ttl_seconds,
+                        last_latency_ms=last_latency_ms,
                     )
                 )
 
@@ -273,12 +291,15 @@ class EndpointHealthMonitor:
         self,
         endpoint: EndpointHealthInfo,
         now: datetime,
-    ) -> bool | None:
+    ) -> tuple[bool, Optional[int]] | None:
         """Check per-endpoint health reported via POST /endpoints/health.
 
-        Returns True/False if a fresh per-endpoint health signal exists,
-        or None if no fresh signal is available (caller should fall through
-        to the next health check tier).
+        Returns a tuple ``(is_healthy, latency_ms)`` if a fresh per-endpoint
+        health signal exists. Latency is included only when the same Tier 1
+        signal is fresh (so it cannot leak forward from a stale report).
+
+        Returns ``None`` when no fresh signal is available — callers should
+        fall through to the next health check tier.
         """
         if (
             endpoint.health_checked_at is not None
@@ -292,9 +313,10 @@ class EndpointHealthMonitor:
                 logger.debug(
                     f"Endpoint {endpoint.id}: fresh per-endpoint health "
                     f"(status={endpoint.health_status}, "
-                    f"expires={health_expires_at})"
+                    f"expires={health_expires_at}, "
+                    f"latency_ms={endpoint.last_latency_ms})"
                 )
-                return is_healthy
+                return (is_healthy, endpoint.last_latency_ms)
         return None
 
     def _check_heartbeat_health(
@@ -323,15 +345,17 @@ class EndpointHealthMonitor:
     def _check_endpoint_health(
         self,
         endpoint: EndpointHealthInfo,
-    ) -> tuple[int, bool]:
+    ) -> tuple[int, bool, Optional[int]]:
         """Determine if an endpoint is healthy using a 2-tier approach.
 
         Priority:
         1. Per-endpoint health (client-reported via POST /endpoints/health):
            If health_checked_at + health_ttl_seconds > now, trust health_status
+           and return the accompanying ``last_latency_ms`` (may be ``None``).
         2. Domain-level heartbeat (deprecated fallback):
-           If heartbeat_expires_at > now, assume healthy
-        3. Neither is fresh: Mark unhealthy
+           If heartbeat_expires_at > now, assume healthy. No latency available
+           because heartbeat is owner-level, not endpoint-level.
+        3. Neither is fresh: Mark unhealthy, no latency.
 
         When the deprecated heartbeat system is removed, delete tier 2
         (the ``_check_heartbeat_health`` call) so this becomes a single-tier check.
@@ -340,7 +364,7 @@ class EndpointHealthMonitor:
             endpoint: The endpoint information to evaluate
 
         Returns:
-            Tuple of (endpoint_id, is_healthy)
+            Tuple of (endpoint_id, is_healthy, latency_ms_or_None)
         """
         now = datetime.now(timezone.utc)
 
@@ -349,21 +373,22 @@ class EndpointHealthMonitor:
             logger.debug(
                 f"Endpoint {endpoint.id}: no owner domain configured (unhealthy)"
             )
-            return (endpoint.id, False)
+            return (endpoint.id, False, None)
 
         # Tier 1: Per-endpoint health (client-reported)
-        result = self._check_per_endpoint_health(endpoint, now)
-        if result is not None:
-            return (endpoint.id, result)
+        tier1 = self._check_per_endpoint_health(endpoint, now)
+        if tier1 is not None:
+            is_healthy, latency_ms = tier1
+            return (endpoint.id, is_healthy, latency_ms)
 
         # Tier 2: Domain-level heartbeat (deprecated fallback — remove with heartbeat)
-        result = self._check_heartbeat_health(endpoint, now)
-        if result is not None:
-            return (endpoint.id, result)
+        tier2 = self._check_heartbeat_health(endpoint, now)
+        if tier2 is not None:
+            return (endpoint.id, tier2, None)
 
         # Neither signal is fresh — mark unhealthy
         logger.debug(f"Endpoint {endpoint.id}: no fresh health signal (unhealthy)")
-        return (endpoint.id, False)
+        return (endpoint.id, False, None)
 
     def _update_endpoint_health_status(
         self, session: Session, endpoint_id: int, is_healthy: bool
@@ -428,6 +453,69 @@ class EndpointHealthMonitor:
             session.rollback()
             return None
 
+    def _current_bucket_start(self, now: datetime) -> datetime:
+        """Return the UTC bucket boundary that ``now`` falls into."""
+        epoch = int(now.timestamp())
+        floored = (epoch // self.bucket_seconds) * self.bucket_seconds
+        return datetime.fromtimestamp(floored, tz=timezone.utc)
+
+    def _emit_uptime_sample(
+        self,
+        session: Session,
+        endpoint_id: int,
+        is_healthy: bool,
+        latency_ms: Optional[int],
+        now: datetime,
+    ) -> None:
+        """Persist one uptime sample for this cycle, swallowing errors.
+
+        The sample is bucketed by ``self.bucket_seconds`` so a single bucket
+        accumulates many monitor cycles (e.g. 60 cycles per 30-minute bucket
+        at the default 30s interval).
+        """
+        from syfthub.repositories.endpoint import EndpointRepository
+
+        try:
+            repo = EndpointRepository(session)
+            repo.upsert_uptime_sample(
+                endpoint_id=endpoint_id,
+                bucket_start=self._current_bucket_start(now),
+                is_healthy=is_healthy,
+                latency_ms=latency_ms,
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(
+                f"Failed to record uptime sample for endpoint {endpoint_id}: {e}"
+            )
+
+    def _maybe_run_uptime_retention(self, session: Session, now: datetime) -> None:
+        """Delete uptime samples older than the configured retention window.
+
+        Runs at most once per UTC day to keep the cost bounded. The first
+        cycle of each day pays the deletion cost; subsequent cycles skip it.
+        """
+        if self.uptime_retention_days <= 0:
+            return
+        today = now.date().isoformat()
+        if self._last_retention_sweep_date == today:
+            return
+
+        try:
+            from syfthub.repositories.endpoint import EndpointRepository
+
+            repo = EndpointRepository(session)
+            removed = repo.delete_uptime_samples_older_than(self.uptime_retention_days)
+            session.commit()
+            self._last_retention_sweep_date = today
+            if removed:
+                logger.info(
+                    f"Uptime retention sweep removed {removed} old sample(s) "
+                    f"(retention: {self.uptime_retention_days} days)"
+                )
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(f"Uptime retention sweep failed: {e}")
+            session.rollback()
+
     async def run_health_check_cycle(self) -> None:
         """Run one complete health check cycle for all endpoints.
 
@@ -447,6 +535,10 @@ class EndpointHealthMonitor:
                 )
                 return
 
+            # Once per UTC day, sweep old uptime samples. Lock-holder only,
+            # so this runs from a single worker process per day.
+            self._maybe_run_uptime_retention(session, datetime.now(timezone.utc))
+
             # Get all endpoints that can be health checked
             endpoints = self._get_endpoints_for_health_check(session)
 
@@ -460,9 +552,12 @@ class EndpointHealthMonitor:
             old_status_map = {ep.id: ep.is_active for ep in endpoints}
 
             # Evaluate each endpoint's health (no I/O — purely signal-based)
+            now = datetime.now(timezone.utc)
             state_changes = 0
             for endpoint in endpoints:
-                endpoint_id, is_healthy = self._check_endpoint_health(endpoint)
+                endpoint_id, is_healthy, latency_ms = self._check_endpoint_health(
+                    endpoint
+                )
 
                 # Get the old status for comparison
                 old_is_active = old_status_map.get(endpoint_id, True)
@@ -475,6 +570,21 @@ class EndpointHealthMonitor:
                 if update_result is None:
                     # Endpoint was deleted between query and update
                     continue
+
+                # Record one uptime sample per cycle. Use a fresh session
+                # transaction (the failure-counter update above already
+                # committed) so an error here cannot poison the next loop.
+                self._emit_uptime_sample(
+                    session, endpoint_id, is_healthy, latency_ms, now
+                )
+                try:
+                    session.commit()
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.warning(
+                        f"Failed to commit uptime sample for endpoint "
+                        f"{endpoint_id}: {e}"
+                    )
+                    session.rollback()
 
                 new_is_active, failure_count = update_result
 

--- a/components/backend/src/syfthub/models/__init__.py
+++ b/components/backend/src/syfthub/models/__init__.py
@@ -2,7 +2,11 @@
 
 from syfthub.models.api_token import APITokenModel
 from syfthub.models.base import Base, BaseModel, TimestampMixin
-from syfthub.models.endpoint import EndpointModel, EndpointStarModel
+from syfthub.models.endpoint import (
+    EndpointModel,
+    EndpointStarModel,
+    EndpointUptimeSampleModel,
+)
 from syfthub.models.organization import OrganizationMemberModel, OrganizationModel
 from syfthub.models.otp import OTPCodeModel
 from syfthub.models.user import UserModel
@@ -16,6 +20,7 @@ __all__ = [
     "BaseModel",
     "EndpointModel",
     "EndpointStarModel",
+    "EndpointUptimeSampleModel",
     "ErrorLogModel",
     "OTPCodeModel",
     "OrganizationMemberModel",

--- a/components/backend/src/syfthub/models/endpoint.py
+++ b/components/backend/src/syfthub/models/endpoint.py
@@ -5,19 +5,21 @@ from typing import TYPE_CHECKING, List, Optional
 
 from sqlalchemy import (
     JSON,
+    BigInteger,
     Boolean,
     CheckConstraint,
     DateTime,
     ForeignKey,
     Index,
     Integer,
+    PrimaryKeyConstraint,
     String,
     Text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from syfthub.models.base import BaseModel, TimestampMixin
+from syfthub.models.base import Base, BaseModel, TimestampMixin
 
 # Use JSONB for PostgreSQL, JSON for other databases (e.g., SQLite in tests)
 JSONType = JSON().with_variant(JSONB(), "postgresql")  # type: ignore[no-untyped-call]
@@ -75,6 +77,14 @@ class EndpointModel(BaseModel, TimestampMixin):
         DateTime(timezone=True), nullable=True, default=None
     )
     health_ttl_seconds: Mapped[Optional[int]] = mapped_column(
+        Integer, nullable=True, default=None
+    )
+
+    # Last endpoint round-trip latency in milliseconds, reported by client
+    # alongside health status via POST /endpoints/health. Trusted only while
+    # the per-endpoint health signal (health_checked_at + health_ttl_seconds)
+    # is still fresh; otherwise treated as stale and ignored by the monitor.
+    last_latency_ms: Mapped[Optional[int]] = mapped_column(
         Integer, nullable=True, default=None
     )
 
@@ -171,3 +181,49 @@ class EndpointStarModel(BaseModel):
     def __repr__(self) -> str:
         """String representation of EndpointStar."""
         return f"<EndpointStar(id={self.id}, user_id={self.user_id}, endpoint_id={self.endpoint_id})>"
+
+
+class EndpointUptimeSampleModel(Base):
+    """Bucketed uptime + latency aggregates for an endpoint.
+
+    One row per (endpoint_id, bucket_start). The health monitor upserts a row
+    every cycle (default every 30s), accumulating totals so the bucket can be
+    rendered as a single uptime + latency data point.
+
+    Bucket size is controlled by ``settings.uptime_bucket_seconds`` (default
+    1800s = 30 min, matching ``heartbeat_max_ttl_seconds``).
+    """
+
+    __tablename__ = "endpoint_uptime_samples"
+
+    endpoint_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("endpoints.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    bucket_start: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    total_checks: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    healthy_checks: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    latency_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    latency_sum_ms: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    latency_min_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    latency_max_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+
+    __table_args__ = (
+        PrimaryKeyConstraint("endpoint_id", "bucket_start"),
+        Index(
+            "idx_endpoint_uptime_endpoint_bucket",
+            "endpoint_id",
+            "bucket_start",
+        ),
+        Index("idx_endpoint_uptime_bucket_start", "bucket_start"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<EndpointUptimeSample(endpoint_id={self.endpoint_id}, "
+            f"bucket_start={self.bucket_start}, "
+            f"healthy={self.healthy_checks}/{self.total_checks})>"
+        )

--- a/components/backend/src/syfthub/repositories/endpoint.py
+++ b/components/backend/src/syfthub/repositories/endpoint.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, List, Optional
 
-from sqlalchemy import Text, and_, cast, delete, func, or_, select, update
+from sqlalchemy import Text, and_, cast, delete, func, or_, select, text, update
 from sqlalchemy.exc import SQLAlchemyError
 
 from syfthub.core.url_builder import transform_connection_urls
-from syfthub.models.endpoint import EndpointModel, EndpointStarModel
+from syfthub.models.endpoint import (
+    EndpointModel,
+    EndpointStarModel,
+    EndpointUptimeSampleModel,
+)
 from syfthub.models.organization import OrganizationModel
 from syfthub.models.user import UserModel
 from syfthub.repositories.base import BaseRepository
@@ -1242,6 +1247,7 @@ class EndpointRepository(BaseRepository[EndpointModel]):
             - health_status: str ("healthy" or "unhealthy")
             - health_checked_at: datetime
             - health_ttl_seconds: int
+            - last_latency_ms: Optional[int] (when missing, latency is not updated)
 
         Does NOT commit — caller manages the transaction.
 
@@ -1254,14 +1260,18 @@ class EndpointRepository(BaseRepository[EndpointModel]):
         updated_count = 0
         for item in updates:
             try:
+                values: dict[str, Any] = {
+                    "health_status": item["health_status"],
+                    "health_checked_at": item["health_checked_at"],
+                    "health_ttl_seconds": item["health_ttl_seconds"],
+                }
+                if "last_latency_ms" in item and item["last_latency_ms"] is not None:
+                    values["last_latency_ms"] = item["last_latency_ms"]
+
                 stmt = (
                     update(EndpointModel)
                     .where(EndpointModel.id == item["endpoint_id"])
-                    .values(
-                        health_status=item["health_status"],
-                        health_checked_at=item["health_checked_at"],
-                        health_ttl_seconds=item["health_ttl_seconds"],
-                    )
+                    .values(**values)
                 )
                 result = self.session.execute(stmt)
                 if result.rowcount > 0:
@@ -1271,6 +1281,211 @@ class EndpointRepository(BaseRepository[EndpointModel]):
                     f"Failed to update health for endpoint {item['endpoint_id']}: {e}"
                 )
         return updated_count
+
+    def get_by_owner_and_slug_any_state(
+        self,
+        user_id: Optional[int],
+        organization_id: Optional[int],
+        slug: str,
+    ) -> Optional[Endpoint]:
+        """Look up an endpoint by owner + slug ignoring is_active.
+
+        Used by callers that need to operate on endpoints that may currently
+        be marked inactive by the health monitor (e.g. rendering the uptime
+        chart for a down endpoint).
+        """
+        if (user_id is None) == (organization_id is None):
+            return None
+        try:
+            conditions = [self.model.slug == slug.lower()]
+            if user_id is not None:
+                conditions.append(self.model.user_id == user_id)
+            else:
+                conditions.append(self.model.organization_id == organization_id)
+            stmt = select(self.model).where(and_(*conditions))
+            endpoint_model = self.session.execute(stmt).scalar_one_or_none()
+            if endpoint_model:
+                return Endpoint.model_validate(endpoint_model)
+            return None
+        except SQLAlchemyError:
+            return None
+
+    # ===========================================
+    # ENDPOINT UPTIME / TELEMETRY METHODS
+    # ===========================================
+
+    def upsert_uptime_sample(
+        self,
+        endpoint_id: int,
+        bucket_start: datetime,
+        is_healthy: bool,
+        latency_ms: Optional[int],
+    ) -> None:
+        """Upsert one health-monitor tick into the bucketed uptime table.
+
+        Uses ``INSERT … ON CONFLICT`` on Postgres and a select-then-update
+        fallback on other dialects (SQLite/dev). Does NOT commit — the caller
+        manages the transaction.
+
+        Args:
+            endpoint_id: Endpoint receiving the sample.
+            bucket_start: Truncated UTC bucket boundary
+                (``floor(epoch / bucket_seconds) * bucket_seconds``).
+            is_healthy: Result of the monitor's tier evaluation.
+            latency_ms: Latency to record, or ``None`` if no fresh latency
+                signal is available (e.g. tier 2/3 decision).
+        """
+        healthy = 1 if is_healthy else 0
+        has_latency = latency_ms is not None
+        lat_count = 1 if has_latency else 0
+        lat_sum = latency_ms if has_latency else 0
+
+        dialect = self.session.bind.dialect.name if self.session.bind else ""
+
+        try:
+            if dialect == "postgresql":
+                self.session.execute(
+                    text(
+                        """
+                        INSERT INTO endpoint_uptime_samples (
+                            endpoint_id, bucket_start,
+                            total_checks, healthy_checks,
+                            latency_count, latency_sum_ms,
+                            latency_min_ms, latency_max_ms
+                        )
+                        VALUES (
+                            :eid, :bucket,
+                            1, :h,
+                            :lc, :ls,
+                            :lat, :lat
+                        )
+                        ON CONFLICT (endpoint_id, bucket_start) DO UPDATE SET
+                            total_checks   = endpoint_uptime_samples.total_checks + 1,
+                            healthy_checks = endpoint_uptime_samples.healthy_checks
+                                             + EXCLUDED.healthy_checks,
+                            latency_count  = endpoint_uptime_samples.latency_count
+                                             + EXCLUDED.latency_count,
+                            latency_sum_ms = endpoint_uptime_samples.latency_sum_ms
+                                             + EXCLUDED.latency_sum_ms,
+                            latency_min_ms = CASE
+                                WHEN EXCLUDED.latency_min_ms IS NULL
+                                    THEN endpoint_uptime_samples.latency_min_ms
+                                WHEN endpoint_uptime_samples.latency_min_ms IS NULL
+                                    THEN EXCLUDED.latency_min_ms
+                                ELSE LEAST(
+                                    endpoint_uptime_samples.latency_min_ms,
+                                    EXCLUDED.latency_min_ms
+                                )
+                            END,
+                            latency_max_ms = CASE
+                                WHEN EXCLUDED.latency_max_ms IS NULL
+                                    THEN endpoint_uptime_samples.latency_max_ms
+                                WHEN endpoint_uptime_samples.latency_max_ms IS NULL
+                                    THEN EXCLUDED.latency_max_ms
+                                ELSE GREATEST(
+                                    endpoint_uptime_samples.latency_max_ms,
+                                    EXCLUDED.latency_max_ms
+                                )
+                            END
+                        """
+                    ),
+                    {
+                        "eid": endpoint_id,
+                        "bucket": bucket_start,
+                        "h": healthy,
+                        "lc": lat_count,
+                        "ls": lat_sum,
+                        "lat": latency_ms,
+                    },
+                )
+                return
+
+            # Fallback path (SQLite/dev): SELECT existing, then INSERT or UPDATE.
+            existing = self.session.execute(
+                select(EndpointUptimeSampleModel).where(
+                    and_(
+                        EndpointUptimeSampleModel.endpoint_id == endpoint_id,
+                        EndpointUptimeSampleModel.bucket_start == bucket_start,
+                    )
+                )
+            ).scalar_one_or_none()
+
+            if existing is None:
+                sample = EndpointUptimeSampleModel(
+                    endpoint_id=endpoint_id,
+                    bucket_start=bucket_start,
+                    total_checks=1,
+                    healthy_checks=healthy,
+                    latency_count=lat_count,
+                    latency_sum_ms=lat_sum,
+                    latency_min_ms=latency_ms,
+                    latency_max_ms=latency_ms,
+                )
+                self.session.add(sample)
+                return
+
+            existing.total_checks += 1
+            existing.healthy_checks += healthy
+            if has_latency:
+                existing.latency_count += 1
+                existing.latency_sum_ms += int(latency_ms or 0)
+                existing.latency_min_ms = (
+                    latency_ms
+                    if existing.latency_min_ms is None
+                    else min(existing.latency_min_ms, int(latency_ms or 0))
+                )
+                existing.latency_max_ms = (
+                    latency_ms
+                    if existing.latency_max_ms is None
+                    else max(existing.latency_max_ms, int(latency_ms or 0))
+                )
+        except SQLAlchemyError as e:
+            logger.error(
+                f"Failed to upsert uptime sample for endpoint {endpoint_id} "
+                f"at {bucket_start}: {e}"
+            )
+
+    def get_uptime_samples(
+        self,
+        endpoint_id: int,
+        window_hours: int,
+    ) -> list[EndpointUptimeSampleModel]:
+        """Return ordered uptime samples for an endpoint in a rolling window."""
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=window_hours)
+        try:
+            stmt = (
+                select(EndpointUptimeSampleModel)
+                .where(
+                    and_(
+                        EndpointUptimeSampleModel.endpoint_id == endpoint_id,
+                        EndpointUptimeSampleModel.bucket_start >= cutoff,
+                    )
+                )
+                .order_by(EndpointUptimeSampleModel.bucket_start.asc())
+            )
+            return list(self.session.execute(stmt).scalars().all())
+        except SQLAlchemyError as e:
+            logger.error(
+                f"Failed to load uptime samples for endpoint {endpoint_id}: {e}"
+            )
+            return []
+
+    def delete_uptime_samples_older_than(self, retention_days: int) -> int:
+        """Delete uptime samples older than the configured retention window.
+
+        Returns the number of rows removed. Does NOT commit — caller manages
+        the transaction.
+        """
+        cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+        try:
+            stmt = delete(EndpointUptimeSampleModel).where(
+                EndpointUptimeSampleModel.bucket_start < cutoff
+            )
+            result = self.session.execute(stmt)
+            return result.rowcount or 0
+        except SQLAlchemyError as e:
+            logger.error(f"Failed to purge old uptime samples: {e}")
+            return 0
 
 
 class EndpointStarRepository(BaseRepository[EndpointStarModel]):

--- a/components/backend/src/syfthub/repositories/endpoint.py
+++ b/components/backend/src/syfthub/repositories/endpoint.py
@@ -1422,6 +1422,10 @@ class EndpointRepository(BaseRepository[EndpointModel]):
                     latency_max_ms=latency_ms,
                 )
                 self.session.add(sample)
+                # Flush so successive calls within the same transaction see
+                # this row and take the UPDATE branch instead of inserting a
+                # duplicate (would violate the (endpoint_id, bucket_start) PK).
+                self.session.flush()
                 return
 
             existing.total_checks += 1

--- a/components/backend/src/syfthub/schemas/endpoint.py
+++ b/components/backend/src/syfthub/schemas/endpoint.py
@@ -446,6 +446,10 @@ class Endpoint(BaseModel):
     health_ttl_seconds: Optional[int] = Field(
         None, description="TTL for the health status report in seconds"
     )
+    last_latency_ms: Optional[int] = Field(
+        None,
+        description="Last reported endpoint round-trip latency in milliseconds",
+    )
 
     model_config = {"from_attributes": True}
 
@@ -497,6 +501,10 @@ class EndpointResponse(BaseModel):
     health_ttl_seconds: Optional[int] = Field(
         None, description="TTL for the health status report in seconds"
     )
+    last_latency_ms: Optional[int] = Field(
+        None,
+        description="Last reported endpoint round-trip latency in milliseconds",
+    )
 
     model_config = {"from_attributes": True}
 
@@ -536,6 +544,10 @@ class EndpointPublicResponse(BaseModel):
     )
     health_checked_at: Optional[datetime] = Field(
         None, description="When the client last checked this endpoint's health"
+    )
+    last_latency_ms: Optional[int] = Field(
+        None,
+        description="Last reported endpoint round-trip latency in milliseconds",
     )
     archived: bool = Field(
         default=False, description="Whether the endpoint is archived"
@@ -712,6 +724,15 @@ class EndpointHealthItem(BaseModel):
     checked_at: datetime = Field(
         ..., description="When the client checked this endpoint's health"
     )
+    latency_ms: Optional[int] = Field(
+        None,
+        ge=0,
+        le=300_000,
+        description=(
+            "Optional round-trip latency for the client's upstream probe, "
+            "in milliseconds. Used to populate the endpoint uptime chart."
+        ),
+    )
 
 
 class EndpointHealthRequest(BaseModel):
@@ -786,4 +807,56 @@ class EndpointHealthResponse(BaseModel):
         ...,
         ge=0,
         description="Number of slugs that were not found or not accessible",
+    )
+
+
+# ===========================================
+# ENDPOINT UPTIME / TELEMETRY SCHEMAS
+# ===========================================
+
+
+class UptimeBucket(BaseModel):
+    """One bucketed uptime + latency data point for an endpoint."""
+
+    bucket_start: datetime = Field(..., description="UTC start of the bucket interval")
+    samples: int = Field(
+        ..., ge=0, description="Number of health monitor cycles in this bucket"
+    )
+    healthy_samples: int = Field(
+        ..., ge=0, description="Number of those cycles that observed a healthy state"
+    )
+    uptime_pct: float = Field(
+        ...,
+        ge=0.0,
+        le=100.0,
+        description="Percentage of cycles in which the endpoint was healthy",
+    )
+    avg_latency_ms: Optional[float] = Field(
+        None,
+        description=(
+            "Mean round-trip latency reported in this bucket. "
+            "Null when no fresh latency signals were recorded."
+        ),
+    )
+    min_latency_ms: Optional[int] = Field(
+        None, description="Minimum reported latency in the bucket (milliseconds)"
+    )
+    max_latency_ms: Optional[int] = Field(
+        None, description="Maximum reported latency in the bucket (milliseconds)"
+    )
+
+
+class EndpointUptimeResponse(BaseModel):
+    """Bucketed uptime + latency series for a single endpoint."""
+
+    endpoint_id: int = Field(..., description="Endpoint ID the series belongs to")
+    owner_username: str = Field(..., description="Owner's username (user or org slug)")
+    slug: str = Field(..., description="Endpoint slug")
+    bucket_seconds: int = Field(..., ge=1, description="Size of each bucket in seconds")
+    window_hours: int = Field(
+        ..., ge=1, description="Time window covered by the response in hours"
+    )
+    buckets: List[UptimeBucket] = Field(
+        default_factory=list,
+        description="Ordered list of buckets (oldest first)",
     )

--- a/components/backend/src/syfthub/services/endpoint_service.py
+++ b/components/backend/src/syfthub/services/endpoint_service.py
@@ -29,12 +29,14 @@ from syfthub.schemas.endpoint import (
     EndpointResponse,
     EndpointType,
     EndpointUpdate,
+    EndpointUptimeResponse,
     EndpointVisibility,
     GroupedEndpointsResponse,
     OwnersListResponse,
     Policy,
     SyncEndpointsResponse,
     SyncValidationError,
+    UptimeBucket,
     filter_visible_policies,
     generate_slug_from_name,
     get_matching_types,
@@ -1477,6 +1479,7 @@ class EndpointService(BaseService):
                     "health_status": item.status.value,
                     "health_checked_at": item.checked_at,
                     "health_ttl_seconds": effective_ttl,
+                    "last_latency_ms": item.latency_ms,
                 }
             )
 
@@ -1522,4 +1525,116 @@ class EndpointService(BaseService):
         return EndpointHealthResponse(
             updated=updated,
             ignored=ignored,
+        )
+
+    # ===========================================
+    # ENDPOINT UPTIME / TELEMETRY
+    # ===========================================
+
+    def get_endpoint_uptime(
+        self,
+        owner_username: str,
+        slug: str,
+        window_hours: int,
+        current_user: Optional[User],
+    ) -> EndpointUptimeResponse:
+        """Return bucketed uptime + latency series for one endpoint.
+
+        Visibility mirrors the rest of the endpoint read path:
+        - Public endpoints are readable by anyone (including guests)
+        - INTERNAL/PRIVATE endpoints require the viewer to be the owner or,
+          for org-owned endpoints, a member of the org.
+
+        Args:
+            owner_username: User username or org slug
+            slug: Endpoint slug
+            window_hours: Rolling window in hours (1..168 enforced at route)
+            current_user: Authenticated viewer (optional for public reads)
+
+        Returns:
+            EndpointUptimeResponse with one entry per bucket (oldest first)
+
+        Raises:
+            HTTPException: 404 if endpoint is not found or not accessible
+        """
+        normalized_slug = slug.lower()
+
+        # Resolve owner — try user first, then organization. Use the
+        # any-state lookup so a chart can be rendered even when the health
+        # monitor has flipped the endpoint to is_active=False.
+        owner_user = self.user_repository.get_by_username(owner_username)
+        endpoint_model = None
+        if owner_user is not None:
+            endpoint_model = self.endpoint_repository.get_by_owner_and_slug_any_state(
+                user_id=owner_user.id,
+                organization_id=None,
+                slug=normalized_slug,
+            )
+
+        if endpoint_model is None:
+            owner_org = self.org_repository.get_by_slug(owner_username)
+            if owner_org is not None:
+                endpoint_model = (
+                    self.endpoint_repository.get_by_owner_and_slug_any_state(
+                        user_id=None,
+                        organization_id=owner_org.id,
+                        slug=normalized_slug,
+                    )
+                )
+
+        if endpoint_model is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Endpoint not found",
+            )
+
+        owner_type = "organization" if endpoint_model.organization_id else "user"
+        if not self._can_access_endpoint(endpoint_model, current_user, owner_type):
+            # Hide existence for security
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Endpoint not found",
+            )
+
+        bucket_seconds = max(1, settings.uptime_bucket_seconds)
+        samples = self.endpoint_repository.get_uptime_samples(
+            endpoint_id=endpoint_model.id,
+            window_hours=window_hours,
+        )
+
+        buckets: list[UptimeBucket] = []
+        for s in samples:
+            total = s.total_checks or 0
+            healthy = s.healthy_checks or 0
+            uptime_pct = (100.0 * healthy / total) if total > 0 else 0.0
+            avg_latency = (
+                (s.latency_sum_ms / s.latency_count)
+                if (s.latency_count and s.latency_count > 0)
+                else None
+            )
+            # bucket_start is NOT NULL in the schema; assert narrows the type
+            # so mypy stops treating it as Optional[datetime].
+            bucket_start = s.bucket_start
+            assert bucket_start is not None
+            buckets.append(
+                UptimeBucket(
+                    bucket_start=bucket_start,
+                    samples=total,
+                    healthy_samples=healthy,
+                    uptime_pct=round(uptime_pct, 2),
+                    avg_latency_ms=(
+                        round(avg_latency, 2) if avg_latency is not None else None
+                    ),
+                    min_latency_ms=s.latency_min_ms,
+                    max_latency_ms=s.latency_max_ms,
+                )
+            )
+
+        return EndpointUptimeResponse(
+            endpoint_id=endpoint_model.id,
+            owner_username=owner_username,
+            slug=endpoint_model.slug,
+            bucket_seconds=bucket_seconds,
+            window_hours=window_hours,
+            buckets=buckets,
         )

--- a/components/backend/tests/test_jobs/test_health_monitor.py
+++ b/components/backend/tests/test_jobs/test_health_monitor.py
@@ -1159,3 +1159,124 @@ class TestHealthMonitorLifecycle:
         await monitor.stop()
 
         mock_task.cancel.assert_not_called()
+
+
+class TestUptimeSampleEmission:
+    """Tests for the new uptime telemetry hooks in EndpointHealthMonitor."""
+
+    @pytest.fixture
+    def monitor(self):
+        settings = MagicMock()
+        settings.health_check_enabled = True
+        settings.health_check_interval_seconds = 30
+        settings.health_check_failure_threshold = 3
+        settings.uptime_bucket_seconds = 1800
+        settings.uptime_retention_days = 90
+        return EndpointHealthMonitor(settings)
+
+    def test_init_reads_uptime_settings(self):
+        settings = MagicMock()
+        settings.health_check_enabled = True
+        settings.health_check_interval_seconds = 30
+        settings.health_check_failure_threshold = 3
+        settings.uptime_bucket_seconds = 600
+        settings.uptime_retention_days = 14
+        m = EndpointHealthMonitor(settings)
+        assert m.bucket_seconds == 600
+        assert m.uptime_retention_days == 14
+
+    def test_init_defaults_when_settings_are_magicmock(self):
+        # MagicMock returns MagicMock for absent attrs; init must fall back to
+        # safe defaults rather than blowing up.
+        settings = MagicMock()
+        settings.health_check_enabled = True
+        settings.health_check_interval_seconds = 30
+        settings.health_check_failure_threshold = 3
+        # uptime_* left unset → MagicMock attr access; init should coerce.
+        m = EndpointHealthMonitor(settings)
+        assert m.bucket_seconds == 1800
+        assert m.uptime_retention_days == 90
+
+    def test_current_bucket_start_floors_to_bucket(self, monitor):
+        # 12:34:56 with 1800s buckets → 12:30:00
+        now = datetime(2026, 5, 13, 12, 34, 56, tzinfo=timezone.utc)
+        bucket = monitor._current_bucket_start(now)
+        assert bucket == datetime(2026, 5, 13, 12, 30, 0, tzinfo=timezone.utc)
+
+    def test_current_bucket_start_on_boundary(self, monitor):
+        now = datetime(2026, 5, 13, 13, 0, 0, tzinfo=timezone.utc)
+        assert monitor._current_bucket_start(now) == now
+
+    def test_emit_uptime_sample_calls_repository(self, monitor):
+        mock_session = MagicMock()
+        now = datetime(2026, 5, 13, 12, 5, 0, tzinfo=timezone.utc)
+        with patch("syfthub.repositories.endpoint.EndpointRepository") as RepoCls:
+            repo = MagicMock()
+            RepoCls.return_value = repo
+            monitor._emit_uptime_sample(
+                mock_session,
+                endpoint_id=42,
+                is_healthy=True,
+                latency_ms=87,
+                now=now,
+            )
+        repo.upsert_uptime_sample.assert_called_once()
+        kwargs = repo.upsert_uptime_sample.call_args.kwargs
+        assert kwargs["endpoint_id"] == 42
+        assert kwargs["is_healthy"] is True
+        assert kwargs["latency_ms"] == 87
+        # bucket boundary
+        assert kwargs["bucket_start"] == datetime(
+            2026, 5, 13, 12, 0, 0, tzinfo=timezone.utc
+        )
+
+    def test_emit_uptime_sample_swallows_errors(self, monitor):
+        mock_session = MagicMock()
+        now = datetime(2026, 5, 13, 12, 0, 0, tzinfo=timezone.utc)
+        with patch(
+            "syfthub.repositories.endpoint.EndpointRepository",
+            side_effect=RuntimeError("boom"),
+        ):
+            # Must not raise — emission is best-effort.
+            monitor._emit_uptime_sample(
+                mock_session,
+                endpoint_id=1,
+                is_healthy=False,
+                latency_ms=None,
+                now=now,
+            )
+
+    def test_retention_runs_at_most_once_per_day(self, monitor):
+        mock_session = MagicMock()
+        now = datetime(2026, 5, 13, 1, 0, 0, tzinfo=timezone.utc)
+        with patch("syfthub.repositories.endpoint.EndpointRepository") as RepoCls:
+            repo = MagicMock()
+            repo.delete_uptime_samples_older_than.return_value = 5
+            RepoCls.return_value = repo
+
+            monitor._maybe_run_uptime_retention(mock_session, now)
+            monitor._maybe_run_uptime_retention(mock_session, now)  # same day → skipped
+        repo.delete_uptime_samples_older_than.assert_called_once_with(90)
+        mock_session.commit.assert_called_once()
+        assert monitor._last_retention_sweep_date == "2026-05-13"
+
+    def test_retention_disabled_when_zero(self, monitor):
+        monitor.uptime_retention_days = 0
+        with patch("syfthub.repositories.endpoint.EndpointRepository") as RepoCls:
+            monitor._maybe_run_uptime_retention(
+                MagicMock(), datetime(2026, 5, 13, tzinfo=timezone.utc)
+            )
+        RepoCls.assert_not_called()
+
+    def test_retention_rolls_back_on_error(self, monitor):
+        mock_session = MagicMock()
+        now = datetime(2026, 5, 14, 1, 0, 0, tzinfo=timezone.utc)
+        with patch("syfthub.repositories.endpoint.EndpointRepository") as RepoCls:
+            repo = MagicMock()
+            repo.delete_uptime_samples_older_than.side_effect = RuntimeError("db")
+            RepoCls.return_value = repo
+            # Must not raise
+            monitor._maybe_run_uptime_retention(mock_session, now)
+        mock_session.rollback.assert_called_once()
+        # Date marker must NOT advance on failure so we'll retry next cycle
+        assert monitor._last_retention_sweep_date != "2026-05-14"

--- a/components/backend/tests/test_jobs/test_health_monitor.py
+++ b/components/backend/tests/test_jobs/test_health_monitor.py
@@ -235,6 +235,7 @@ class TestGetEndpointsForHealthCheck:
                 None,
                 None,
                 None,
+                None,
             ),
             (
                 2,
@@ -248,6 +249,7 @@ class TestGetEndpointsForHealthCheck:
                 "healthy",
                 datetime.now(timezone.utc),
                 300,
+                None,
             ),
         ]
         org_results = []
@@ -287,6 +289,7 @@ class TestGetEndpointsForHealthCheck:
                 None,
                 None,
                 None,
+                None,
             ),
         ]
 
@@ -319,6 +322,7 @@ class TestGetEndpointsForHealthCheck:
                 None,
                 None,
                 None,
+                None,
             ),
         ]
         org_results = [
@@ -330,6 +334,7 @@ class TestGetEndpointsForHealthCheck:
                 [{"type": "rest_api", "config": {"url": "/org"}}],
                 "https://org.com",
                 100,
+                None,
                 None,
                 None,
                 None,
@@ -365,6 +370,7 @@ class TestGetEndpointsForHealthCheck:
                 None,
                 None,
                 None,
+                None,
             ),
             # Empty connect config (falsy)
             (
@@ -379,6 +385,7 @@ class TestGetEndpointsForHealthCheck:
                 None,
                 None,
                 None,
+                None,
             ),
             # Has connect config
             (
@@ -389,6 +396,7 @@ class TestGetEndpointsForHealthCheck:
                 [{"type": "rest_api"}],
                 "https://user3.com",
                 30,
+                None,
                 None,
                 None,
                 None,
@@ -423,6 +431,7 @@ class TestGetEndpointsForHealthCheck:
                 None,
                 None,
                 None,
+                None,
             ),
             # Empty domain - included
             (
@@ -437,6 +446,7 @@ class TestGetEndpointsForHealthCheck:
                 None,
                 None,
                 None,
+                None,
             ),
             # Has domain - included
             (
@@ -447,6 +457,7 @@ class TestGetEndpointsForHealthCheck:
                 [{"type": "rest_api"}],
                 "https://valid.com",
                 30,
+                None,
                 None,
                 None,
                 None,
@@ -509,7 +520,7 @@ class TestCheckEndpointHealth:
             owner_type="user",
             heartbeat_expires_at=None,
         )
-        endpoint_id, is_healthy = monitor._check_endpoint_health(endpoint)
+        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(endpoint)
         assert endpoint_id == 1
         assert is_healthy is False
 
@@ -526,7 +537,7 @@ class TestCheckEndpointHealth:
             owner_type="user",
             heartbeat_expires_at=None,
         )
-        endpoint_id, is_healthy = monitor._check_endpoint_health(endpoint)
+        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(endpoint)
         assert endpoint_id == 2
         assert is_healthy is False
 
@@ -547,7 +558,7 @@ class TestCheckEndpointHealth:
             health_checked_at=now - timedelta(seconds=10),
             health_ttl_seconds=300,
         )
-        endpoint_id, is_healthy = monitor._check_endpoint_health(endpoint)
+        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(endpoint)
         assert endpoint_id == 1
         assert is_healthy is True
 
@@ -568,7 +579,7 @@ class TestCheckEndpointHealth:
             health_checked_at=now - timedelta(seconds=10),
             health_ttl_seconds=300,
         )
-        endpoint_id, is_healthy = monitor._check_endpoint_health(endpoint)
+        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(endpoint)
         assert endpoint_id == 1
         assert is_healthy is False
 
@@ -589,7 +600,7 @@ class TestCheckEndpointHealth:
             health_checked_at=now - timedelta(seconds=600),  # Stale (expired)
             health_ttl_seconds=300,
         )
-        endpoint_id, is_healthy = monitor._check_endpoint_health(endpoint)
+        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(endpoint)
         assert endpoint_id == 1
         assert is_healthy is True  # Heartbeat says healthy
 
@@ -598,7 +609,9 @@ class TestCheckEndpointHealth:
         sample_endpoint.heartbeat_expires_at = datetime.now(timezone.utc) + timedelta(
             seconds=60
         )
-        endpoint_id, is_healthy = monitor._check_endpoint_health(sample_endpoint)
+        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(
+            sample_endpoint
+        )
         assert endpoint_id == 1
         assert is_healthy is True
 
@@ -607,13 +620,17 @@ class TestCheckEndpointHealth:
         sample_endpoint.heartbeat_expires_at = datetime.now(timezone.utc) - timedelta(
             seconds=60
         )
-        endpoint_id, is_healthy = monitor._check_endpoint_health(sample_endpoint)
+        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(
+            sample_endpoint
+        )
         assert endpoint_id == 1
         assert is_healthy is False
 
     def test_no_signals_is_unhealthy(self, monitor, sample_endpoint):
         """Test no health signals (null heartbeat, null health fields) is unhealthy."""
-        endpoint_id, is_healthy = monitor._check_endpoint_health(sample_endpoint)
+        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(
+            sample_endpoint
+        )
         assert endpoint_id == 1
         assert is_healthy is False
 
@@ -634,7 +651,7 @@ class TestCheckEndpointHealth:
             health_checked_at=now - timedelta(seconds=10),
             health_ttl_seconds=300,
         )
-        endpoint_id, is_healthy = monitor._check_endpoint_health(endpoint)
+        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(endpoint)
         assert endpoint_id == 1
         assert is_healthy is False  # Per-endpoint health wins
 
@@ -655,7 +672,7 @@ class TestCheckEndpointHealth:
             health_checked_at=now,
             health_ttl_seconds=None,  # Missing TTL
         )
-        endpoint_id, is_healthy = monitor._check_endpoint_health(endpoint)
+        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(endpoint)
         assert endpoint_id == 1
         assert is_healthy is True  # Falls through to heartbeat
 
@@ -723,7 +740,7 @@ class TestCheckPerEndpointHealth:
             health_checked_at=now - timedelta(seconds=10),
             health_ttl_seconds=300,
         )
-        assert monitor._check_per_endpoint_health(endpoint, now) is True
+        assert monitor._check_per_endpoint_health(endpoint, now) == (True, None)
 
     def test_returns_false_when_unhealthy(self, monitor):
         """Test returns False when fresh and unhealthy."""
@@ -742,7 +759,7 @@ class TestCheckPerEndpointHealth:
             health_checked_at=now - timedelta(seconds=10),
             health_ttl_seconds=300,
         )
-        assert monitor._check_per_endpoint_health(endpoint, now) is False
+        assert monitor._check_per_endpoint_health(endpoint, now) == (False, None)
 
 
 class TestCheckHeartbeatHealth:
@@ -970,7 +987,9 @@ class TestRunHealthCheckCycle:
             patch.object(
                 monitor, "_get_endpoints_for_health_check", return_value=endpoints
             ),
-            patch.object(monitor, "_check_endpoint_health", return_value=(1, True)),
+            patch.object(
+                monitor, "_check_endpoint_health", return_value=(1, True, None)
+            ),
             patch.object(
                 monitor,
                 "_update_endpoint_health_status",
@@ -1007,7 +1026,9 @@ class TestRunHealthCheckCycle:
             patch.object(
                 monitor, "_get_endpoints_for_health_check", return_value=endpoints
             ),
-            patch.object(monitor, "_check_endpoint_health", return_value=(1, False)),
+            patch.object(
+                monitor, "_check_endpoint_health", return_value=(1, False, None)
+            ),
             patch.object(
                 monitor,
                 "_update_endpoint_health_status",

--- a/components/backend/tests/test_repositories/test_endpoint_uptime.py
+++ b/components/backend/tests/test_repositories/test_endpoint_uptime.py
@@ -1,0 +1,217 @@
+"""Tests for the endpoint uptime/telemetry repository methods.
+
+Exercises the SQLite fallback paths (no ``ON CONFLICT``) of
+``upsert_uptime_sample``, plus ``get_uptime_samples``,
+``delete_uptime_samples_older_than``, ``get_by_owner_and_slug_any_state``,
+and the latency-aware path of ``bulk_update_health_status``.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from syfthub.models.endpoint import EndpointModel
+from syfthub.models.user import UserModel
+from syfthub.repositories.endpoint import EndpointRepository
+
+
+@pytest.fixture
+def user(test_session, sample_user_data):
+    u = UserModel(**sample_user_data)
+    test_session.add(u)
+    test_session.commit()
+    return u
+
+
+@pytest.fixture
+def endpoint(test_session, user, sample_endpoint_data):
+    data = dict(sample_endpoint_data)
+    data["user_id"] = user.id
+    ep = EndpointModel(**data)
+    test_session.add(ep)
+    test_session.commit()
+    return ep
+
+
+class TestUpsertUptimeSample:
+    def test_insert_new_row(self, test_session, endpoint):
+        repo = EndpointRepository(test_session)
+        bucket = datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc)
+
+        repo.upsert_uptime_sample(
+            endpoint_id=endpoint.id,
+            bucket_start=bucket,
+            is_healthy=True,
+            latency_ms=42,
+        )
+        test_session.commit()
+
+        samples = repo.get_uptime_samples(endpoint_id=endpoint.id, window_hours=24 * 30)
+        assert len(samples) == 1
+        s = samples[0]
+        assert s.total_checks == 1
+        assert s.healthy_checks == 1
+        assert s.latency_count == 1
+        assert s.latency_sum_ms == 42
+        assert s.latency_min_ms == 42
+        assert s.latency_max_ms == 42
+
+    def test_accumulates_into_existing_bucket(self, test_session, endpoint):
+        repo = EndpointRepository(test_session)
+        bucket = datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc)
+
+        repo.upsert_uptime_sample(endpoint.id, bucket, True, 30)
+        repo.upsert_uptime_sample(endpoint.id, bucket, True, 50)
+        repo.upsert_uptime_sample(endpoint.id, bucket, False, None)
+        test_session.commit()
+
+        samples = repo.get_uptime_samples(endpoint.id, 24 * 30)
+        assert len(samples) == 1
+        s = samples[0]
+        assert s.total_checks == 3
+        assert s.healthy_checks == 2
+        assert s.latency_count == 2
+        assert s.latency_sum_ms == 80
+        assert s.latency_min_ms == 30
+        assert s.latency_max_ms == 50
+
+    def test_unhealthy_without_latency_does_not_touch_latency_fields(
+        self, test_session, endpoint
+    ):
+        repo = EndpointRepository(test_session)
+        bucket = datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc)
+
+        repo.upsert_uptime_sample(endpoint.id, bucket, False, None)
+        test_session.commit()
+
+        s = repo.get_uptime_samples(endpoint.id, 24 * 30)[0]
+        assert s.total_checks == 1
+        assert s.healthy_checks == 0
+        assert s.latency_count == 0
+        assert s.latency_min_ms is None
+        assert s.latency_max_ms is None
+
+
+class TestUptimeRetention:
+    def test_purges_old_samples_only(self, test_session, endpoint):
+        repo = EndpointRepository(test_session)
+        now = datetime.now(timezone.utc)
+        old = now - timedelta(days=100)
+        fresh = now - timedelta(days=1)
+
+        repo.upsert_uptime_sample(endpoint.id, old, True, 10)
+        repo.upsert_uptime_sample(endpoint.id, fresh, True, 20)
+        test_session.commit()
+
+        removed = repo.delete_uptime_samples_older_than(retention_days=30)
+        test_session.commit()
+        assert removed == 1
+
+        remaining = repo.get_uptime_samples(endpoint.id, window_hours=24 * 365)
+        assert len(remaining) == 1
+        assert remaining[0].latency_sum_ms == 20
+
+    def test_zero_retention_is_noop_when_no_old_rows(self, test_session, endpoint):
+        repo = EndpointRepository(test_session)
+        bucket = datetime.now(timezone.utc) - timedelta(hours=1)
+        repo.upsert_uptime_sample(endpoint.id, bucket, True, 50)
+        test_session.commit()
+        # Asking to delete rows older than 30 days when nothing is that old
+        assert repo.delete_uptime_samples_older_than(retention_days=30) == 0
+
+
+class TestGetByOwnerAndSlugAnyState:
+    def test_finds_user_owned(self, test_session, endpoint, user):
+        repo = EndpointRepository(test_session)
+        found = repo.get_by_owner_and_slug_any_state(
+            user_id=user.id,
+            organization_id=None,
+            slug=endpoint.slug,
+        )
+        assert found is not None
+        assert found.id == endpoint.id
+
+    def test_returns_inactive_endpoints(self, test_session, endpoint, user):
+        # The unique pattern: the regular lookup filters is_active=True; this
+        # method must NOT.
+        endpoint.is_active = False
+        test_session.commit()
+
+        repo = EndpointRepository(test_session)
+        found = repo.get_by_owner_and_slug_any_state(
+            user_id=user.id,
+            organization_id=None,
+            slug=endpoint.slug,
+        )
+        assert found is not None
+        assert found.id == endpoint.id
+
+    def test_rejects_both_owners_set(self, test_session):
+        repo = EndpointRepository(test_session)
+        assert (
+            repo.get_by_owner_and_slug_any_state(user_id=1, organization_id=2, slug="x")
+            is None
+        )
+
+    def test_rejects_neither_owner_set(self, test_session):
+        repo = EndpointRepository(test_session)
+        assert (
+            repo.get_by_owner_and_slug_any_state(
+                user_id=None, organization_id=None, slug="x"
+            )
+            is None
+        )
+
+    def test_not_found(self, test_session, user):
+        repo = EndpointRepository(test_session)
+        assert (
+            repo.get_by_owner_and_slug_any_state(
+                user_id=user.id, organization_id=None, slug="nope"
+            )
+            is None
+        )
+
+
+class TestBulkUpdateHealthLatency:
+    def test_writes_latency_when_provided(self, test_session, endpoint):
+        repo = EndpointRepository(test_session)
+        now = datetime.now(timezone.utc)
+        repo.bulk_update_health_status(
+            [
+                {
+                    "endpoint_id": endpoint.id,
+                    "health_status": "healthy",
+                    "health_checked_at": now,
+                    "health_ttl_seconds": 300,
+                    "last_latency_ms": 73,
+                }
+            ]
+        )
+        test_session.commit()
+
+        refreshed = test_session.get(EndpointModel, endpoint.id)
+        assert refreshed.last_latency_ms == 73
+        assert refreshed.health_status == "healthy"
+
+    def test_skips_latency_when_none(self, test_session, endpoint):
+        endpoint.last_latency_ms = 99
+        test_session.commit()
+
+        repo = EndpointRepository(test_session)
+        repo.bulk_update_health_status(
+            [
+                {
+                    "endpoint_id": endpoint.id,
+                    "health_status": "unhealthy",
+                    "health_checked_at": datetime.now(timezone.utc),
+                    "health_ttl_seconds": 300,
+                    "last_latency_ms": None,
+                }
+            ]
+        )
+        test_session.commit()
+
+        refreshed = test_session.get(EndpointModel, endpoint.id)
+        # Untouched — None means "no fresh signal", not "clear the field"
+        assert refreshed.last_latency_ms == 99
+        assert refreshed.health_status == "unhealthy"

--- a/components/backend/tests/test_services/test_endpoint_service.py
+++ b/components/backend/tests/test_services/test_endpoint_service.py
@@ -1603,3 +1603,260 @@ class TestReportEndpointHealth:
             assert exc_info.value.status_code == 500
 
         endpoint_service.session.rollback.assert_called_once()
+
+
+class TestGetEndpointUptime:
+    """Tests for EndpointService.get_endpoint_uptime method."""
+
+    @pytest.fixture
+    def endpoint_service(self):
+        session = MagicMock()
+        return EndpointService(session)
+
+    @pytest.fixture
+    def sample_user(self):
+        return User(
+            id=1,
+            username="testuser",
+            email="test@example.com",
+            full_name="Test User",
+            role="user",
+            is_active=True,
+            created_at=datetime.fromisoformat("2023-01-01T00:00:00"),
+            updated_at=datetime.fromisoformat("2023-01-01T00:00:00"),
+            key_created_at=datetime.fromisoformat("2023-01-01T00:00:00"),
+            age=25,
+            public_key="public_key",
+            password_hash="hashed_pass",
+        )
+
+    def _endpoint(self, **overrides):
+        ep = MagicMock()
+        ep.id = overrides.get("id", 42)
+        ep.slug = overrides.get("slug", "ep")
+        ep.user_id = overrides.get("user_id", 1)
+        ep.organization_id = overrides.get("organization_id")
+        ep.visibility = overrides.get("visibility", EndpointVisibility.PUBLIC)
+        return ep
+
+    def _sample(self, **kwargs):
+        s = MagicMock()
+        s.bucket_start = kwargs["bucket_start"]
+        s.total_checks = kwargs.get("total_checks", 0)
+        s.healthy_checks = kwargs.get("healthy_checks", 0)
+        s.latency_count = kwargs.get("latency_count", 0)
+        s.latency_sum_ms = kwargs.get("latency_sum_ms", 0)
+        s.latency_min_ms = kwargs.get("latency_min_ms")
+        s.latency_max_ms = kwargs.get("latency_max_ms")
+        return s
+
+    def test_uptime_user_owned_happy_path(self, endpoint_service, sample_user):
+        owner = MagicMock(id=1, username="testuser")
+        endpoint = self._endpoint(
+            id=42, slug="my-ep", user_id=1, visibility=EndpointVisibility.PUBLIC
+        )
+        bucket = datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc)
+        samples = [
+            self._sample(
+                bucket_start=bucket,
+                total_checks=60,
+                healthy_checks=60,
+                latency_count=60,
+                latency_sum_ms=60 * 42,
+                latency_min_ms=30,
+                latency_max_ms=80,
+            )
+        ]
+
+        with (
+            patch.object(
+                endpoint_service.user_repository, "get_by_username", return_value=owner
+            ),
+            patch.object(
+                endpoint_service.endpoint_repository,
+                "get_by_owner_and_slug_any_state",
+                return_value=endpoint,
+            ),
+            patch.object(
+                endpoint_service.endpoint_repository,
+                "get_uptime_samples",
+                return_value=samples,
+            ),
+        ):
+            result = endpoint_service.get_endpoint_uptime(
+                owner_username="testuser",
+                slug="my-ep",
+                window_hours=24,
+                current_user=sample_user,
+            )
+
+        assert result.endpoint_id == 42
+        assert result.owner_username == "testuser"
+        assert result.window_hours == 24
+        assert result.bucket_seconds > 0
+        assert len(result.buckets) == 1
+        b = result.buckets[0]
+        assert b.bucket_start == bucket
+        assert b.samples == 60
+        assert b.healthy_samples == 60
+        assert b.uptime_pct == 100.0
+        assert b.avg_latency_ms == 42.0
+        assert b.min_latency_ms == 30
+        assert b.max_latency_ms == 80
+
+    def test_uptime_falls_back_to_org_lookup(self, endpoint_service, sample_user):
+        org = MagicMock(id=99, slug="acme")
+        endpoint = self._endpoint(
+            id=7,
+            slug="bar",
+            user_id=None,
+            organization_id=99,
+            visibility=EndpointVisibility.PUBLIC,
+        )
+
+        with (
+            patch.object(
+                endpoint_service.user_repository, "get_by_username", return_value=None
+            ),
+            patch.object(
+                endpoint_service.org_repository, "get_by_slug", return_value=org
+            ),
+            patch.object(
+                endpoint_service.endpoint_repository,
+                "get_by_owner_and_slug_any_state",
+                return_value=endpoint,
+            ),
+            patch.object(
+                endpoint_service.endpoint_repository,
+                "get_uptime_samples",
+                return_value=[],
+            ),
+        ):
+            result = endpoint_service.get_endpoint_uptime(
+                owner_username="acme",
+                slug="bar",
+                window_hours=12,
+                current_user=sample_user,
+            )
+
+        assert result.endpoint_id == 7
+        assert result.buckets == []
+
+    def test_uptime_not_found_returns_404(self, endpoint_service, sample_user):
+        with (
+            patch.object(
+                endpoint_service.user_repository, "get_by_username", return_value=None
+            ),
+            patch.object(
+                endpoint_service.org_repository, "get_by_slug", return_value=None
+            ),
+            pytest.raises(HTTPException) as exc,
+        ):
+            endpoint_service.get_endpoint_uptime(
+                owner_username="ghost",
+                slug="missing",
+                window_hours=24,
+                current_user=sample_user,
+            )
+        assert exc.value.status_code == 404
+
+    def test_uptime_private_endpoint_hidden_from_outsider(
+        self, endpoint_service, sample_user
+    ):
+        owner = MagicMock(id=2, username="owner2")
+        # Endpoint owned by user 2 with private visibility — sample_user.id is 1
+        endpoint = self._endpoint(
+            id=11, slug="hush", user_id=2, visibility=EndpointVisibility.PRIVATE
+        )
+        with (
+            patch.object(
+                endpoint_service.user_repository, "get_by_username", return_value=owner
+            ),
+            patch.object(
+                endpoint_service.endpoint_repository,
+                "get_by_owner_and_slug_any_state",
+                return_value=endpoint,
+            ),
+            pytest.raises(HTTPException) as exc,
+        ):
+            endpoint_service.get_endpoint_uptime(
+                owner_username="owner2",
+                slug="hush",
+                window_hours=24,
+                current_user=sample_user,
+            )
+        # Hidden via 404, not 403, to avoid leaking existence
+        assert exc.value.status_code == 404
+
+    def test_uptime_zero_samples_returns_empty(self, endpoint_service, sample_user):
+        owner = MagicMock(id=1, username="testuser")
+        endpoint = self._endpoint(
+            id=42, slug="empty", user_id=1, visibility=EndpointVisibility.PUBLIC
+        )
+        with (
+            patch.object(
+                endpoint_service.user_repository, "get_by_username", return_value=owner
+            ),
+            patch.object(
+                endpoint_service.endpoint_repository,
+                "get_by_owner_and_slug_any_state",
+                return_value=endpoint,
+            ),
+            patch.object(
+                endpoint_service.endpoint_repository,
+                "get_uptime_samples",
+                return_value=[],
+            ),
+        ):
+            result = endpoint_service.get_endpoint_uptime(
+                owner_username="testuser",
+                slug="empty",
+                window_hours=24,
+                current_user=None,
+            )
+        assert result.buckets == []
+
+    def test_uptime_partial_health_and_no_latency(self, endpoint_service, sample_user):
+        owner = MagicMock(id=1, username="testuser")
+        endpoint = self._endpoint(
+            id=42, slug="mixed", user_id=1, visibility=EndpointVisibility.PUBLIC
+        )
+        bucket = datetime(2026, 5, 13, 12, 30, tzinfo=timezone.utc)
+        # 40 of 60 checks healthy, no latency data
+        samples = [
+            self._sample(
+                bucket_start=bucket,
+                total_checks=60,
+                healthy_checks=40,
+                latency_count=0,
+                latency_sum_ms=0,
+                latency_min_ms=None,
+                latency_max_ms=None,
+            )
+        ]
+        with (
+            patch.object(
+                endpoint_service.user_repository, "get_by_username", return_value=owner
+            ),
+            patch.object(
+                endpoint_service.endpoint_repository,
+                "get_by_owner_and_slug_any_state",
+                return_value=endpoint,
+            ),
+            patch.object(
+                endpoint_service.endpoint_repository,
+                "get_uptime_samples",
+                return_value=samples,
+            ),
+        ):
+            result = endpoint_service.get_endpoint_uptime(
+                owner_username="testuser",
+                slug="mixed",
+                window_hours=24,
+                current_user=sample_user,
+            )
+        b = result.buckets[0]
+        assert b.uptime_pct == round(100.0 * 40 / 60, 2)
+        assert b.avg_latency_ms is None
+        assert b.min_latency_ms is None
+        assert b.max_latency_ms is None


### PR DESCRIPTION
## Summary
- New `endpoint_uptime_samples` table aggregates the health monitor's per-cycle decisions into time buckets (default 30 min, mirrors `heartbeat_max_ttl_seconds`) so each endpoint has a renderable uptime + latency series.
- `EndpointHealthItem.latency_ms` (optional) — SDK clients now report round-trip latency alongside health status; the monitor only records it when the Tier 1 signal is fresh, so stale latency cannot leak forward.
- `GET /api/v1/endpoints/{owner}/{slug}/uptime?window_hours=…` returns the bucketed series (`uptime_pct`, `avg/min/max_latency_ms`, sample counts). Respects existing visibility rules and works for endpoints currently marked inactive so a down endpoint still shows a chart.
- Daily retention sweep (default 90 days) piggybacks on the monitor's existing PostgreSQL advisory lock — no new background job.

## Design notes
- Aggregation happens at the monitor cycle (30s tick) rather than at the request path, so an endpoint that stops reporting still gets sampled (as unhealthy) and the chart reflects it.
- Bucket key `floor(epoch / uptime_bucket_seconds) * uptime_bucket_seconds` keeps buckets bounded (~48 rows/endpoint/day at the default).
- `UPSERT … ON CONFLICT DO UPDATE` on Postgres, SELECT+UPDATE fallback for the SQLite dev path.

## Test plan
- [x] `uv run pytest tests/` — 1316 tests pass.
- [x] `uv run ruff check && uv run ruff format --check` — clean.
- [x] `uv run mypy` — passes via pre-commit.
- [x] `uv run alembic upgrade head` on a fresh DB applies cleanly; new table + indexes present.
- [ ] Manual SDK smoke: report health with `latency_ms`, wait one monitor cycle, hit `GET /endpoints/{owner}/{slug}/uptime` and confirm a bucket appears with the expected `uptime_pct` and `avg_latency_ms`.
- [ ] Validate Postgres `INSERT … ON CONFLICT` path on a staging instance (the SQLite fallback is exercised by tests; the Postgres path is structurally identical but worth a quick eyeball under load).