### PR TITLE
chore(deps): bump Mako to 1.3.12 and urllib3 to 2.7.0

### DIFF
--- a/components/aggregator/pyproject.toml
+++ b/components/aggregator/pyproject.toml
@@ -127,6 +127,7 @@ ignore_missing_imports = true
 # fastembed uses only basic Pillow image I/O; the major-version cap is overly conservative.
 override-dependencies = [
     "pillow>=12.1.1",
-    "mako>=1.3.11",  # CVE-2025-68735: path traversal via double-slash URI in TemplateLookup (transitive via alembic)
+    "mako>=1.3.12",  # CVE-2025-68735 + path traversal via backslash URI on Windows in TemplateLookup (transitive via alembic)
     "Pygments>=2.20.0",  # CVE-2025-68139: ReDoS via inefficient regex for GUID matching (transitive via pytest)
+    "urllib3>=2.7.0",  # GHSA-pq67-6m6q-mj2v: sensitive headers forwarded on cross-origin redirects; CVE-2026-21441: decompression bomb (transitive via requests/google-auth)
 ]

--- a/components/aggregator/uv.lock
+++ b/components/aggregator/uv.lock
@@ -18,9 +18,10 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "mako", specifier = ">=1.3.11" },
+    { name = "mako", specifier = ">=1.3.12" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pygments", specifier = ">=2.20.0" },
+    { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
 [[package]]
@@ -1322,14 +1323,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.11"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]
@@ -3303,11 +3304,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/components/backend/pyproject.toml
+++ b/components/backend/pyproject.toml
@@ -259,6 +259,7 @@ dev = [
 override-dependencies = [
     # Security overrides - force minimum secure versions even when transitive deps pin older versions
     "pyasn1>=0.6.3",  # CVE-2026-30922: DoS via unbounded recursion (transitive via google-auth)
-    "mako>=1.3.11",  # CVE-2025-68735: path traversal via double-slash URI in TemplateLookup (transitive via alembic)
+    "mako>=1.3.12",  # CVE-2025-68735 + path traversal via backslash URI on Windows in TemplateLookup (transitive via alembic)
     "Pygments>=2.20.0",  # CVE-2025-68139: ReDoS via inefficient regex for GUID matching (transitive via pytest)
+    "urllib3>=2.7.0",  # GHSA-pq67-6m6q-mj2v: sensitive headers forwarded on cross-origin redirects; CVE-2026-21441: decompression bomb (transitive via requests/google-auth)
 ]

--- a/components/backend/requirements.txt
+++ b/components/backend/requirements.txt
@@ -132,7 +132,7 @@ idna==3.11
     #   yarl
 jinja2==3.1.6
     # via syfthub (pyproject.toml)
-mako==1.3.11
+mako==1.3.12
     # via
     #   --override (workspace)
     #   alembic
@@ -246,8 +246,9 @@ typing-inspection==0.4.2
     # via
     #   pydantic
     #   pydantic-settings
-urllib3==2.6.3
+urllib3==2.7.0
     # via
+    #   --override (workspace)
     #   google-auth
     #   requests
     #   types-requests

--- a/components/backend/uv.lock
+++ b/components/backend/uv.lock
@@ -8,9 +8,10 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "mako", specifier = ">=1.3.11" },
+    { name = "mako", specifier = ">=1.3.12" },
     { name = "pyasn1", specifier = ">=0.6.3" },
     { name = "pygments", specifier = ">=2.20.0" },
+    { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
 [[package]]
@@ -1315,14 +1316,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.11"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]
@@ -2572,11 +2573,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/components/mcp/pyproject.toml
+++ b/components/mcp/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "requests>=2.32.4",  # CVE-2024-47081: .netrc credentials leak
     "httpx>=0.27.0",
     "aiohttp>=3.13.3",  # CVE-2025-69223 and related DoS vulnerabilities
-    "urllib3>=2.6.3",  # CVE-2025-66471, CVE-2026-21441: decompression bomb
+    "urllib3>=2.7.0",  # CVE-2025-66471, CVE-2026-21441: decompression bomb; GHSA-pq67-6m6q-mj2v: sensitive headers forwarded on cross-origin redirects
     # Web framework dependencies with security fixes
     "starlette>=0.49.1",  # CVE-2025-62727: O(n^2) DoS via Range header
     "werkzeug>=3.1.6",  # CVE-2025-66221, CVE-2026-21860, CVE-2026-27199: Windows device names
@@ -45,7 +45,7 @@ override-dependencies = [
     # No upstream fix is available. The cache directory is hardened in Dockerfile (chmod 700, owned by
     # syfthub user only). Monitor https://github.com/grantjenks/python-diskcache for a patched release.
     "requests>=2.32.4",  # CVE-2024-47081: syft-accounting-sdk pins 2.32.3
-    "urllib3>=2.6.3",  # CVE-2025-66471, CVE-2026-21441
+    "urllib3>=2.7.0",  # CVE-2025-66471, CVE-2026-21441, GHSA-pq67-6m6q-mj2v
     "starlette>=0.49.1",  # CVE-2025-62727
     "werkzeug>=3.1.6",  # CVE-2025-66221, CVE-2026-21860, CVE-2026-27199
     "authlib>=1.6.11",  # CVE-2025-68158, CVE-2026-27962, CVE-2026-28490, CVE-2026-28498, CVE-2026-28802

--- a/components/mcp/uv.lock
+++ b/components/mcp/uv.lock
@@ -12,7 +12,7 @@ overrides = [
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "starlette", specifier = ">=0.49.1" },
-    { name = "urllib3", specifier = ">=2.6.3" },
+    { name = "urllib3", specifier = ">=2.7.0" },
     { name = "werkzeug", specifier = ">=3.1.6" },
 ]
 
@@ -1624,7 +1624,7 @@ requires-dist = [
     { name = "starlette", specifier = ">=0.49.1" },
     { name = "syft-accounting-sdk", git = "https://github.com/OpenMined/accounting-sdk.git" },
     { name = "syfthub-sdk", editable = "../../sdk/python" },
-    { name = "urllib3", specifier = ">=2.6.3" },
+    { name = "urllib3", specifier = ">=2.7.0" },
     { name = "werkzeug", specifier = ">=3.1.6" },
 ]
 
@@ -1683,11 +1683,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Resolves the actionable open Dependabot alerts on this repo. Alert #55 (diskcache) has no upstream patch and is intentionally left open until grantjenks/python-diskcache ships a fix.

- **Mako 1.3.11 → 1.3.12** (alerts #174–#176, high) — fixes path traversal via backslash URI on Windows in `TemplateLookup`. Bumped across `components/backend` and `components/aggregator` (transitive via alembic), plus `components/backend/requirements.txt`.
- **urllib3 2.6.3 → 2.7.0** (high) — fixes [GHSA-pq67-6m6q-mj2v](https://github.com/advisories/GHSA-pq67-6m6q-mj2v) (sensitive headers forwarded across origins in proxied low-level redirects) and the decompression-bomb safeguard bypass. Bumped across `components/backend`, `components/aggregator`, and `components/mcp`.
- **diskcache ≤ 5.6.3** (alert #55, medium) — **intentionally not changed.** No upstream patch is available. The existing `pyproject.toml` comments in `components/aggregator` already document this and the Dockerfile-side hardening (chmod 700, owned by app user). Will resolve automatically when a patched release ships.

## Changes
- `components/{backend,aggregator}/pyproject.toml`: explicit `urllib3>=2.7.0` and `mako>=1.3.12` overrides in `[tool.uv]` (both transitive via `requests`/`google-auth` and `alembic`).
- `components/mcp/pyproject.toml`: direct dep and override bumped to `urllib3>=2.7.0`.
- All three `uv.lock` files regenerated.
- `components/backend/requirements.txt` regenerated via `uv pip compile pyproject.toml`.

## Test plan
- [ ] CI passes (lint, type-check, tests across backend / aggregator / mcp).
- [ ] Dependabot closes alerts #174–#176 after merge.
- [ ] `pip install -r components/backend/requirements.txt` resolves cleanly.