### PR TITLE
fix(frontend): derive endpoint status from connection reachability

### DIFF
--- a/components/frontend/src/components/endpoint/endpoint-detail.tsx
+++ b/components/frontend/src/components/endpoint/endpoint-detail.tsx
@@ -33,62 +33,21 @@ function parseTab(raw: string | null): EndpointTabId {
 const TAB_TRIGGER_CLASS =
   'font-inter focus-visible:ring-ring data-[state=active]:border-primary data-[state=active]:text-foreground text-muted-foreground hover:text-foreground relative inline-flex h-12 items-center justify-center rounded-none border-b-2 border-transparent bg-transparent px-4 text-sm font-medium shadow-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-0 data-[state=active]:shadow-none';
 
-type EndpointStatus = 'active' | 'warning' | 'inactive';
+type EndpointStatus = 'active' | 'inactive';
 
-// Helper functions moved outside component for consistent-function-scoping
 function getStatusBadgeColor(status: EndpointStatus) {
-  switch (status) {
-    case 'active': {
-      return 'bg-green-100 text-green-800 border-green-200 hover:bg-green-200';
-    }
-    case 'warning': {
-      return 'bg-yellow-100 text-yellow-800 border-yellow-200 hover:bg-yellow-200';
-    }
-    case 'inactive': {
-      return 'bg-red-100 text-red-800 border-red-200 hover:bg-red-200';
-    }
-    default: {
-      return 'bg-muted text-foreground border-border';
-    }
-  }
+  return status === 'active'
+    ? 'bg-green-100 text-green-800 border-green-200 hover:bg-green-200'
+    : 'bg-muted text-muted-foreground border-border';
 }
 
 function getStatusDotColor(status: EndpointStatus) {
-  switch (status) {
-    case 'active': {
-      return 'bg-green-500';
-    }
-    case 'warning': {
-      return 'bg-yellow-500';
-    }
-    case 'inactive': {
-      return 'bg-red-500';
-    }
-    default: {
-      return 'bg-muted-foreground';
-    }
-  }
+  return status === 'active' ? 'bg-green-500' : 'bg-muted-foreground';
 }
 
 function getStatusLabel(status: EndpointStatus) {
-  switch (status) {
-    case 'active': {
-      return 'Active';
-    }
-    case 'warning': {
-      return 'Needs Update';
-    }
-    case 'inactive': {
-      return 'Inactive';
-    }
-    default: {
-      return status;
-    }
-  }
+  return status === 'active' ? 'Active' : 'Inactive';
 }
-
-// getTypeStyles and getTypeLabel are now centralized in @/lib/endpoint-utils
-// as getEndpointTypeBadgeStyles and getEndpointTypeLabel respectively.
 
 // Skeleton loading state that mirrors the real page layout
 function EndpointDetailSkeleton() {

--- a/components/frontend/src/lib/__tests__/endpoint-utils.test.ts
+++ b/components/frontend/src/lib/__tests__/endpoint-utils.test.ts
@@ -237,9 +237,16 @@ describe('mapEndpointPublicToSource', () => {
       tags: ['ai'],
       starsCount: 5,
       policies: [],
-      connect: [],
+      connect: [
+        {
+          type: 'http',
+          enabled: true,
+          description: 'HTTP',
+          config: { url: 'https://example.com/api', tenant_name: 't' }
+        }
+      ],
       createdAt: new Date('2024-01-01T00:00:00Z'),
-      updatedAt: new Date('2024-01-14T00:00:00Z') // 1 day ago
+      updatedAt: new Date('2024-01-14T00:00:00Z')
     };
 
     const result = mapEndpointPublicToSource(endpoint as never);
@@ -251,10 +258,10 @@ describe('mapEndpointPublicToSource', () => {
     expect(result.tags).toEqual(['ai']);
   });
 
-  it('sets warning status for endpoints older than 7 days', () => {
+  it('sets inactive status when all connections are disabled', () => {
     const endpoint = {
-      name: 'Old',
-      slug: 'old',
+      name: 'Disabled',
+      slug: 'disabled',
       description: '',
       type: 'model' as const,
       ownerUsername: 'bob',
@@ -264,19 +271,26 @@ describe('mapEndpointPublicToSource', () => {
       tags: [],
       starsCount: 0,
       policies: [],
-      connect: [],
-      createdAt: new Date('2023-12-01T00:00:00Z'),
-      updatedAt: new Date('2024-01-01T00:00:00Z') // 14 days ago
+      connect: [
+        {
+          type: 'http',
+          enabled: false,
+          description: 'HTTP',
+          config: { url: 'https://example.com/api', tenant_name: 't' }
+        }
+      ],
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      updatedAt: new Date('2024-01-14T00:00:00Z')
     };
 
     const result = mapEndpointPublicToSource(endpoint as never);
-    expect(result.status).toBe('warning');
+    expect(result.status).toBe('inactive');
   });
 
-  it('sets inactive status for endpoints older than 30 days', () => {
+  it('sets inactive status when there are no connections', () => {
     const endpoint = {
-      name: 'Very Old',
-      slug: 'very-old',
+      name: 'No Connect',
+      slug: 'no-connect',
       description: '',
       type: 'model' as const,
       ownerUsername: 'carol',
@@ -287,8 +301,8 @@ describe('mapEndpointPublicToSource', () => {
       starsCount: 0,
       policies: [],
       connect: [],
-      createdAt: new Date('2023-06-01T00:00:00Z'),
-      updatedAt: new Date('2023-11-01T00:00:00Z') // > 30 days ago
+      createdAt: new Date('2024-01-14T00:00:00Z'),
+      updatedAt: new Date('2024-01-14T00:00:00Z')
     };
 
     const result = mapEndpointPublicToSource(endpoint as never);

--- a/components/frontend/src/lib/endpoint-utils.ts
+++ b/components/frontend/src/lib/endpoint-utils.ts
@@ -193,13 +193,9 @@ export function mapEndpointPublicToSource(endpoint: SdkEndpointPublic): ChatSour
   // Get policies for mapping
   const policies = endpoint.policies;
 
-  // Determine status based on updated time
   const updatedDate = endpoint.updatedAt;
-  const daysSinceUpdate = Math.floor((Date.now() - updatedDate.getTime()) / (1000 * 60 * 60 * 24));
 
-  let status: 'active' | 'warning' | 'inactive' = 'active';
-  if (daysSinceUpdate > 7) status = 'warning';
-  if (daysSinceUpdate > 30) status = 'inactive';
+  const status = endpoint.connect.some((c) => c.enabled) ? 'active' : 'inactive';
 
   const ownerUsername = endpoint.ownerUsername;
   const fullPath = `${ownerUsername}/${endpoint.slug}`;

--- a/components/frontend/src/lib/types.ts
+++ b/components/frontend/src/lib/types.ts
@@ -289,7 +289,7 @@ export interface ChatSource {
   type: EndpointType; // Endpoint type (model or data_source)
   updated: string; // Pre-formatted relative time, e.g. "2 days ago" (mapped from updated_at)
   updated_at: string; // Raw ISO 8601 timestamp — use this for sorting/comparisons
-  status: 'active' | 'warning' | 'inactive'; // Derived from backend data
+  status: 'active' | 'inactive'; // Active iff the endpoint has at least one enabled connection (reachable)
   slug: string; // Backend URL identifier
   stars_count: number;
   version: string;


### PR DESCRIPTION
## Summary
- Endpoint status now reflects reachability: `active` iff at least one connection is enabled, else `inactive`. Replaces the prior heuristic that flipped to `warning`/`inactive` based on days since `updatedAt`, which was unrelated to whether the endpoint actually works.
- Drops the `warning` state from `ChatSource.status`, the `EndpointStatus` union, and the corresponding badge/dot/label branches in `endpoint-detail.tsx`.

## Test plan
- [ ] Endpoint with all connections disabled shows the muted "Inactive" badge.
- [ ] Endpoint with at least one enabled connection shows the green "Active" badge.
- [ ] No remaining references to the `warning` status anywhere in the frontend.
