### PR TITLE
ci: notify syft-space-hub-docs on PR merge to main

### DIFF
--- a/.github/workflows/notify-docs-on-pr-merge.yml
+++ b/.github/workflows/notify-docs-on-pr-merge.yml
@@ -1,0 +1,35 @@
+# Creates a draft issue in OpenMined/syft-space-hub-docs whenever a PR is merged into main.
+#
+# Required secret:
+#   DOCS_REPO_PAT — GitHub Personal Access Token (classic) with `repo` scope,
+#                   belonging to a user with write access to OpenMined/syft-space-hub-docs.
+
+name: Notify Docs on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create draft issue in syft-space-hub-docs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.DOCS_REPO_PAT }}
+          script: |
+            const pr = context.payload.pull_request;
+            const sourceRepo = context.repo.repo;
+
+            await github.rest.issues.create({
+              owner: 'OpenMined',
+              repo: 'syft-space-hub-docs',
+              title: `[DRAFT] Update documentation to match changes in ${sourceRepo} PR #${pr.number}`,
+              body: `## Documentation Update Required\n\nA PR was merged into \`${sourceRepo}\` that may require documentation updates.\n\n**Source PR:** ${pr.html_url}\n**Title:** ${pr.title}\n**Merged by:** @${pr.merged_by.login}\n\n---\n_This issue was automatically created by GitHub Actions._`,
+              assignees: ['callezenwaka'],
+            });


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that creates a draft issue in [`OpenMined/syft-space-hub-docs`](https://github.com/OpenMined/syft-space-hub-docs) whenever a PR is merged into `main`, so docs updates can be tracked alongside code changes.

The new issue is assigned to `@callezenwaka` (Callis) and titled `[DRAFT] Update documentation to match changes in <repo> PR #<n>`, with a link back to the source PR.

Refs: [OME-259](https://linear.app/openmined/issue/OME-259/github-actions-for-docs)

## Required setup before this workflow can run

A repository secret named `DOCS_REPO_PAT` must be configured:

- **Type:** Personal Access Token (classic)
- **Scope:** `repo`
- **Owner:** a user with write access to `OpenMined/syft-space-hub-docs`

Generate via: `github.com → Settings → Developer settings → Personal access tokens → Tokens (classic) → Generate new token (classic)`, then add it under `Settings → Secrets and variables → Actions → New repository secret`.

> Note: an equivalent workflow should also be added to `OpenMined/syft-space` (separate PR).

## Test plan

- [ ] Repo admin adds the `DOCS_REPO_PAT` secret
- [ ] Merge a small PR into `main` and verify a draft issue appears in `syft-space-hub-docs` assigned to `@callezenwaka`
- [ ] Confirm the issue body contains the source PR URL, title, and merger