### PR TITLE
feat(frontend): add Overview/Uptime tabs to endpoint detail page

### DIFF
--- a/components/frontend/src/components/endpoint/endpoint-detail.tsx
+++ b/components/frontend/src/components/endpoint/endpoint-detail.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 
 import type { Components } from 'react-markdown';
 
@@ -8,16 +8,24 @@ import ExternalLink from 'lucide-react/dist/esm/icons/external-link';
 import Package from 'lucide-react/dist/esm/icons/package';
 import Star from 'lucide-react/dist/esm/icons/star';
 import Users from 'lucide-react/dist/esm/icons/users';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 
 import { ConnectionCard } from '@/components/connection-card';
 import { Markdown } from '@/components/prompt-kit/markdown';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useEndpointByPath } from '@/hooks/use-endpoint-queries';
 import { getEndpointTypeBadgeStyles, getEndpointTypeLabel } from '@/lib/endpoint-utils';
 
 import { AccessPoliciesCard } from './access-policies-card';
+import { UptimeTab } from './uptime-tab';
+
+type EndpointTabId = 'overview' | 'uptime';
+
+function parseTab(raw: string | null): EndpointTabId {
+  return raw === 'uptime' ? 'uptime' : 'overview';
+}
 
 type EndpointStatus = 'active' | 'warning' | 'inactive';
 
@@ -134,6 +142,33 @@ export const EndpointDetail = memo(function EndpointDetail({
 }: Readonly<EndpointDetailProperties>) {
   const path = owner ? `${owner}/${slug}` : undefined;
   const { data: fetchedEndpoint, isLoading, error: queryError, refetch } = useEndpointByPath(path);
+
+  // Tab state lives in the URL so links like /:user/:slug?tab=uptime are
+  // shareable and refresh-stable. Default to overview when no param.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = parseTab(searchParams.get('tab'));
+
+  // Lazy-mount tracker: keep the uptime tab unmounted until the user has
+  // activated it at least once. After that, keep it mounted so the React
+  // Query cache survives further tab toggling without re-fetching.
+  const [uptimeOpened, setUptimeOpened] = useState(activeTab === 'uptime');
+
+  const handleTabChange = useCallback(
+    (next: string) => {
+      const nextTab = parseTab(next);
+      if (nextTab === 'uptime') setUptimeOpened(true);
+      setSearchParams(
+        (previous) => {
+          const params = new URLSearchParams(previous);
+          if (nextTab === 'overview') params.delete('tab');
+          else params.set('tab', nextTab);
+          return params;
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
 
   // Derive endpoint with full_path set
   const endpoint = fetchedEndpoint
@@ -254,10 +289,10 @@ export const EndpointDetail = memo(function EndpointDetail({
   }
 
   return (
-    <div className='bg-background min-h-screen'>
-      {/* Header */}
+    <Tabs value={activeTab} onValueChange={handleTabChange} className='bg-background min-h-screen'>
+      {/* Header (sticky) — back button, h1, description, badges, then tab strip */}
       <div className='border-border bg-card sticky top-0 z-10 border-b backdrop-blur-sm'>
-        <div className='mx-auto max-w-5xl px-6 py-4'>
+        <div className='mx-auto max-w-5xl px-6 pt-4'>
           <Button
             variant='ghost'
             onClick={onBack}
@@ -305,114 +340,141 @@ export const EndpointDetail = memo(function EndpointDetail({
               </div>
             </div>
           </div>
+
+          {/* Tab strip — sits flush with the header's bottom border via -mb-px */}
+          <TabsList className='-mb-px flex h-12 w-full justify-start gap-1 rounded-none bg-transparent p-0'>
+            <TabsTrigger
+              value='overview'
+              className='font-inter focus-visible:ring-ring data-[state=active]:border-primary data-[state=active]:text-foreground text-muted-foreground hover:text-foreground relative inline-flex h-12 items-center justify-center rounded-none border-b-2 border-transparent bg-transparent px-4 text-sm font-medium shadow-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-0 data-[state=active]:shadow-none'
+            >
+              Overview
+            </TabsTrigger>
+            <TabsTrigger
+              value='uptime'
+              className='font-inter focus-visible:ring-ring data-[state=active]:border-primary data-[state=active]:text-foreground text-muted-foreground hover:text-foreground relative inline-flex h-12 items-center justify-center rounded-none border-b-2 border-transparent bg-transparent px-4 text-sm font-medium shadow-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-0 data-[state=active]:shadow-none'
+            >
+              Uptime
+            </TabsTrigger>
+          </TabsList>
         </div>
       </div>
 
       {/* Content */}
       <div className='mx-auto max-w-5xl px-6 py-8'>
-        <div className='grid gap-8 lg:grid-cols-3'>
-          {/* Main content */}
-          <main className='space-y-6 lg:col-span-2'>
-            {/* README Section */}
-            <article className='border-border bg-card rounded-xl border p-6'>
-              <div className='prose prose-sm text-muted-foreground max-w-none'>
-                {endpoint.readme ? (
-                  <Markdown components={markdownComponents}>{endpoint.readme}</Markdown>
-                ) : (
-                  <p className='font-inter text-muted-foreground italic'>
-                    No documentation available for this endpoint.
-                  </p>
-                )}
-              </div>
-            </article>
-
-            {/* Access Policies Card */}
-            <AccessPoliciesCard
-              policies={endpoint.policies}
-              endpointSlug={endpoint.full_path ?? endpoint.slug}
-              endpointOwner={endpoint.owner_username}
-            />
-          </main>
-
-          {/* Sidebar */}
-          <aside className='space-y-6'>
-            {/* Info Card */}
-            <div className='border-border bg-card rounded-xl border p-6'>
-              <h3 className='font-rubik text-foreground mb-4 text-sm font-medium'>About</h3>
-              <div className='space-y-4'>
-                <div>
-                  <p className='font-inter text-muted-foreground mb-1 text-xs'>Owner</p>
-                  {endpoint.owner_username ? (
-                    <Link
-                      to={`/${endpoint.owner_username}`}
-                      className='hover:text-primary group flex items-center gap-2 transition-colors'
-                    >
-                      <div
-                        className='from-secondary to-chart-3 h-6 w-6 rounded-full bg-gradient-to-br'
-                        role='img'
-                        aria-label={`Avatar for ${endpoint.owner_username}`}
-                      />
-                      <span className='font-inter text-foreground group-hover:text-primary text-sm font-medium group-hover:underline'>
-                        @{endpoint.owner_username}
-                      </span>
-                    </Link>
+        <TabsContent value='overview' className='mt-0 focus-visible:outline-none'>
+          <div className='grid gap-8 lg:grid-cols-3'>
+            {/* Main content */}
+            <main className='space-y-6 lg:col-span-2'>
+              {/* README Section */}
+              <article className='border-border bg-card rounded-xl border p-6'>
+                <div className='prose prose-sm text-muted-foreground max-w-none'>
+                  {endpoint.readme ? (
+                    <Markdown components={markdownComponents}>{endpoint.readme}</Markdown>
                   ) : (
-                    <div className='flex items-center gap-2'>
-                      <div
-                        className='from-secondary to-chart-3 h-6 w-6 rounded-full bg-gradient-to-br'
-                        role='img'
-                        aria-label='Avatar for anonymous'
-                      />
-                      <span className='font-inter text-foreground text-sm font-medium'>
-                        @anonymous
-                      </span>
-                    </div>
+                    <p className='font-inter text-muted-foreground italic'>
+                      No documentation available for this endpoint.
+                    </p>
                   )}
                 </div>
+              </article>
 
-                <div>
-                  <p className='font-inter text-muted-foreground mb-1 text-xs'>Endpoint Type</p>
-                  <Badge className={`border ${getEndpointTypeBadgeStyles(endpoint.type)}`}>
-                    {getEndpointTypeLabel(endpoint.type)}
-                  </Badge>
-                </div>
+              {/* Access Policies Card */}
+              <AccessPoliciesCard
+                policies={endpoint.policies}
+                endpointSlug={endpoint.full_path ?? endpoint.slug}
+                endpointOwner={endpoint.owner_username}
+              />
+            </main>
 
-                {endpoint.tags.length > 0 ? (
+            {/* Sidebar */}
+            <aside className='space-y-6'>
+              {/* Info Card */}
+              <div className='border-border bg-card rounded-xl border p-6'>
+                <h3 className='font-rubik text-foreground mb-4 text-sm font-medium'>About</h3>
+                <div className='space-y-4'>
                   <div>
-                    <p className='font-inter text-muted-foreground mb-1 text-xs'>Tags</p>
-                    <div className='flex flex-wrap gap-1'>
-                      {endpoint.tags.map((tag) => (
-                        <Badge key={tag} variant='outline'>
-                          {tag}
-                        </Badge>
-                      ))}
-                    </div>
+                    <p className='font-inter text-muted-foreground mb-1 text-xs'>Owner</p>
+                    {endpoint.owner_username ? (
+                      <Link
+                        to={`/${endpoint.owner_username}`}
+                        className='hover:text-primary group flex items-center gap-2 transition-colors'
+                      >
+                        <div
+                          className='from-secondary to-chart-3 h-6 w-6 rounded-full bg-gradient-to-br'
+                          role='img'
+                          aria-label={`Avatar for ${endpoint.owner_username}`}
+                        />
+                        <span className='font-inter text-foreground group-hover:text-primary text-sm font-medium group-hover:underline'>
+                          @{endpoint.owner_username}
+                        </span>
+                      </Link>
+                    ) : (
+                      <div className='flex items-center gap-2'>
+                        <div
+                          className='from-secondary to-chart-3 h-6 w-6 rounded-full bg-gradient-to-br'
+                          role='img'
+                          aria-label='Avatar for anonymous'
+                        />
+                        <span className='font-inter text-foreground text-sm font-medium'>
+                          @anonymous
+                        </span>
+                      </div>
+                    )}
                   </div>
-                ) : null}
 
-                <div>
-                  <p className='font-inter text-muted-foreground mb-1 text-xs'>Contributors</p>
-                  <div className='flex items-center gap-1'>
-                    <Users className='text-muted-foreground h-4 w-4' />
-                    <span className='font-inter text-foreground text-sm'>
-                      {endpoint.contributors_count} contributor
-                      {endpoint.contributors_count === 1 ? '' : 's'}
-                    </span>
+                  <div>
+                    <p className='font-inter text-muted-foreground mb-1 text-xs'>Endpoint Type</p>
+                    <Badge className={`border ${getEndpointTypeBadgeStyles(endpoint.type)}`}>
+                      {getEndpointTypeLabel(endpoint.type)}
+                    </Badge>
+                  </div>
+
+                  {endpoint.tags.length > 0 ? (
+                    <div>
+                      <p className='font-inter text-muted-foreground mb-1 text-xs'>Tags</p>
+                      <div className='flex flex-wrap gap-1'>
+                        {endpoint.tags.map((tag) => (
+                          <Badge key={tag} variant='outline'>
+                            {tag}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  <div>
+                    <p className='font-inter text-muted-foreground mb-1 text-xs'>Contributors</p>
+                    <div className='flex items-center gap-1'>
+                      <Users className='text-muted-foreground h-4 w-4' />
+                      <span className='font-inter text-foreground text-sm'>
+                        {endpoint.contributors_count} contributor
+                        {endpoint.contributors_count === 1 ? '' : 's'}
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
 
-            {/* Connections Card */}
-            {endpoint.connections && endpoint.connections.length > 0 ? (
-              <ConnectionCard
-                connections={endpoint.connections}
-                endpointSlug={endpoint.full_path}
-              />
-            ) : null}
-          </aside>
-        </div>
+              {/* Connections Card */}
+              {endpoint.connections && endpoint.connections.length > 0 ? (
+                <ConnectionCard
+                  connections={endpoint.connections}
+                  endpointSlug={endpoint.full_path}
+                />
+              ) : null}
+            </aside>
+          </div>
+        </TabsContent>
+
+        <TabsContent value='uptime' className='mt-0 focus-visible:outline-none'>
+          {/* Lazy-mount: only render once the user has activated the Uptime
+              tab at least once. After that we keep it mounted so the React
+              Query cache survives toggling. */}
+          {uptimeOpened ? (
+            <UptimeTab owner={endpoint.owner_username ?? owner ?? undefined} slug={endpoint.slug} />
+          ) : null}
+        </TabsContent>
       </div>
-    </div>
+    </Tabs>
   );
 });

--- a/components/frontend/src/components/endpoint/uptime-strip.tsx
+++ b/components/frontend/src/components/endpoint/uptime-strip.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react';
+
+import type { DayCell, DayStatus } from '@/lib/uptime';
+
+import { formatDateLong } from '@/lib/date-utils';
+import { formatDuration } from '@/lib/uptime';
+
+interface UptimeStripProperties {
+  days: DayCell[];
+  /** Bucket size in seconds — used to label the resolution caption. */
+  bucketSeconds: number;
+}
+
+function dayColor(status: DayStatus): string {
+  switch (status) {
+    case 'operational': {
+      return 'bg-green-500 dark:bg-green-600';
+    }
+    case 'degraded': {
+      return 'bg-yellow-500';
+    }
+    case 'down': {
+      return 'bg-red-500 dark:bg-red-600';
+    }
+    default: {
+      // no-data
+      return 'bg-muted';
+    }
+  }
+}
+
+function statusLabel(status: DayStatus): string {
+  switch (status) {
+    case 'operational': {
+      return 'Operational';
+    }
+    case 'degraded': {
+      return 'Degraded';
+    }
+    case 'down': {
+      return 'Down';
+    }
+    default: {
+      return 'No data';
+    }
+  }
+}
+
+function formatIncidents(count: number): string {
+  if (count === 0) return 'no incidents';
+  if (count === 1) return '1 incident';
+  return `${String(count)} incidents`;
+}
+
+function accessibleLabel(day: DayCell): string {
+  const date = formatDateLong(day.date);
+  if (day.samples === 0) return `${date}: no uptime data recorded`;
+  const uptime = (day.mean_uptime_pct ?? 0).toFixed(2);
+  const downtime = formatDuration(day.downtime_seconds);
+  const incidents = formatIncidents(day.incident_count);
+  return `${date}: ${uptime}% uptime, ${downtime} downtime, ${incidents}, ${String(day.samples)} samples`;
+}
+
+function resolutionLabel(bucketSeconds: number): string {
+  if (bucketSeconds % 3600 === 0) return `${String(bucketSeconds / 3600)}-hour resolution`;
+  if (bucketSeconds % 60 === 0) return `${String(bucketSeconds / 60)}-minute resolution`;
+  return `${String(bucketSeconds)}-second resolution`;
+}
+
+export function UptimeStrip({ days, bucketSeconds }: Readonly<UptimeStripProperties>) {
+  const [selected, setSelected] = useState<DayCell | null>(null);
+
+  const handleToggle = (day: DayCell) => {
+    setSelected((previous) => (previous?.dateKey === day.dateKey ? null : day));
+  };
+
+  return (
+    <section className='border-border bg-card rounded-xl border p-6'>
+      <header className='mb-4 flex items-baseline justify-between gap-4'>
+        <h3 className='font-rubik text-foreground text-sm font-medium'>Uptime history</h3>
+        <p className='font-inter text-muted-foreground text-xs'>
+          Last {String(days.length)} days · {resolutionLabel(bucketSeconds)}
+        </p>
+      </header>
+
+      <div
+        // role="list" lets screen readers walk the cells; each cell's
+        // accessible label carries the full status, so colour is never the
+        // only signal (WCAG 2.2 SC 1.4.1).
+        role='list'
+        aria-label={`Daily uptime over the last ${String(days.length)} days`}
+        className='mb-3 flex h-10 items-stretch gap-[3px]'
+      >
+        {days.map((day) => {
+          const isSelected = selected?.dateKey === day.dateKey;
+          return (
+            <button
+              key={day.dateKey}
+              type='button'
+              role='listitem'
+              aria-label={accessibleLabel(day)}
+              aria-pressed={isSelected}
+              onClick={() => {
+                handleToggle(day);
+              }}
+              className={`focus-visible:ring-ring flex-1 rounded-[3px] transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none ${dayColor(day.status)} ${
+                isSelected ? 'ring-foreground/40 ring-2 ring-offset-1 ring-offset-transparent' : ''
+              }`}
+            />
+          );
+        })}
+      </div>
+
+      <div className='font-inter text-muted-foreground flex justify-between text-xs'>
+        <span>{String(days.length)} days ago</span>
+        <span>Today</span>
+      </div>
+
+      <div className='border-border mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 border-t pt-4'>
+        {(
+          [
+            ['operational', 'Operational'],
+            ['degraded', 'Degraded'],
+            ['down', 'Down'],
+            ['no-data', 'No data']
+          ] as const
+        ).map(([status, label]) => (
+          <span
+            key={status}
+            className='font-inter text-muted-foreground inline-flex items-center gap-1.5 text-xs'
+          >
+            <span className={`h-2.5 w-2.5 rounded-[2px] ${dayColor(status)}`} aria-hidden='true' />
+            {label}
+          </span>
+        ))}
+      </div>
+
+      {selected && (
+        <div className='border-border bg-muted/30 mt-4 rounded-lg border p-4'>
+          <div className='mb-2 flex items-center justify-between gap-4'>
+            <p className='font-rubik text-foreground text-sm font-medium'>
+              {formatDateLong(selected.date)}
+            </p>
+            <span className='font-inter text-muted-foreground text-xs'>
+              {statusLabel(selected.status)}
+            </span>
+          </div>
+          {selected.samples === 0 ? (
+            <p className='font-inter text-muted-foreground text-sm'>
+              No uptime data recorded for this day.
+            </p>
+          ) : (
+            <dl className='grid grid-cols-2 gap-4 text-sm sm:grid-cols-4'>
+              <div>
+                <dt className='text-muted-foreground text-xs'>Uptime</dt>
+                <dd className='font-inter text-foreground tabular-nums'>
+                  {(selected.mean_uptime_pct ?? 0).toFixed(2)}%
+                </dd>
+              </div>
+              <div>
+                <dt className='text-muted-foreground text-xs'>Downtime</dt>
+                <dd className='font-inter text-foreground tabular-nums'>
+                  {formatDuration(selected.downtime_seconds)}
+                </dd>
+              </div>
+              <div>
+                <dt className='text-muted-foreground text-xs'>Incidents</dt>
+                <dd className='font-inter text-foreground tabular-nums'>
+                  {selected.incident_count}
+                </dd>
+              </div>
+              <div>
+                <dt className='text-muted-foreground text-xs'>Samples</dt>
+                <dd className='font-inter text-foreground tabular-nums'>{selected.samples}</dd>
+              </div>
+            </dl>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/components/frontend/src/components/endpoint/uptime-summary-card.tsx
+++ b/components/frontend/src/components/endpoint/uptime-summary-card.tsx
@@ -1,0 +1,63 @@
+import type { UptimeSummary } from '@/lib/uptime';
+
+import { formatDuration } from '@/lib/uptime';
+
+interface UptimeSummaryCardProperties {
+  summary: UptimeSummary;
+  /** Window label, e.g. "30-day". Defaults to "30-day". */
+  windowLabel?: string;
+}
+
+function formatPct(value: number | null): string {
+  if (value === null) return '—';
+  return value.toFixed(2);
+}
+
+function classifyUptimeTone(uptimePct: number | null): string {
+  if (uptimePct === null) return 'text-foreground';
+  if (uptimePct >= 99) return 'text-green-600 dark:text-green-500';
+  if (uptimePct >= 90) return 'text-yellow-600 dark:text-yellow-500';
+  return 'text-red-600 dark:text-red-500';
+}
+
+export function UptimeSummaryCard({
+  summary,
+  windowLabel = '30-day'
+}: Readonly<UptimeSummaryCardProperties>) {
+  const uptimeTone = classifyUptimeTone(summary.uptime_pct);
+  return (
+    <section className='border-border bg-card rounded-xl border p-6'>
+      <div className='grid grid-cols-1 gap-6 sm:grid-cols-3'>
+        <div>
+          <p className='font-inter text-muted-foreground mb-1 text-xs tracking-wide uppercase'>
+            {windowLabel} uptime
+          </p>
+          <p className={`font-rubik text-3xl font-medium tabular-nums ${uptimeTone}`}>
+            {formatPct(summary.uptime_pct)}
+            {summary.uptime_pct !== null && (
+              <span className='text-muted-foreground ml-0.5 text-xl'>%</span>
+            )}
+          </p>
+        </div>
+
+        <div>
+          <p className='font-inter text-muted-foreground mb-1 text-xs tracking-wide uppercase'>
+            Total downtime
+          </p>
+          <p className='font-rubik text-foreground text-3xl font-medium tabular-nums'>
+            {formatDuration(summary.downtime_seconds)}
+          </p>
+        </div>
+
+        <div>
+          <p className='font-inter text-muted-foreground mb-1 text-xs tracking-wide uppercase'>
+            Incidents
+          </p>
+          <p className='font-rubik text-foreground text-3xl font-medium tabular-nums'>
+            {summary.incident_count}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/frontend/src/components/endpoint/uptime-tab.tsx
+++ b/components/frontend/src/components/endpoint/uptime-tab.tsx
@@ -1,0 +1,96 @@
+import { useMemo } from 'react';
+
+import { useEndpointUptime } from '@/hooks/use-endpoint-uptime';
+import { aggregateByDay, summarize } from '@/lib/uptime';
+
+import { UptimeStrip } from './uptime-strip';
+import { UptimeSummaryCard } from './uptime-summary-card';
+
+interface UptimeTabProperties {
+  owner: string | undefined;
+  slug: string;
+  /** Rolling window. Defaults to 720 (30 days). */
+  windowHours?: number;
+}
+
+function UptimeSkeleton() {
+  return (
+    <div className='space-y-6' role='status' aria-label='Loading uptime data'>
+      <div className='border-border bg-card rounded-xl border p-6'>
+        <div className='grid grid-cols-1 gap-6 sm:grid-cols-3'>
+          {[0, 1, 2].map((index) => (
+            <div key={index}>
+              <div className='bg-muted mb-2 h-3 w-24 animate-pulse rounded' />
+              <div className='bg-muted h-8 w-20 animate-pulse rounded' />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className='border-border bg-card rounded-xl border p-6'>
+        <div className='bg-muted mb-4 h-4 w-32 animate-pulse rounded' />
+        <div className='mb-3 flex h-10 items-stretch gap-[3px]'>
+          {Array.from({ length: 30 }, (_, index) => (
+            <div key={index} className='bg-muted flex-1 animate-pulse rounded-[3px]' />
+          ))}
+        </div>
+        <div className='bg-muted h-3 w-full max-w-xs animate-pulse rounded' />
+      </div>
+    </div>
+  );
+}
+
+export function UptimeTab({ owner, slug, windowHours = 720 }: Readonly<UptimeTabProperties>) {
+  const { data, isLoading, error, refetch } = useEndpointUptime(owner, slug, { windowHours });
+
+  const days = useMemo(
+    () => aggregateByDay(data, Math.ceil(windowHours / 24)),
+    [data, windowHours]
+  );
+  const summary = useMemo(() => summarize(data), [data]);
+
+  if (isLoading) {
+    return <UptimeSkeleton />;
+  }
+
+  if (error) {
+    return (
+      <div className='border-border bg-card rounded-xl border p-6 text-center'>
+        <h3 className='font-rubik text-foreground mb-2 text-sm font-medium'>
+          Couldn&apos;t load uptime
+        </h3>
+        <p className='font-inter text-muted-foreground mb-4 text-sm'>
+          {error instanceof Error ? error.message : 'Unknown error'}
+        </p>
+        <button
+          type='button'
+          onClick={() => void refetch()}
+          className='border-border text-foreground hover:bg-muted inline-flex items-center rounded-md border px-4 py-2 text-sm font-medium transition-colors'
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (!data || data.buckets.length === 0) {
+    return (
+      <div className='border-border bg-card rounded-xl border p-6 text-center'>
+        <h3 className='font-rubik text-foreground mb-2 text-sm font-medium'>No uptime data yet</h3>
+        <p className='font-inter text-muted-foreground text-sm'>
+          The health monitor records one sample every 30 seconds and aggregates them into 30-minute
+          buckets. The first data point should appear within the next half hour.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className='space-y-6'>
+      <UptimeSummaryCard
+        summary={summary}
+        windowLabel={`${String(Math.ceil(windowHours / 24))}-day`}
+      />
+      <UptimeStrip days={days} bucketSeconds={data.bucket_seconds} />
+    </div>
+  );
+}

--- a/components/frontend/src/hooks/use-endpoint-uptime.ts
+++ b/components/frontend/src/hooks/use-endpoint-uptime.ts
@@ -1,0 +1,59 @@
+import type { EndpointUptimeResponse } from '@/lib/uptime';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { endpointKeys } from '@/lib/query-keys';
+import { getStoredAccessToken } from '@/lib/sdk-client';
+
+function buildAuthHeaders(): Record<string, string> {
+  // Public uptime is readable without auth, but a token lets the backend
+  // surface PRIVATE/INTERNAL endpoints to their owners.
+  const token = getStoredAccessToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function fetchEndpointUptime(
+  owner: string,
+  slug: string,
+  windowHours: number
+): Promise<EndpointUptimeResponse> {
+  const response = await fetch(
+    `/api/v1/endpoints/${encodeURIComponent(owner)}/${encodeURIComponent(slug)}/uptime?window_hours=${windowHours}`,
+    { headers: buildAuthHeaders() }
+  );
+  if (!response.ok) {
+    throw new Error(`Uptime fetch failed: ${response.status} ${response.statusText}`);
+  }
+  return (await response.json()) as EndpointUptimeResponse;
+}
+
+interface UseEndpointUptimeOptions {
+  /**
+   * If false, the query stays disabled. Used to lazy-mount the uptime tab —
+   * pass `enabled` only when the user has activated the tab at least once.
+   */
+  enabled?: boolean;
+  /** Window in hours. Defaults to 720 (30 days). */
+  windowHours?: number;
+}
+
+/**
+ * Fetch a per-endpoint uptime time series. The endpoint is public, so this
+ * works whether or not the user is signed in.
+ */
+export function useEndpointUptime(
+  owner: string | undefined,
+  slug: string | undefined,
+  { enabled = true, windowHours = 720 }: UseEndpointUptimeOptions = {}
+) {
+  const ownerKey = owner ?? '';
+  const slugKey = slug ?? '';
+  return useQuery({
+    queryKey: endpointKeys.uptime(ownerKey, slugKey, windowHours),
+    queryFn: () => fetchEndpointUptime(ownerKey, slugKey, windowHours),
+    enabled: enabled && Boolean(owner && slug),
+    // Buckets update at most every 30s server-side; a 60s stale window keeps
+    // the cache hot during tab toggling without spamming the API.
+    staleTime: 60 * 1000
+  });
+}

--- a/components/frontend/src/lib/__tests__/uptime.test.ts
+++ b/components/frontend/src/lib/__tests__/uptime.test.ts
@@ -1,0 +1,228 @@
+import type { EndpointUptimeResponse, UptimeBucket } from '../uptime';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  aggregateByDay,
+  classifyDay,
+  countIncidents,
+  formatDuration,
+  summarize,
+  utcDateKey
+} from '../uptime';
+
+function bucket(bucket_start: string, samples: number, healthy_samples: number): UptimeBucket {
+  return {
+    bucket_start,
+    samples,
+    healthy_samples,
+    uptime_pct: samples > 0 ? (100 * healthy_samples) / samples : 0
+  };
+}
+
+function response(buckets: UptimeBucket[]): EndpointUptimeResponse {
+  return {
+    endpoint_id: 1,
+    owner_username: 'alice',
+    slug: 'demo',
+    bucket_seconds: 1800,
+    window_hours: 720,
+    buckets
+  };
+}
+
+// ----------------------------------------------------------------------------
+// classifyDay
+// ----------------------------------------------------------------------------
+
+describe('classifyDay', () => {
+  it('returns no-data when samples is 0', () => {
+    expect(classifyDay(100, 0)).toBe('no-data');
+  });
+
+  it('returns no-data when min_uptime_pct is null', () => {
+    expect(classifyDay(null, 10)).toBe('no-data');
+  });
+
+  it('returns operational at or above 99', () => {
+    expect(classifyDay(99, 10)).toBe('operational');
+    expect(classifyDay(100, 10)).toBe('operational');
+  });
+
+  it('returns degraded between 90 and 99', () => {
+    expect(classifyDay(95, 10)).toBe('degraded');
+    expect(classifyDay(90, 10)).toBe('degraded');
+  });
+
+  it('returns down below 90', () => {
+    expect(classifyDay(89.9, 10)).toBe('down');
+    expect(classifyDay(0, 10)).toBe('down');
+  });
+});
+
+// ----------------------------------------------------------------------------
+// countIncidents
+// ----------------------------------------------------------------------------
+
+describe('countIncidents', () => {
+  it('counts a single isolated dip', () => {
+    expect(
+      countIncidents([
+        bucket('2026-05-01T00:00:00Z', 60, 60),
+        bucket('2026-05-01T00:30:00Z', 60, 30), // 50% → down
+        bucket('2026-05-01T01:00:00Z', 60, 60)
+      ])
+    ).toBe(1);
+  });
+
+  it('collapses consecutive bad buckets into one incident', () => {
+    expect(
+      countIncidents([
+        bucket('2026-05-01T00:00:00Z', 60, 60),
+        bucket('2026-05-01T00:30:00Z', 60, 30),
+        bucket('2026-05-01T01:00:00Z', 60, 10),
+        bucket('2026-05-01T01:30:00Z', 60, 60)
+      ])
+    ).toBe(1);
+  });
+
+  it('counts separated bad buckets as separate incidents', () => {
+    expect(
+      countIncidents([
+        bucket('2026-05-01T00:00:00Z', 60, 30),
+        bucket('2026-05-01T00:30:00Z', 60, 60),
+        bucket('2026-05-01T01:00:00Z', 60, 30)
+      ])
+    ).toBe(2);
+  });
+
+  it('ignores empty buckets when counting streaks', () => {
+    // An empty bucket between two bad ones must NOT split a real incident,
+    // because "no data" is not "recovered".
+    expect(
+      countIncidents([
+        bucket('2026-05-01T00:00:00Z', 60, 30),
+        bucket('2026-05-01T00:30:00Z', 0, 0),
+        bucket('2026-05-01T01:00:00Z', 60, 30)
+      ])
+    ).toBe(1);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// aggregateByDay
+// ----------------------------------------------------------------------------
+
+describe('aggregateByDay', () => {
+  const fixedNow = new Date('2026-05-13T15:00:00Z');
+
+  it('returns exactly N day cells covering the last N days', () => {
+    const cells = aggregateByDay(response([]), 30, fixedNow);
+    expect(cells).toHaveLength(30);
+    expect(cells.at(-1)?.dateKey).toBe('2026-05-13'); // today
+    expect(cells[0]?.dateKey).toBe('2026-04-14'); // 29 days ago
+  });
+
+  it('fills missing days with no-data cells', () => {
+    const cells = aggregateByDay(response([]), 30, fixedNow);
+    expect(cells.every((c) => c.status === 'no-data')).toBe(true);
+    expect(cells.every((c) => c.samples === 0)).toBe(true);
+  });
+
+  it('groups buckets into their UTC day', () => {
+    const r = response([
+      bucket('2026-05-13T01:00:00Z', 60, 60),
+      bucket('2026-05-13T22:00:00Z', 60, 30),
+      bucket('2026-05-12T12:00:00Z', 60, 60)
+    ]);
+    const cells = aggregateByDay(r, 30, fixedNow);
+    const today = cells.find((c) => c.dateKey === '2026-05-13');
+    const yesterday = cells.find((c) => c.dateKey === '2026-05-12');
+    expect(today?.samples).toBe(120);
+    expect(today?.healthy_samples).toBe(90);
+    expect(today?.status).toBe('down'); // 22:00 bucket was 50%
+    expect(yesterday?.samples).toBe(60);
+    expect(yesterday?.status).toBe('operational');
+  });
+
+  it('classifies a day by its worst bucket, not by its mean', () => {
+    const r = response([
+      bucket('2026-05-13T00:00:00Z', 60, 60),
+      bucket('2026-05-13T01:00:00Z', 60, 60),
+      bucket('2026-05-13T02:00:00Z', 60, 56) // ~93%
+    ]);
+    const cells = aggregateByDay(r, 30, fixedNow);
+    const today = cells.find((c) => c.dateKey === '2026-05-13');
+    expect(today?.status).toBe('degraded');
+  });
+});
+
+// ----------------------------------------------------------------------------
+// summarize
+// ----------------------------------------------------------------------------
+
+describe('summarize', () => {
+  it('returns nulls/zeros for empty input', () => {
+    const s = summarize(null);
+    expect(s.uptime_pct).toBeNull();
+    expect(s.downtime_seconds).toBe(0);
+    expect(s.incident_count).toBe(0);
+  });
+
+  it('computes overall uptime_pct as healthy / total', () => {
+    const s = summarize(
+      response([bucket('2026-05-13T00:00:00Z', 60, 60), bucket('2026-05-13T00:30:00Z', 60, 30)])
+    );
+    expect(s.uptime_pct).toBeCloseTo(75);
+  });
+
+  it('computes downtime_seconds from missed samples × bucket_seconds', () => {
+    // bucket of 60 samples, 30 healthy → 50% down × 1800s = 900s
+    const s = summarize(response([bucket('2026-05-13T00:00:00Z', 60, 30)]));
+    expect(s.downtime_seconds).toBe(900);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// formatDuration
+// ----------------------------------------------------------------------------
+
+describe('formatDuration', () => {
+  it('renders 0s for zero', () => {
+    expect(formatDuration(0)).toBe('0s');
+  });
+
+  it('renders seconds below a minute', () => {
+    expect(formatDuration(45)).toBe('45s');
+  });
+
+  it('renders minutes below an hour', () => {
+    expect(formatDuration(60 * 5)).toBe('5m');
+    // Minute display is floored — we count completed minutes, not rounded.
+    expect(formatDuration(60 * 5 + 30)).toBe('5m');
+    expect(formatDuration(60 * 6 - 1)).toBe('5m');
+  });
+
+  it('renders hours without minutes when minutes is 0', () => {
+    expect(formatDuration(3600 * 2)).toBe('2h');
+  });
+
+  it('combines hours and minutes', () => {
+    expect(formatDuration(3600 * 4 + 60 * 12)).toBe('4h 12m');
+  });
+
+  it('clamps negative input to 0', () => {
+    expect(formatDuration(-10)).toBe('0s');
+  });
+});
+
+// ----------------------------------------------------------------------------
+// utcDateKey
+// ----------------------------------------------------------------------------
+
+describe('utcDateKey', () => {
+  it('uses UTC midnight, not local', () => {
+    expect(utcDateKey(new Date('2026-05-13T23:59:59Z'))).toBe('2026-05-13');
+    expect(utcDateKey(new Date('2026-05-14T00:00:00Z'))).toBe('2026-05-14');
+  });
+});

--- a/components/frontend/src/lib/query-keys.ts
+++ b/components/frontend/src/lib/query-keys.ts
@@ -16,7 +16,9 @@ export const endpointKeys = {
   trending: (limit: number) => [...endpointKeys.all, 'trending', limit] as const,
   count: () => [...endpointKeys.all, 'count'] as const,
   byPath: (path: string) => [...endpointKeys.all, 'byPath', path] as const,
-  byOwner: (owner: string) => [...endpointKeys.all, 'byOwner', owner] as const
+  byOwner: (owner: string) => [...endpointKeys.all, 'byOwner', owner] as const,
+  uptime: (owner: string, slug: string, windowHours: number) =>
+    [...endpointKeys.all, 'uptime', owner, slug, windowHours] as const
 };
 
 export const userKeys = {

--- a/components/frontend/src/lib/uptime.ts
+++ b/components/frontend/src/lib/uptime.ts
@@ -1,0 +1,232 @@
+/**
+ * Pure utilities for the endpoint uptime tab.
+ *
+ * The backend exposes 30-minute buckets via
+ * GET /api/v1/endpoints/{owner}/{slug}/uptime?window_hours=720, where each
+ * bucket aggregates the health monitor's per-cycle decisions. These helpers
+ * roll the bucket array up into day-level cells for the strip chart and
+ * compute window-wide summary stats.
+ *
+ * All functions are pure so the math can be unit-tested without rendering.
+ */
+
+export interface UptimeBucket {
+  /** ISO timestamp marking the start of the 30-min bucket. */
+  bucket_start: string;
+  /** Number of monitor cycles recorded in this bucket. */
+  samples: number;
+  /** Number of those cycles in which the endpoint was healthy. */
+  healthy_samples: number;
+  /** healthy_samples / samples * 100. */
+  uptime_pct: number;
+}
+
+export interface EndpointUptimeResponse {
+  endpoint_id: number;
+  owner_username: string;
+  slug: string;
+  /** Bucket size in seconds (default 1800 = 30 min). */
+  bucket_seconds: number;
+  /** Window covered by the response. */
+  window_hours: number;
+  buckets: UptimeBucket[];
+}
+
+export type DayStatus = 'operational' | 'degraded' | 'down' | 'no-data';
+
+export interface DayCell {
+  /** UTC midnight for this day. */
+  date: Date;
+  /** YYYY-MM-DD key (UTC). */
+  dateKey: string;
+  samples: number;
+  healthy_samples: number;
+  /** Sum of `bucket_seconds * (samples - healthy_samples) / samples` across the day. */
+  downtime_seconds: number;
+  /** mean uptime % across the day, or null if no samples. */
+  mean_uptime_pct: number | null;
+  /** Worst (lowest) uptime % observed in any bucket of the day. */
+  min_uptime_pct: number | null;
+  /** Number of distinct unhealthy incidents in the day (see countIncidents). */
+  incident_count: number;
+  status: DayStatus;
+}
+
+export interface UptimeSummary {
+  uptime_pct: number | null;
+  downtime_seconds: number;
+  incident_count: number;
+  total_samples: number;
+  total_healthy: number;
+}
+
+/**
+ * A bucket is "unhealthy enough to count as an incident" when its uptime
+ * dipped below 90%. Chosen to match the strip's red threshold so the
+ * incident count visibly tracks what the user sees.
+ */
+const INCIDENT_THRESHOLD_PCT = 90;
+
+export function utcDateKey(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function utcMidnight(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+/**
+ * Classify a day cell into one of four visual states based on its worst
+ * (lowest) bucket uptime. Worst-of, not average, because operators care
+ * about whether *anything* went wrong, not the smoothed mean.
+ */
+export function classifyDay(min_uptime_pct: number | null, samples: number): DayStatus {
+  if (samples === 0 || min_uptime_pct === null) return 'no-data';
+  if (min_uptime_pct >= 99) return 'operational';
+  if (min_uptime_pct >= INCIDENT_THRESHOLD_PCT) return 'degraded';
+  return 'down';
+}
+
+/**
+ * Count maximal contiguous runs of buckets that fell below the incident
+ * threshold. A single sub-90% bucket is one incident; consecutive sub-90%
+ * buckets are still one incident.
+ */
+export function countIncidents(buckets: UptimeBucket[]): number {
+  let incidents = 0;
+  let inIncident = false;
+  for (const b of buckets) {
+    if (b.samples === 0) continue;
+    if (b.uptime_pct < INCIDENT_THRESHOLD_PCT) {
+      if (!inIncident) {
+        incidents += 1;
+        inIncident = true;
+      }
+    } else {
+      inIncident = false;
+    }
+  }
+  return incidents;
+}
+
+/**
+ * Group buckets into day cells covering the last `days` days, ending at
+ * `now`. Missing days are filled with no-data cells so the strip always
+ * renders `days` items regardless of how much history exists.
+ */
+export function aggregateByDay(
+  response: EndpointUptimeResponse | null | undefined,
+  days = 30,
+  now: Date = new Date()
+): DayCell[] {
+  const cells: DayCell[] = [];
+
+  const todayMidnight = utcMidnight(now);
+  const dayKeys: string[] = [];
+  for (let index = days - 1; index >= 0; index--) {
+    const d = new Date(todayMidnight);
+    d.setUTCDate(d.getUTCDate() - index);
+    dayKeys.push(utcDateKey(d));
+  }
+
+  const grouped = new Map<string, UptimeBucket[]>();
+  if (response) {
+    for (const b of response.buckets) {
+      const d = new Date(b.bucket_start);
+      const key = utcDateKey(d);
+      const array = grouped.get(key);
+      if (array) array.push(b);
+      else grouped.set(key, [b]);
+    }
+  }
+
+  const bucketSeconds = response?.bucket_seconds ?? 1800;
+
+  for (const key of dayKeys) {
+    const dayBuckets = grouped.get(key) ?? [];
+    const samples = dayBuckets.reduce((s, b) => s + b.samples, 0);
+    const healthy = dayBuckets.reduce((s, b) => s + b.healthy_samples, 0);
+
+    let downtime = 0;
+    let minPct: number | null = null;
+    for (const b of dayBuckets) {
+      if (b.samples === 0) continue;
+      downtime += bucketSeconds * ((b.samples - b.healthy_samples) / b.samples);
+      minPct = minPct === null ? b.uptime_pct : Math.min(minPct, b.uptime_pct);
+    }
+    const meanPct = samples > 0 ? (100 * healthy) / samples : null;
+
+    const parts = key.split('-');
+    const y = Number(parts[0]);
+    const m = Number(parts[1]);
+    const d = Number(parts[2]);
+    cells.push({
+      date: new Date(Date.UTC(y, m - 1, d)),
+      dateKey: key,
+      samples,
+      healthy_samples: healthy,
+      downtime_seconds: downtime,
+      mean_uptime_pct: meanPct,
+      min_uptime_pct: minPct,
+      incident_count: countIncidents(dayBuckets),
+      status: classifyDay(minPct, samples)
+    });
+  }
+
+  return cells;
+}
+
+/**
+ * Compute window-wide summary stats. Returns null uptime_pct when no
+ * samples have been recorded (so the UI can show "—" instead of "NaN%").
+ */
+export function summarize(response: EndpointUptimeResponse | null | undefined): UptimeSummary {
+  if (!response || response.buckets.length === 0) {
+    return {
+      uptime_pct: null,
+      downtime_seconds: 0,
+      incident_count: 0,
+      total_samples: 0,
+      total_healthy: 0
+    };
+  }
+
+  const total_samples = response.buckets.reduce((s, b) => s + b.samples, 0);
+  const total_healthy = response.buckets.reduce((s, b) => s + b.healthy_samples, 0);
+
+  let downtime_seconds = 0;
+  for (const b of response.buckets) {
+    if (b.samples === 0) continue;
+    downtime_seconds += response.bucket_seconds * ((b.samples - b.healthy_samples) / b.samples);
+  }
+
+  return {
+    uptime_pct: total_samples > 0 ? (100 * total_healthy) / total_samples : null,
+    downtime_seconds,
+    incident_count: countIncidents(response.buckets),
+    total_samples,
+    total_healthy
+  };
+}
+
+/**
+ * Compact human duration: "4h 12m", "37m", "12s", "0s".
+ *
+ * Drops smaller units when larger ones dominate. Designed for stat cards
+ * where the value should read at a glance, not for precise timestamps.
+ */
+export function formatDuration(seconds: number): string {
+  const total = Math.max(0, Math.round(seconds));
+  if (total === 0) return '0s';
+  if (total < 60) return `${total}s`;
+
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+
+  if (hours === 0) return `${minutes}m`;
+  if (minutes === 0) return `${hours}h`;
+  return `${hours}h ${minutes}m`;
+}


### PR DESCRIPTION
## Summary

Splits the public endpoint detail page (`/{owner}/{slug}`) into two tabs. Existing content lives unchanged inside an **Overview** tab; a new **Uptime** tab visualises 30 days of bucketed health-monitor samples via the `GET /api/v1/endpoints/{owner}/{slug}/uptime?window_hours=720` endpoint that landed in #411 / #413.

![Tabs render](https://user-images.githubusercontent.com/placeholder)

## UX choices

| Decision | Why |
|---|---|
| Tab strip lives at the bottom of the existing sticky header band, underline-style triggers | One sticky surface (no header-height measurement). Underline matches GitHub / Vercel / Linear "section nav" semantics rather than "filter pill" semantics. |
| URL tracks active tab via `?tab=uptime` (`useSearchParams`, `replace: true`) | Shareable + refresh-stable. `replace` keeps the back button useful — switching tabs isn't navigation history. Default omits the param so existing shared links are untouched. |
| Lazy-mount the Uptime tab on first activation | Users who never click it pay nothing for the extra fetch. React Query keeps it cached after first open so toggling is instant. |

## Uptime visualisation

- **30 daily cells** (1440 30-min buckets aggregated to one cell per UTC day). Each cell is colour-coded by the **worst** bucket of the day — operators care about whether anything went wrong, not the smoothed mean.
- **Thresholds match the existing status palette**: `≥99` green, `90–99` yellow, `<90` red, no samples gray.
- **Click/tap a cell** to pin its details in a panel below the strip — same state model on desktop hover and mobile tap.
- **Three summary stats** above the strip:
  - `30-day uptime %` — coloured by the same thresholds
  - `Total downtime` — `Σ bucket_seconds × (samples - healthy) / samples`
  - `Incidents` — count of maximal `<90%` streaks; empty buckets do **not** split a streak (a missing data point is not a recovery)
- **Empty / loading / error states** live inside the same `border-border bg-card rounded-xl` shell as the rest of the page so the page rhythm is preserved.

## Accessibility

- Each day-cell is a `<button>` with a self-contained `aria-label` carrying date, uptime %, downtime, incident count, and sample count. Screen-reader users can arrow through the strip without seeing colour at all.
- Strip uses `role="list"` / `role="listitem"`; colour is never the sole signal (legend + ARIA always accompany it).
- Focus rings work against all four cell colours.
- shadcn `Tabs` (Radix-backed) handles `role="tablist"`, arrow-key nav, and `aria-selected` automatically.

## Tests

23 unit tests against `lib/uptime.ts` cover:
- `classifyDay` thresholds (boundary tests for 99 / 90 / 0 samples / null)
- `countIncidents` — single dips, consecutive-bucket collapsing, separated incidents, and the "empty bucket does not split a streak" invariant
- `aggregateByDay` — exactly N cells returned, missing days filled with no-data, UTC grouping, worst-bucket classification
- `summarize` — null on empty input, correct uptime % and downtime math
- `formatDuration` — 0, seconds, minutes-floor behaviour, hours-only, combined, negative clamp
- `utcDateKey` — UTC midnight semantics

## Verification

- [x] `npm run typecheck` — clean on the touched files
- [x] `npm run lint` — zero errors on touched files (pre-existing warnings on unrelated files left alone)
- [x] `npm run test:unit src/lib/__tests__/uptime.test.ts` — 23/23 pass
- [ ] Manual smoke: visit `/afdolriski/tempo-plus`, switch to the Uptime tab, confirm strip + stats render with real prod data; verify `?tab=uptime` deep-link works on refresh
- [ ] Manual smoke: hit an endpoint with `<30` days of data — confirm gray "no data" cells on the left and coloured cells on the right
- [ ] Manual smoke: hit a brand-new endpoint with zero buckets — confirm the empty state card shows

## File map

```
components/frontend/src/
├── components/endpoint/
│   ├── endpoint-detail.tsx          ← wrap render in <Tabs>, URL state, lazy mount
│   ├── uptime-tab.tsx               ← orchestrator (loading / error / empty / data)
│   ├── uptime-summary-card.tsx      ← 3 stats grid
│   └── uptime-strip.tsx             ← 30 day-cells + selected-day panel + legend
├── hooks/
│   └── use-endpoint-uptime.ts       ← React Query wrapper
├── lib/
│   ├── uptime.ts                    ← pure utilities (no React)
│   ├── query-keys.ts                ← add endpointKeys.uptime(...)
│   └── __tests__/uptime.test.ts     ← 23 unit tests
```