### PR TITLE
fix(uptime): allow window_hours up to 90 days, matching retention

### DIFF
--- a/components/backend/src/syfthub/api/endpoints/endpoints.py
+++ b/components/backend/src/syfthub/api/endpoints/endpoints.py
@@ -517,8 +517,11 @@ async def get_endpoint_uptime(
     window_hours: int = Query(
         24,
         ge=1,
-        le=168,
-        description="Rolling time window (max 7 days)",
+        le=2160,
+        description=(
+            "Rolling time window in hours. Max 2160 (90 days), matching "
+            "``settings.uptime_retention_days``."
+        ),
     ),
 ) -> EndpointUptimeResponse:
     """Get bucketed uptime + latency time series for one endpoint."""

--- a/components/backend/src/syfthub/services/endpoint_service.py
+++ b/components/backend/src/syfthub/services/endpoint_service.py
@@ -1547,7 +1547,7 @@ class EndpointService(BaseService):
         Args:
             owner_username: User username or org slug
             slug: Endpoint slug
-            window_hours: Rolling window in hours (1..168 enforced at route)
+            window_hours: Rolling window in hours (1..2160 enforced at route)
             current_user: Authenticated viewer (optional for public reads)
 
         Returns:

--- a/components/backend/tests/test_endpoints.py
+++ b/components/backend/tests/test_endpoints.py
@@ -2370,3 +2370,39 @@ def test_remove_xendit_policy_does_not_remove_tag(
     assert response.status_code == 200
     # Tag should still be present (not auto-removed)
     assert "prepaid" in response.json()["tags"]
+
+
+# ---------------------------------------------------------------------------
+# GET /endpoints/{owner}/{slug}/uptime — window_hours boundary
+# ---------------------------------------------------------------------------
+#
+# The route uses Pydantic's Query(le=...) validation, so the validator runs
+# before the endpoint-lookup branch. A non-existent owner/slug means a valid
+# query returns 404 while an invalid query returns 422 — which lets us pin
+# the boundary without seeding endpoint data.
+
+
+def test_uptime_accepts_window_up_to_90_days(client: TestClient) -> None:
+    """30-day (720h) and 90-day (2160h) queries must clear the validator.
+
+    Regression: the original validator capped window_hours at 168h while the
+    frontend asked for 720h, so every Uptime tab on prod 422'd.
+    """
+    for hours in (720, 2160):
+        response = client.get(
+            f"/api/v1/endpoints/ghost/missing/uptime?window_hours={hours}"
+        )
+        assert response.status_code == 404, (
+            f"window_hours={hours} should clear validation and 404 on "
+            f"missing endpoint, got {response.status_code}: {response.text}"
+        )
+
+
+def test_uptime_rejects_window_over_cap(client: TestClient) -> None:
+    """Beyond the 90-day retention there is no data, so the cap holds."""
+    response = client.get("/api/v1/endpoints/ghost/missing/uptime?window_hours=2161")
+    assert response.status_code == 422
+    body = response.json()
+    assert any(
+        "window_hours" in (err.get("loc") or []) for err in body.get("detail", [])
+    ), body


### PR DESCRIPTION
## Why

The Uptime tab (#414) defaults to \`window_hours=720\` (30 days), but the backend route (#411) capped \`window_hours\` at 168 (7 days). Every request from the Uptime tab on prod 422'd:

\`\`\`
{
  \"detail\": [
    {\"type\": \"less_than_equal\", \"loc\": [\"query\", \"window_hours\"],
     \"msg\": \"Input should be less than or equal to 168\", \"input\": \"720\"}
  ]
}
\`\`\`

User-visible: \"Couldn't load uptime · Uptime fetch failed: 422\".

## What

Bump the cap from 168 to **2160 hours (90 days)**, which matches \`settings.uptime_retention_days\`. The default stays at 24h so callers asking for shorter windows are unchanged. Anything beyond 90 days has been purged by the retention sweep anyway, so 2160 is the largest window with real data behind it.

## Tests

Two new route-level boundary tests in \`test_endpoints.py\`:
- \`test_uptime_accepts_window_up_to_90_days\` — \`window_hours=720\` and \`2160\` clear the validator and reach the lookup branch (\`404\` on a non-existent endpoint)
- \`test_uptime_rejects_window_over_cap\` — \`window_hours=2161\` returns \`422\` citing \`window_hours\`

The tests use a non-existent owner/slug so they don't need to seed endpoint data; the validator runs before the lookup, so a passing validator → 404 and a failing one → 422.

## Verification

- [x] \`uv run pytest tests/\` — 1344 pass (+2 new)
- [x] Coverage 80.46% (above the 80% gate)
- [x] \`ruff check\` / \`ruff format --check\` / \`mypy\` clean via pre-commit
- [ ] Post-merge: hit \`https://syfthub.openmined.org/api/v1/endpoints/afdolriski/tempo-plus/uptime?window_hours=720\` and confirm \`200\`
- [ ] Post-merge: Uptime tab on the public endpoint detail page renders the 30-day strip