### PR TITLE
chore(uptime): drop latency from telemetry, keep uptime aggregates only

### DIFF
--- a/components/backend/alembic/versions/20260513_120000_drop_endpoint_uptime_latency_fields.py
+++ b/components/backend/alembic/versions/20260513_120000_drop_endpoint_uptime_latency_fields.py
@@ -1,0 +1,74 @@
+"""Drop latency fields from the endpoint uptime telemetry.
+
+The 30s health-monitor cycle records uptime via the existing 2-tier health
+check. Latency, in contrast, can only be supplied by SDK clients via the
+new ``POST /endpoints/health`` route, and the in-the-wild SDKs all still
+report through the deprecated owner-level heartbeat endpoints.
+
+In practice this means every uptime sample on prod was being recorded from
+the Tier 2 (heartbeat) path with no latency signal, leaving the
+``latency_*`` columns NULL/zero forever. Drop them rather than carry dead
+schema and dead code paths around indefinitely.
+
+Removes:
+- ``endpoints.last_latency_ms``
+- ``endpoint_uptime_samples.latency_count``
+- ``endpoint_uptime_samples.latency_sum_ms``
+- ``endpoint_uptime_samples.latency_min_ms``
+- ``endpoint_uptime_samples.latency_max_ms``
+
+Revision ID: 014_drop_uptime_latency
+Revises: 013_endpoint_uptime
+Create Date: 2026-05-13 12:00:00.000000+00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "014_drop_uptime_latency"
+down_revision: str | None = "013_endpoint_uptime"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_column("endpoint_uptime_samples", "latency_max_ms")
+    op.drop_column("endpoint_uptime_samples", "latency_min_ms")
+    op.drop_column("endpoint_uptime_samples", "latency_sum_ms")
+    op.drop_column("endpoint_uptime_samples", "latency_count")
+    op.drop_column("endpoints", "last_latency_ms")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "endpoints",
+        sa.Column("last_latency_ms", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "endpoint_uptime_samples",
+        sa.Column(
+            "latency_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+    op.add_column(
+        "endpoint_uptime_samples",
+        sa.Column(
+            "latency_sum_ms",
+            sa.BigInteger(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+    op.add_column(
+        "endpoint_uptime_samples",
+        sa.Column("latency_min_ms", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "endpoint_uptime_samples",
+        sa.Column("latency_max_ms", sa.Integer(), nullable=True),
+    )

--- a/components/backend/src/syfthub/jobs/health_monitor.py
+++ b/components/backend/src/syfthub/jobs/health_monitor.py
@@ -80,7 +80,6 @@ class EndpointHealthInfo:
     health_status: Optional[str] = None
     health_checked_at: Optional[datetime] = None
     health_ttl_seconds: Optional[int] = None
-    last_latency_ms: Optional[int] = None
 
 
 class EndpointHealthMonitor:
@@ -188,7 +187,6 @@ class EndpointHealthMonitor:
             EndpointModel.health_status,
             EndpointModel.health_checked_at,
             EndpointModel.health_ttl_seconds,
-            EndpointModel.last_latency_ms,
         ).join(UserModel, EndpointModel.user_id == UserModel.id)
 
         # Query endpoints with organization domain (org-owned endpoints)
@@ -204,7 +202,6 @@ class EndpointHealthMonitor:
             EndpointModel.health_status,
             EndpointModel.health_checked_at,
             EndpointModel.health_ttl_seconds,
-            EndpointModel.last_latency_ms,
         ).join(OrganizationModel, EndpointModel.organization_id == OrganizationModel.id)
 
         endpoints: list[EndpointHealthInfo] = []
@@ -224,7 +221,6 @@ class EndpointHealthMonitor:
                 health_status,
                 health_checked_at,
                 health_ttl_seconds,
-                last_latency_ms,
             ) = row
             # Include endpoints with connections (even if domain is None)
             # Endpoints without domain will be marked unhealthy in health check
@@ -243,7 +239,6 @@ class EndpointHealthMonitor:
                         health_status=health_status,
                         health_checked_at=health_checked_at,
                         health_ttl_seconds=health_ttl_seconds,
-                        last_latency_ms=last_latency_ms,
                     )
                 )
 
@@ -262,7 +257,6 @@ class EndpointHealthMonitor:
                 health_status,
                 health_checked_at,
                 health_ttl_seconds,
-                last_latency_ms,
             ) = row
             # Include endpoints with connections (even if domain is None)
             # Endpoints without domain will be marked unhealthy in health check
@@ -281,7 +275,6 @@ class EndpointHealthMonitor:
                         health_status=health_status,
                         health_checked_at=health_checked_at,
                         health_ttl_seconds=health_ttl_seconds,
-                        last_latency_ms=last_latency_ms,
                     )
                 )
 
@@ -291,15 +284,12 @@ class EndpointHealthMonitor:
         self,
         endpoint: EndpointHealthInfo,
         now: datetime,
-    ) -> tuple[bool, Optional[int]] | None:
+    ) -> bool | None:
         """Check per-endpoint health reported via POST /endpoints/health.
 
-        Returns a tuple ``(is_healthy, latency_ms)`` if a fresh per-endpoint
-        health signal exists. Latency is included only when the same Tier 1
-        signal is fresh (so it cannot leak forward from a stale report).
-
-        Returns ``None`` when no fresh signal is available — callers should
-        fall through to the next health check tier.
+        Returns True/False if a fresh per-endpoint health signal exists,
+        or None if no fresh signal is available (caller should fall through
+        to the next health check tier).
         """
         if (
             endpoint.health_checked_at is not None
@@ -313,10 +303,9 @@ class EndpointHealthMonitor:
                 logger.debug(
                     f"Endpoint {endpoint.id}: fresh per-endpoint health "
                     f"(status={endpoint.health_status}, "
-                    f"expires={health_expires_at}, "
-                    f"latency_ms={endpoint.last_latency_ms})"
+                    f"expires={health_expires_at})"
                 )
-                return (is_healthy, endpoint.last_latency_ms)
+                return is_healthy
         return None
 
     def _check_heartbeat_health(
@@ -345,17 +334,15 @@ class EndpointHealthMonitor:
     def _check_endpoint_health(
         self,
         endpoint: EndpointHealthInfo,
-    ) -> tuple[int, bool, Optional[int]]:
+    ) -> tuple[int, bool]:
         """Determine if an endpoint is healthy using a 2-tier approach.
 
         Priority:
         1. Per-endpoint health (client-reported via POST /endpoints/health):
            If health_checked_at + health_ttl_seconds > now, trust health_status
-           and return the accompanying ``last_latency_ms`` (may be ``None``).
         2. Domain-level heartbeat (deprecated fallback):
-           If heartbeat_expires_at > now, assume healthy. No latency available
-           because heartbeat is owner-level, not endpoint-level.
-        3. Neither is fresh: Mark unhealthy, no latency.
+           If heartbeat_expires_at > now, assume healthy
+        3. Neither is fresh: Mark unhealthy
 
         When the deprecated heartbeat system is removed, delete tier 2
         (the ``_check_heartbeat_health`` call) so this becomes a single-tier check.
@@ -364,7 +351,7 @@ class EndpointHealthMonitor:
             endpoint: The endpoint information to evaluate
 
         Returns:
-            Tuple of (endpoint_id, is_healthy, latency_ms_or_None)
+            Tuple of (endpoint_id, is_healthy)
         """
         now = datetime.now(timezone.utc)
 
@@ -373,22 +360,21 @@ class EndpointHealthMonitor:
             logger.debug(
                 f"Endpoint {endpoint.id}: no owner domain configured (unhealthy)"
             )
-            return (endpoint.id, False, None)
+            return (endpoint.id, False)
 
         # Tier 1: Per-endpoint health (client-reported)
         tier1 = self._check_per_endpoint_health(endpoint, now)
         if tier1 is not None:
-            is_healthy, latency_ms = tier1
-            return (endpoint.id, is_healthy, latency_ms)
+            return (endpoint.id, tier1)
 
         # Tier 2: Domain-level heartbeat (deprecated fallback — remove with heartbeat)
         tier2 = self._check_heartbeat_health(endpoint, now)
         if tier2 is not None:
-            return (endpoint.id, tier2, None)
+            return (endpoint.id, tier2)
 
         # Neither signal is fresh — mark unhealthy
         logger.debug(f"Endpoint {endpoint.id}: no fresh health signal (unhealthy)")
-        return (endpoint.id, False, None)
+        return (endpoint.id, False)
 
     def _update_endpoint_health_status(
         self, session: Session, endpoint_id: int, is_healthy: bool
@@ -464,7 +450,6 @@ class EndpointHealthMonitor:
         session: Session,
         endpoint_id: int,
         is_healthy: bool,
-        latency_ms: Optional[int],
         now: datetime,
     ) -> None:
         """Persist one uptime sample for this cycle, swallowing errors.
@@ -481,7 +466,6 @@ class EndpointHealthMonitor:
                 endpoint_id=endpoint_id,
                 bucket_start=self._current_bucket_start(now),
                 is_healthy=is_healthy,
-                latency_ms=latency_ms,
             )
         except Exception as e:  # pragma: no cover - defensive
             logger.warning(
@@ -555,9 +539,7 @@ class EndpointHealthMonitor:
             now = datetime.now(timezone.utc)
             state_changes = 0
             for endpoint in endpoints:
-                endpoint_id, is_healthy, latency_ms = self._check_endpoint_health(
-                    endpoint
-                )
+                endpoint_id, is_healthy = self._check_endpoint_health(endpoint)
 
                 # Get the old status for comparison
                 old_is_active = old_status_map.get(endpoint_id, True)
@@ -574,9 +556,7 @@ class EndpointHealthMonitor:
                 # Record one uptime sample per cycle. Use a fresh session
                 # transaction (the failure-counter update above already
                 # committed) so an error here cannot poison the next loop.
-                self._emit_uptime_sample(
-                    session, endpoint_id, is_healthy, latency_ms, now
-                )
+                self._emit_uptime_sample(session, endpoint_id, is_healthy, now)
                 try:
                     session.commit()
                 except Exception as e:  # pragma: no cover - defensive

--- a/components/backend/src/syfthub/models/endpoint.py
+++ b/components/backend/src/syfthub/models/endpoint.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, List, Optional
 
 from sqlalchemy import (
     JSON,
-    BigInteger,
     Boolean,
     CheckConstraint,
     DateTime,
@@ -77,14 +76,6 @@ class EndpointModel(BaseModel, TimestampMixin):
         DateTime(timezone=True), nullable=True, default=None
     )
     health_ttl_seconds: Mapped[Optional[int]] = mapped_column(
-        Integer, nullable=True, default=None
-    )
-
-    # Last endpoint round-trip latency in milliseconds, reported by client
-    # alongside health status via POST /endpoints/health. Trusted only while
-    # the per-endpoint health signal (health_checked_at + health_ttl_seconds)
-    # is still fresh; otherwise treated as stale and ignored by the monitor.
-    last_latency_ms: Mapped[Optional[int]] = mapped_column(
         Integer, nullable=True, default=None
     )
 
@@ -206,10 +197,6 @@ class EndpointUptimeSampleModel(Base):
     )
     total_checks: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     healthy_checks: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    latency_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    latency_sum_ms: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
-    latency_min_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
-    latency_max_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
 
     __table_args__ = (
         PrimaryKeyConstraint("endpoint_id", "bucket_start"),

--- a/components/backend/src/syfthub/repositories/endpoint.py
+++ b/components/backend/src/syfthub/repositories/endpoint.py
@@ -1247,7 +1247,6 @@ class EndpointRepository(BaseRepository[EndpointModel]):
             - health_status: str ("healthy" or "unhealthy")
             - health_checked_at: datetime
             - health_ttl_seconds: int
-            - last_latency_ms: Optional[int] (when missing, latency is not updated)
 
         Does NOT commit — caller manages the transaction.
 
@@ -1260,18 +1259,14 @@ class EndpointRepository(BaseRepository[EndpointModel]):
         updated_count = 0
         for item in updates:
             try:
-                values: dict[str, Any] = {
-                    "health_status": item["health_status"],
-                    "health_checked_at": item["health_checked_at"],
-                    "health_ttl_seconds": item["health_ttl_seconds"],
-                }
-                if "last_latency_ms" in item and item["last_latency_ms"] is not None:
-                    values["last_latency_ms"] = item["last_latency_ms"]
-
                 stmt = (
                     update(EndpointModel)
                     .where(EndpointModel.id == item["endpoint_id"])
-                    .values(**values)
+                    .values(
+                        health_status=item["health_status"],
+                        health_checked_at=item["health_checked_at"],
+                        health_ttl_seconds=item["health_ttl_seconds"],
+                    )
                 )
                 result = self.session.execute(stmt)
                 if result.rowcount > 0:
@@ -1319,7 +1314,6 @@ class EndpointRepository(BaseRepository[EndpointModel]):
         endpoint_id: int,
         bucket_start: datetime,
         is_healthy: bool,
-        latency_ms: Optional[int],
     ) -> None:
         """Upsert one health-monitor tick into the bucketed uptime table.
 
@@ -1332,14 +1326,8 @@ class EndpointRepository(BaseRepository[EndpointModel]):
             bucket_start: Truncated UTC bucket boundary
                 (``floor(epoch / bucket_seconds) * bucket_seconds``).
             is_healthy: Result of the monitor's tier evaluation.
-            latency_ms: Latency to record, or ``None`` if no fresh latency
-                signal is available (e.g. tier 2/3 decision).
         """
         healthy = 1 if is_healthy else 0
-        has_latency = latency_ms is not None
-        lat_count = 1 if has_latency else 0
-        lat_sum = latency_ms if has_latency else 0
-
         dialect = self.session.bind.dialect.name if self.session.bind else ""
 
         try:
@@ -1349,54 +1337,16 @@ class EndpointRepository(BaseRepository[EndpointModel]):
                         """
                         INSERT INTO endpoint_uptime_samples (
                             endpoint_id, bucket_start,
-                            total_checks, healthy_checks,
-                            latency_count, latency_sum_ms,
-                            latency_min_ms, latency_max_ms
+                            total_checks, healthy_checks
                         )
-                        VALUES (
-                            :eid, :bucket,
-                            1, :h,
-                            :lc, :ls,
-                            :lat, :lat
-                        )
+                        VALUES (:eid, :bucket, 1, :h)
                         ON CONFLICT (endpoint_id, bucket_start) DO UPDATE SET
                             total_checks   = endpoint_uptime_samples.total_checks + 1,
                             healthy_checks = endpoint_uptime_samples.healthy_checks
-                                             + EXCLUDED.healthy_checks,
-                            latency_count  = endpoint_uptime_samples.latency_count
-                                             + EXCLUDED.latency_count,
-                            latency_sum_ms = endpoint_uptime_samples.latency_sum_ms
-                                             + EXCLUDED.latency_sum_ms,
-                            latency_min_ms = CASE
-                                WHEN EXCLUDED.latency_min_ms IS NULL
-                                    THEN endpoint_uptime_samples.latency_min_ms
-                                WHEN endpoint_uptime_samples.latency_min_ms IS NULL
-                                    THEN EXCLUDED.latency_min_ms
-                                ELSE LEAST(
-                                    endpoint_uptime_samples.latency_min_ms,
-                                    EXCLUDED.latency_min_ms
-                                )
-                            END,
-                            latency_max_ms = CASE
-                                WHEN EXCLUDED.latency_max_ms IS NULL
-                                    THEN endpoint_uptime_samples.latency_max_ms
-                                WHEN endpoint_uptime_samples.latency_max_ms IS NULL
-                                    THEN EXCLUDED.latency_max_ms
-                                ELSE GREATEST(
-                                    endpoint_uptime_samples.latency_max_ms,
-                                    EXCLUDED.latency_max_ms
-                                )
-                            END
+                                             + EXCLUDED.healthy_checks
                         """
                     ),
-                    {
-                        "eid": endpoint_id,
-                        "bucket": bucket_start,
-                        "h": healthy,
-                        "lc": lat_count,
-                        "ls": lat_sum,
-                        "lat": latency_ms,
-                    },
+                    {"eid": endpoint_id, "bucket": bucket_start, "h": healthy},
                 )
                 return
 
@@ -1416,10 +1366,6 @@ class EndpointRepository(BaseRepository[EndpointModel]):
                     bucket_start=bucket_start,
                     total_checks=1,
                     healthy_checks=healthy,
-                    latency_count=lat_count,
-                    latency_sum_ms=lat_sum,
-                    latency_min_ms=latency_ms,
-                    latency_max_ms=latency_ms,
                 )
                 self.session.add(sample)
                 # Flush so successive calls within the same transaction see
@@ -1430,19 +1376,6 @@ class EndpointRepository(BaseRepository[EndpointModel]):
 
             existing.total_checks += 1
             existing.healthy_checks += healthy
-            if has_latency:
-                existing.latency_count += 1
-                existing.latency_sum_ms += int(latency_ms or 0)
-                existing.latency_min_ms = (
-                    latency_ms
-                    if existing.latency_min_ms is None
-                    else min(existing.latency_min_ms, int(latency_ms or 0))
-                )
-                existing.latency_max_ms = (
-                    latency_ms
-                    if existing.latency_max_ms is None
-                    else max(existing.latency_max_ms, int(latency_ms or 0))
-                )
         except SQLAlchemyError as e:
             logger.error(
                 f"Failed to upsert uptime sample for endpoint {endpoint_id} "

--- a/components/backend/src/syfthub/schemas/endpoint.py
+++ b/components/backend/src/syfthub/schemas/endpoint.py
@@ -446,11 +446,6 @@ class Endpoint(BaseModel):
     health_ttl_seconds: Optional[int] = Field(
         None, description="TTL for the health status report in seconds"
     )
-    last_latency_ms: Optional[int] = Field(
-        None,
-        description="Last reported endpoint round-trip latency in milliseconds",
-    )
-
     model_config = {"from_attributes": True}
 
 
@@ -501,11 +496,6 @@ class EndpointResponse(BaseModel):
     health_ttl_seconds: Optional[int] = Field(
         None, description="TTL for the health status report in seconds"
     )
-    last_latency_ms: Optional[int] = Field(
-        None,
-        description="Last reported endpoint round-trip latency in milliseconds",
-    )
-
     model_config = {"from_attributes": True}
 
 
@@ -544,10 +534,6 @@ class EndpointPublicResponse(BaseModel):
     )
     health_checked_at: Optional[datetime] = Field(
         None, description="When the client last checked this endpoint's health"
-    )
-    last_latency_ms: Optional[int] = Field(
-        None,
-        description="Last reported endpoint round-trip latency in milliseconds",
     )
     archived: bool = Field(
         default=False, description="Whether the endpoint is archived"
@@ -724,15 +710,6 @@ class EndpointHealthItem(BaseModel):
     checked_at: datetime = Field(
         ..., description="When the client checked this endpoint's health"
     )
-    latency_ms: Optional[int] = Field(
-        None,
-        ge=0,
-        le=300_000,
-        description=(
-            "Optional round-trip latency for the client's upstream probe, "
-            "in milliseconds. Used to populate the endpoint uptime chart."
-        ),
-    )
 
 
 class EndpointHealthRequest(BaseModel):
@@ -816,7 +793,7 @@ class EndpointHealthResponse(BaseModel):
 
 
 class UptimeBucket(BaseModel):
-    """One bucketed uptime + latency data point for an endpoint."""
+    """One bucketed uptime data point for an endpoint."""
 
     bucket_start: datetime = Field(..., description="UTC start of the bucket interval")
     samples: int = Field(
@@ -831,23 +808,10 @@ class UptimeBucket(BaseModel):
         le=100.0,
         description="Percentage of cycles in which the endpoint was healthy",
     )
-    avg_latency_ms: Optional[float] = Field(
-        None,
-        description=(
-            "Mean round-trip latency reported in this bucket. "
-            "Null when no fresh latency signals were recorded."
-        ),
-    )
-    min_latency_ms: Optional[int] = Field(
-        None, description="Minimum reported latency in the bucket (milliseconds)"
-    )
-    max_latency_ms: Optional[int] = Field(
-        None, description="Maximum reported latency in the bucket (milliseconds)"
-    )
 
 
 class EndpointUptimeResponse(BaseModel):
-    """Bucketed uptime + latency series for a single endpoint."""
+    """Bucketed uptime series for a single endpoint."""
 
     endpoint_id: int = Field(..., description="Endpoint ID the series belongs to")
     owner_username: str = Field(..., description="Owner's username (user or org slug)")

--- a/components/backend/src/syfthub/services/endpoint_service.py
+++ b/components/backend/src/syfthub/services/endpoint_service.py
@@ -1479,7 +1479,6 @@ class EndpointService(BaseService):
                     "health_status": item.status.value,
                     "health_checked_at": item.checked_at,
                     "health_ttl_seconds": effective_ttl,
-                    "last_latency_ms": item.latency_ms,
                 }
             )
 
@@ -1607,11 +1606,6 @@ class EndpointService(BaseService):
             total = s.total_checks or 0
             healthy = s.healthy_checks or 0
             uptime_pct = (100.0 * healthy / total) if total > 0 else 0.0
-            avg_latency = (
-                (s.latency_sum_ms / s.latency_count)
-                if (s.latency_count and s.latency_count > 0)
-                else None
-            )
             # bucket_start is NOT NULL in the schema; assert narrows the type
             # so mypy stops treating it as Optional[datetime].
             bucket_start = s.bucket_start
@@ -1622,11 +1616,6 @@ class EndpointService(BaseService):
                     samples=total,
                     healthy_samples=healthy,
                     uptime_pct=round(uptime_pct, 2),
-                    avg_latency_ms=(
-                        round(avg_latency, 2) if avg_latency is not None else None
-                    ),
-                    min_latency_ms=s.latency_min_ms,
-                    max_latency_ms=s.latency_max_ms,
                 )
             )
 

--- a/components/backend/tests/test_jobs/test_health_monitor.py
+++ b/components/backend/tests/test_jobs/test_health_monitor.py
@@ -235,7 +235,6 @@ class TestGetEndpointsForHealthCheck:
                 None,
                 None,
                 None,
-                None,
             ),
             (
                 2,
@@ -249,7 +248,6 @@ class TestGetEndpointsForHealthCheck:
                 "healthy",
                 datetime.now(timezone.utc),
                 300,
-                None,
             ),
         ]
         org_results = []
@@ -289,7 +287,6 @@ class TestGetEndpointsForHealthCheck:
                 None,
                 None,
                 None,
-                None,
             ),
         ]
 
@@ -322,7 +319,6 @@ class TestGetEndpointsForHealthCheck:
                 None,
                 None,
                 None,
-                None,
             ),
         ]
         org_results = [
@@ -334,7 +330,6 @@ class TestGetEndpointsForHealthCheck:
                 [{"type": "rest_api", "config": {"url": "/org"}}],
                 "https://org.com",
                 100,
-                None,
                 None,
                 None,
                 None,
@@ -370,7 +365,6 @@ class TestGetEndpointsForHealthCheck:
                 None,
                 None,
                 None,
-                None,
             ),
             # Empty connect config (falsy)
             (
@@ -385,7 +379,6 @@ class TestGetEndpointsForHealthCheck:
                 None,
                 None,
                 None,
-                None,
             ),
             # Has connect config
             (
@@ -396,7 +389,6 @@ class TestGetEndpointsForHealthCheck:
                 [{"type": "rest_api"}],
                 "https://user3.com",
                 30,
-                None,
                 None,
                 None,
                 None,
@@ -431,7 +423,6 @@ class TestGetEndpointsForHealthCheck:
                 None,
                 None,
                 None,
-                None,
             ),
             # Empty domain - included
             (
@@ -446,7 +437,6 @@ class TestGetEndpointsForHealthCheck:
                 None,
                 None,
                 None,
-                None,
             ),
             # Has domain - included
             (
@@ -457,7 +447,6 @@ class TestGetEndpointsForHealthCheck:
                 [{"type": "rest_api"}],
                 "https://valid.com",
                 30,
-                None,
                 None,
                 None,
                 None,
@@ -520,7 +509,7 @@ class TestCheckEndpointHealth:
             owner_type="user",
             heartbeat_expires_at=None,
         )
-        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(endpoint)
+        endpoint_id, is_healthy = monitor._check_endpoint_health(endpoint)
         assert endpoint_id == 1
         assert is_healthy is False
 
@@ -537,7 +526,7 @@ class TestCheckEndpointHealth:
             owner_type="user",
             heartbeat_expires_at=None,
         )
-        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(endpoint)
+        endpoint_id, is_healthy = monitor._check_endpoint_health(endpoint)
         assert endpoint_id == 2
         assert is_healthy is False
 
@@ -558,7 +547,7 @@ class TestCheckEndpointHealth:
             health_checked_at=now - timedelta(seconds=10),
             health_ttl_seconds=300,
         )
-        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(endpoint)
+        endpoint_id, is_healthy = monitor._check_endpoint_health(endpoint)
         assert endpoint_id == 1
         assert is_healthy is True
 
@@ -579,7 +568,7 @@ class TestCheckEndpointHealth:
             health_checked_at=now - timedelta(seconds=10),
             health_ttl_seconds=300,
         )
-        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(endpoint)
+        endpoint_id, is_healthy = monitor._check_endpoint_health(endpoint)
         assert endpoint_id == 1
         assert is_healthy is False
 
@@ -600,7 +589,7 @@ class TestCheckEndpointHealth:
             health_checked_at=now - timedelta(seconds=600),  # Stale (expired)
             health_ttl_seconds=300,
         )
-        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(endpoint)
+        endpoint_id, is_healthy = monitor._check_endpoint_health(endpoint)
         assert endpoint_id == 1
         assert is_healthy is True  # Heartbeat says healthy
 
@@ -609,9 +598,7 @@ class TestCheckEndpointHealth:
         sample_endpoint.heartbeat_expires_at = datetime.now(timezone.utc) + timedelta(
             seconds=60
         )
-        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(
-            sample_endpoint
-        )
+        endpoint_id, is_healthy = monitor._check_endpoint_health(sample_endpoint)
         assert endpoint_id == 1
         assert is_healthy is True
 
@@ -620,17 +607,13 @@ class TestCheckEndpointHealth:
         sample_endpoint.heartbeat_expires_at = datetime.now(timezone.utc) - timedelta(
             seconds=60
         )
-        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(
-            sample_endpoint
-        )
+        endpoint_id, is_healthy = monitor._check_endpoint_health(sample_endpoint)
         assert endpoint_id == 1
         assert is_healthy is False
 
     def test_no_signals_is_unhealthy(self, monitor, sample_endpoint):
         """Test no health signals (null heartbeat, null health fields) is unhealthy."""
-        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(
-            sample_endpoint
-        )
+        endpoint_id, is_healthy = monitor._check_endpoint_health(sample_endpoint)
         assert endpoint_id == 1
         assert is_healthy is False
 
@@ -651,7 +634,7 @@ class TestCheckEndpointHealth:
             health_checked_at=now - timedelta(seconds=10),
             health_ttl_seconds=300,
         )
-        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(endpoint)
+        endpoint_id, is_healthy = monitor._check_endpoint_health(endpoint)
         assert endpoint_id == 1
         assert is_healthy is False  # Per-endpoint health wins
 
@@ -672,7 +655,7 @@ class TestCheckEndpointHealth:
             health_checked_at=now,
             health_ttl_seconds=None,  # Missing TTL
         )
-        endpoint_id, is_healthy, _latency = monitor._check_endpoint_health(endpoint)
+        endpoint_id, is_healthy = monitor._check_endpoint_health(endpoint)
         assert endpoint_id == 1
         assert is_healthy is True  # Falls through to heartbeat
 
@@ -740,7 +723,7 @@ class TestCheckPerEndpointHealth:
             health_checked_at=now - timedelta(seconds=10),
             health_ttl_seconds=300,
         )
-        assert monitor._check_per_endpoint_health(endpoint, now) == (True, None)
+        assert monitor._check_per_endpoint_health(endpoint, now) is True
 
     def test_returns_false_when_unhealthy(self, monitor):
         """Test returns False when fresh and unhealthy."""
@@ -759,7 +742,7 @@ class TestCheckPerEndpointHealth:
             health_checked_at=now - timedelta(seconds=10),
             health_ttl_seconds=300,
         )
-        assert monitor._check_per_endpoint_health(endpoint, now) == (False, None)
+        assert monitor._check_per_endpoint_health(endpoint, now) is False
 
 
 class TestCheckHeartbeatHealth:
@@ -987,9 +970,7 @@ class TestRunHealthCheckCycle:
             patch.object(
                 monitor, "_get_endpoints_for_health_check", return_value=endpoints
             ),
-            patch.object(
-                monitor, "_check_endpoint_health", return_value=(1, True, None)
-            ),
+            patch.object(monitor, "_check_endpoint_health", return_value=(1, True)),
             patch.object(
                 monitor,
                 "_update_endpoint_health_status",
@@ -1026,9 +1007,7 @@ class TestRunHealthCheckCycle:
             patch.object(
                 monitor, "_get_endpoints_for_health_check", return_value=endpoints
             ),
-            patch.object(
-                monitor, "_check_endpoint_health", return_value=(1, False, None)
-            ),
+            patch.object(monitor, "_check_endpoint_health", return_value=(1, False)),
             patch.object(
                 monitor,
                 "_update_endpoint_health_status",
@@ -1217,14 +1196,12 @@ class TestUptimeSampleEmission:
                 mock_session,
                 endpoint_id=42,
                 is_healthy=True,
-                latency_ms=87,
                 now=now,
             )
         repo.upsert_uptime_sample.assert_called_once()
         kwargs = repo.upsert_uptime_sample.call_args.kwargs
         assert kwargs["endpoint_id"] == 42
         assert kwargs["is_healthy"] is True
-        assert kwargs["latency_ms"] == 87
         # bucket boundary
         assert kwargs["bucket_start"] == datetime(
             2026, 5, 13, 12, 0, 0, tzinfo=timezone.utc
@@ -1242,7 +1219,6 @@ class TestUptimeSampleEmission:
                 mock_session,
                 endpoint_id=1,
                 is_healthy=False,
-                latency_ms=None,
                 now=now,
             )
 

--- a/components/backend/tests/test_repositories/test_endpoint_uptime.py
+++ b/components/backend/tests/test_repositories/test_endpoint_uptime.py
@@ -2,8 +2,7 @@
 
 Exercises the SQLite fallback paths (no ``ON CONFLICT``) of
 ``upsert_uptime_sample``, plus ``get_uptime_samples``,
-``delete_uptime_samples_older_than``, ``get_by_owner_and_slug_any_state``,
-and the latency-aware path of ``bulk_update_health_status``.
+``delete_uptime_samples_older_than`` and ``get_by_owner_and_slug_any_state``.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -42,7 +41,6 @@ class TestUpsertUptimeSample:
             endpoint_id=endpoint.id,
             bucket_start=bucket,
             is_healthy=True,
-            latency_ms=42,
         )
         test_session.commit()
 
@@ -51,18 +49,14 @@ class TestUpsertUptimeSample:
         s = samples[0]
         assert s.total_checks == 1
         assert s.healthy_checks == 1
-        assert s.latency_count == 1
-        assert s.latency_sum_ms == 42
-        assert s.latency_min_ms == 42
-        assert s.latency_max_ms == 42
 
     def test_accumulates_into_existing_bucket(self, test_session, endpoint):
         repo = EndpointRepository(test_session)
         bucket = datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc)
 
-        repo.upsert_uptime_sample(endpoint.id, bucket, True, 30)
-        repo.upsert_uptime_sample(endpoint.id, bucket, True, 50)
-        repo.upsert_uptime_sample(endpoint.id, bucket, False, None)
+        repo.upsert_uptime_sample(endpoint.id, bucket, True)
+        repo.upsert_uptime_sample(endpoint.id, bucket, True)
+        repo.upsert_uptime_sample(endpoint.id, bucket, False)
         test_session.commit()
 
         samples = repo.get_uptime_samples(endpoint.id, 24 * 30)
@@ -70,26 +64,17 @@ class TestUpsertUptimeSample:
         s = samples[0]
         assert s.total_checks == 3
         assert s.healthy_checks == 2
-        assert s.latency_count == 2
-        assert s.latency_sum_ms == 80
-        assert s.latency_min_ms == 30
-        assert s.latency_max_ms == 50
 
-    def test_unhealthy_without_latency_does_not_touch_latency_fields(
-        self, test_session, endpoint
-    ):
+    def test_unhealthy_sample_only_increments_total(self, test_session, endpoint):
         repo = EndpointRepository(test_session)
         bucket = datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc)
 
-        repo.upsert_uptime_sample(endpoint.id, bucket, False, None)
+        repo.upsert_uptime_sample(endpoint.id, bucket, False)
         test_session.commit()
 
         s = repo.get_uptime_samples(endpoint.id, 24 * 30)[0]
         assert s.total_checks == 1
         assert s.healthy_checks == 0
-        assert s.latency_count == 0
-        assert s.latency_min_ms is None
-        assert s.latency_max_ms is None
 
 
 class TestUptimeRetention:
@@ -99,8 +84,8 @@ class TestUptimeRetention:
         old = now - timedelta(days=100)
         fresh = now - timedelta(days=1)
 
-        repo.upsert_uptime_sample(endpoint.id, old, True, 10)
-        repo.upsert_uptime_sample(endpoint.id, fresh, True, 20)
+        repo.upsert_uptime_sample(endpoint.id, old, True)
+        repo.upsert_uptime_sample(endpoint.id, fresh, True)
         test_session.commit()
 
         removed = repo.delete_uptime_samples_older_than(retention_days=30)
@@ -109,12 +94,15 @@ class TestUptimeRetention:
 
         remaining = repo.get_uptime_samples(endpoint.id, window_hours=24 * 365)
         assert len(remaining) == 1
-        assert remaining[0].latency_sum_ms == 20
+        # The old (100 days ago) sample is gone; only the fresh one (1 day ago)
+        # survives. SQLite drops tzinfo on read so we compare naively.
+        bucket = remaining[0].bucket_start.replace(tzinfo=None)
+        assert bucket >= (now - timedelta(days=2)).replace(tzinfo=None)
 
     def test_zero_retention_is_noop_when_no_old_rows(self, test_session, endpoint):
         repo = EndpointRepository(test_session)
         bucket = datetime.now(timezone.utc) - timedelta(hours=1)
-        repo.upsert_uptime_sample(endpoint.id, bucket, True, 50)
+        repo.upsert_uptime_sample(endpoint.id, bucket, True)
         test_session.commit()
         # Asking to delete rows older than 30 days when nothing is that old
         assert repo.delete_uptime_samples_older_than(retention_days=30) == 0
@@ -172,8 +160,8 @@ class TestGetByOwnerAndSlugAnyState:
         )
 
 
-class TestBulkUpdateHealthLatency:
-    def test_writes_latency_when_provided(self, test_session, endpoint):
+class TestBulkUpdateHealthStatus:
+    def test_writes_health_fields(self, test_session, endpoint):
         repo = EndpointRepository(test_session)
         now = datetime.now(timezone.utc)
         repo.bulk_update_health_status(
@@ -183,35 +171,11 @@ class TestBulkUpdateHealthLatency:
                     "health_status": "healthy",
                     "health_checked_at": now,
                     "health_ttl_seconds": 300,
-                    "last_latency_ms": 73,
                 }
             ]
         )
         test_session.commit()
 
         refreshed = test_session.get(EndpointModel, endpoint.id)
-        assert refreshed.last_latency_ms == 73
         assert refreshed.health_status == "healthy"
-
-    def test_skips_latency_when_none(self, test_session, endpoint):
-        endpoint.last_latency_ms = 99
-        test_session.commit()
-
-        repo = EndpointRepository(test_session)
-        repo.bulk_update_health_status(
-            [
-                {
-                    "endpoint_id": endpoint.id,
-                    "health_status": "unhealthy",
-                    "health_checked_at": datetime.now(timezone.utc),
-                    "health_ttl_seconds": 300,
-                    "last_latency_ms": None,
-                }
-            ]
-        )
-        test_session.commit()
-
-        refreshed = test_session.get(EndpointModel, endpoint.id)
-        # Untouched — None means "no fresh signal", not "clear the field"
-        assert refreshed.last_latency_ms == 99
-        assert refreshed.health_status == "unhealthy"
+        assert refreshed.health_ttl_seconds == 300

--- a/components/backend/tests/test_services/test_endpoint_service.py
+++ b/components/backend/tests/test_services/test_endpoint_service.py
@@ -1644,10 +1644,6 @@ class TestGetEndpointUptime:
         s.bucket_start = kwargs["bucket_start"]
         s.total_checks = kwargs.get("total_checks", 0)
         s.healthy_checks = kwargs.get("healthy_checks", 0)
-        s.latency_count = kwargs.get("latency_count", 0)
-        s.latency_sum_ms = kwargs.get("latency_sum_ms", 0)
-        s.latency_min_ms = kwargs.get("latency_min_ms")
-        s.latency_max_ms = kwargs.get("latency_max_ms")
         return s
 
     def test_uptime_user_owned_happy_path(self, endpoint_service, sample_user):
@@ -1657,15 +1653,7 @@ class TestGetEndpointUptime:
         )
         bucket = datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc)
         samples = [
-            self._sample(
-                bucket_start=bucket,
-                total_checks=60,
-                healthy_checks=60,
-                latency_count=60,
-                latency_sum_ms=60 * 42,
-                latency_min_ms=30,
-                latency_max_ms=80,
-            )
+            self._sample(bucket_start=bucket, total_checks=60, healthy_checks=60)
         ]
 
         with (
@@ -1700,9 +1688,6 @@ class TestGetEndpointUptime:
         assert b.samples == 60
         assert b.healthy_samples == 60
         assert b.uptime_pct == 100.0
-        assert b.avg_latency_ms == 42.0
-        assert b.min_latency_ms == 30
-        assert b.max_latency_ms == 80
 
     def test_uptime_falls_back_to_org_lookup(self, endpoint_service, sample_user):
         org = MagicMock(id=99, slug="acme")
@@ -1816,23 +1801,15 @@ class TestGetEndpointUptime:
             )
         assert result.buckets == []
 
-    def test_uptime_partial_health_and_no_latency(self, endpoint_service, sample_user):
+    def test_uptime_partial_health(self, endpoint_service, sample_user):
         owner = MagicMock(id=1, username="testuser")
         endpoint = self._endpoint(
             id=42, slug="mixed", user_id=1, visibility=EndpointVisibility.PUBLIC
         )
         bucket = datetime(2026, 5, 13, 12, 30, tzinfo=timezone.utc)
-        # 40 of 60 checks healthy, no latency data
+        # 40 of 60 cycles observed a healthy state
         samples = [
-            self._sample(
-                bucket_start=bucket,
-                total_checks=60,
-                healthy_checks=40,
-                latency_count=0,
-                latency_sum_ms=0,
-                latency_min_ms=None,
-                latency_max_ms=None,
-            )
+            self._sample(bucket_start=bucket, total_checks=60, healthy_checks=40)
         ]
         with (
             patch.object(
@@ -1857,6 +1834,5 @@ class TestGetEndpointUptime:
             )
         b = result.buckets[0]
         assert b.uptime_pct == round(100.0 * 40 / 60, 2)
-        assert b.avg_latency_ms is None
-        assert b.min_latency_ms is None
-        assert b.max_latency_ms is None
+        assert b.samples == 60
+        assert b.healthy_samples == 40


### PR DESCRIPTION
## Why

The latency half of the uptime feature (added in #411) relies on SDK clients reporting per-endpoint round-trip latency via \`POST /endpoints/health\`'s \`latency_ms\` field. Every SDK in the wild (Python, TypeScript, Go, CLI, syfthubapi) still reports through the deprecated owner-level heartbeat endpoints, and there is no realistic path to retrofitting \`latency_ms\` into all of those release artifacts running on endpoint owners' machines.

In practice every uptime sample on prod is being recorded from the Tier 2 (heartbeat) fallback path with no latency signal, so the latency columns/code are dead weight. Verified earlier today against \`afdolriski/tempo-plus\` on \`syfthub.openmined.org\` — 42 samples, 100% healthy, every latency field null.

This PR rips the latency surface out entirely. Uptime is still recorded (\`total_checks\`, \`healthy_checks\`) and the \`GET .../uptime\` route still returns the time series — just without latency stats per bucket.

(Supersedes #412, which was branched from the pre-squash \`uptime\` branch and carried two redundant commits already on main.)

## What changes

**Removed**
- DB columns: \`endpoints.last_latency_ms\`, \`endpoint_uptime_samples.latency_count\` / \`latency_sum_ms\` / \`latency_min_ms\` / \`latency_max_ms\`
- Request: \`EndpointHealthItem.latency_ms\`
- Response: \`last_latency_ms\` on \`Endpoint\` / \`EndpointResponse\` / \`EndpointPublicResponse\`; \`avg_latency_ms\` / \`min_latency_ms\` / \`max_latency_ms\` on \`UptimeBucket\`
- Monitor plumbing: \`_check_per_endpoint_health\` / \`_check_endpoint_health\` return plain \`bool\` again (was \`(bool, latency)\`); \`_emit_uptime_sample\` drops the \`latency_ms\` param

**Kept**
- \`endpoint_uptime_samples\` table, with the \`total_checks\` / \`healthy_checks\` counters
- The full \`GET /api/v1/endpoints/{owner}/{slug}/uptime\` route, with a simpler \`UptimeBucket\` shape
- All per-endpoint health reporting via \`POST /endpoints/health\` — clients that adopt the new endpoint still benefit from Tier 1 (fresh per-endpoint health) over Tier 2 (owner heartbeat)

## Migration

\`014_drop_uptime_latency\` drops the five columns. Destructive but safe — every value on prod is NULL/0 (no SDK ever wrote one). Downgrade re-adds the columns with the original defaults so the change is reversible.

Smoke-tested by running \`alembic upgrade head\` end-to-end against a fresh SQLite DB; confirmed final schema:
\`\`\`
endpoint_uptime_samples columns: endpoint_id, bucket_start, total_checks, healthy_checks
endpoints.last_latency_ms present?: False
\`\`\`

## Test plan
- [x] \`uv run pytest tests/\` — 1342 pass (was 1343; dropped one latency-specific assert).
- [x] Coverage 80.45% (above the 80% gate).
- [x] \`ruff check\` / \`ruff format --check\` / \`mypy\` clean (pre-commit gate passes).
- [x] \`alembic upgrade head\` clean on a fresh DB; downgrade re-adds columns.
- [ ] Post-merge: hit \`GET /api/v1/endpoints/{owner}/{slug}/uptime\` on prod, confirm response no longer carries latency fields.