### PR TITLE
feat(policies): support per-unit billing (request|document) from config

### DIFF
--- a/components/backend/tests/test_endpoints.py
+++ b/components/backend/tests/test_endpoints.py
@@ -1380,6 +1380,29 @@ _XENDIT_POLICY_MINIMAL = {
     },
 }
 
+# New Syft Space wire shape: generic `price` + `unit_type` instead of
+# `price_per_request`. Frontend parsers fall back to the legacy keys, so the
+# old fixture above still exercises the backwards-compat path.
+_XENDIT_POLICY_PER_DOCUMENT = {
+    "type": "xendit",
+    "version": "1.0",
+    "enabled": True,
+    "description": "Document-billed Xendit policy",
+    "config": {
+        "price": 5.0,
+        "unit_type": "document",
+        "currency": "IDR",
+        "country": "ID",
+        "applied_to": ["*"],
+        "bundles": [
+            {"name": "Starter", "amount": 10000.0},
+            {"name": "Pro", "amount": 100000.0},
+        ],
+        "payment_url": "https://my-server.example.com/api/v1/payments/gateway/xendit/invoices",
+        "credits_url": "https://my-server.example.com/api/v1/payments/gateway/bundles/test-endpoint",
+    },
+}
+
 
 def test_xendit_policy_auto_injects_prepaid_tag_on_create(
     client: TestClient, user1_token: str
@@ -1508,6 +1531,32 @@ def test_create_endpoint_with_xendit_policy(
         == "https://my-server.example.com/api/v1/payments/gateway/bundles/test-endpoint"
     )
     assert "prepaid" in data["tags"]
+
+
+def test_create_endpoint_with_xendit_per_document_policy(
+    client: TestClient, user1_token: str
+) -> None:
+    """New wire shape (price + unit_type=document) round-trips and still
+    auto-injects the prepaid tag — gateway is keyed on type, unit lives in config."""
+    headers = {"Authorization": f"Bearer {user1_token}"}
+
+    endpoint_data = {
+        "name": "Xendit Per-Document Endpoint",
+        "type": "model",
+        "visibility": "public",
+        "policies": [_XENDIT_POLICY_PER_DOCUMENT],
+    }
+
+    response = client.post("/api/v1/endpoints", json=endpoint_data, headers=headers)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert "prepaid" in data["tags"]
+    policy = data["policies"][0]
+    assert policy["type"] == "xendit"
+    assert policy["config"]["price"] == 5.0
+    assert policy["config"]["unit_type"] == "document"
+    assert policy["config"]["currency"] == "IDR"
 
 
 def test_create_endpoint_with_connections(client: TestClient, user1_token: str) -> None:

--- a/components/frontend/src/components/chat/payment-gate.tsx
+++ b/components/frontend/src/components/chat/payment-gate.tsx
@@ -31,7 +31,8 @@ import {
   fetchBalance,
   getSatelliteToken,
   openCheckoutWindow,
-  POLL_INTERVAL_MS
+  POLL_INTERVAL_MS,
+  UNIT_LABEL
 } from '@/lib/xendit-client';
 
 function distinctOwners(pending: PendingSubscription[]): string[] {
@@ -69,12 +70,13 @@ function renderStatusLine(pending: PendingSubscription, isActive: boolean, liveB
       </span>
     );
   }
-  if (pending.pricePerRequest === null) {
+  if (pending.pricePerUnit === null) {
     return <>Prepaid credits required</>;
   }
   return (
     <span className='tabular-nums'>
-      {pending.currency} {pending.pricePerRequest.toLocaleString()} per request
+      {pending.currency} {pending.pricePerUnit.toLocaleString()} per{' '}
+      {UNIT_LABEL[pending.unit].singular}
     </span>
   );
 }
@@ -103,11 +105,12 @@ function MppPaymentGateRow({ pending, onRemove }: Readonly<MppRowProperties>) {
               <span className='text-muted-foreground text-[11px]'>· {roleLabel}</span>
             </div>
             <div className='text-muted-foreground mt-0.5 text-[11px]'>
-              {pending.pricePerRequest === null ? (
+              {pending.pricePerUnit === null ? (
                 <>MPP credits required</>
               ) : (
                 <span className='tabular-nums'>
-                  {pending.currency} {pending.pricePerRequest.toLocaleString()} per request (MPP)
+                  {pending.currency} {pending.pricePerUnit.toLocaleString()} per{' '}
+                  {UNIT_LABEL[pending.unit].singular} (MPP)
                 </span>
               )}
             </div>
@@ -257,7 +260,8 @@ function PaymentGateRow({ pending, liveBalance, isActive, onRemove }: Readonly<R
                 onChange={setSelectedBundleName}
                 disabled={isBusy}
                 triggerClassName='h-8 min-w-[7rem]'
-                pricePerRequest={pending.pricePerRequest}
+                pricePerUnit={pending.pricePerUnit}
+                unit={pending.unit}
               />
               <button
                 type='button'
@@ -359,7 +363,7 @@ export function PaymentGate({
       // mpp has no payment flow yet — these rows can never become active.
       if (p.policyType === 'mpp') return false;
       const balance = balances[p.walletKey] ?? 0;
-      const threshold = p.pricePerRequest ?? 1;
+      const threshold = p.pricePerUnit ?? 1;
       return balance >= threshold;
     },
     [balances]

--- a/components/frontend/src/components/endpoint/bundle-picker.tsx
+++ b/components/frontend/src/components/endpoint/bundle-picker.tsx
@@ -2,7 +2,7 @@
  * Violet-themed bundle dropdown shared by the Xendit-policy sidebar card
  * and the chat-flow subscription gate modal.
  */
-import type { MoneyBundle } from '@/lib/xendit-client';
+import type { MoneyBundle, PolicyUnit } from '@/lib/xendit-client';
 
 import {
   Select,
@@ -12,7 +12,7 @@ import {
   SelectValue
 } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
-import { formatRequestEstimate } from '@/lib/xendit-client';
+import { formatUnitEstimate } from '@/lib/xendit-client';
 
 export interface BundlePickerProperties {
   bundles: MoneyBundle[];
@@ -21,21 +21,24 @@ export interface BundlePickerProperties {
   onChange: (name: string) => void;
   disabled?: boolean;
   triggerClassName?: string;
-  /** When set (>0), each option shows an estimated request count. */
-  pricePerRequest?: number | null;
+  /** When set (>0), each option shows an estimated unit count. */
+  pricePerUnit?: number | null;
+  /** Billing unit driven by policy.config.unit_type; defaults to request. */
+  unit?: PolicyUnit;
 }
 
-function RequestEstimate({
+function UnitEstimate({
   amount,
-  pricePerRequest
-}: Readonly<{ amount: number; pricePerRequest: number }>) {
+  pricePerUnit,
+  unit
+}: Readonly<{ amount: number; pricePerUnit: number; unit: PolicyUnit }>) {
   return (
     <>
       <span className='opacity-40' aria-hidden='true'>
         ·
       </span>
       <span className='text-[11px] font-normal opacity-75'>
-        {formatRequestEstimate(amount, pricePerRequest)}
+        {formatUnitEstimate(amount, pricePerUnit, unit)}
       </span>
     </>
   );
@@ -48,12 +51,13 @@ export function BundlePicker({
   onChange,
   disabled,
   triggerClassName,
-  pricePerRequest
+  pricePerUnit,
+  unit = 'request'
 }: Readonly<BundlePickerProperties>) {
   const selected = bundles.find((b) => b.name === value) ?? bundles[0];
   if (!selected) return null;
 
-  const showRequestEstimate = typeof pricePerRequest === 'number' && pricePerRequest > 0;
+  const showUnitEstimate = typeof pricePerUnit === 'number' && pricePerUnit > 0;
 
   return (
     <Select value={value} onValueChange={onChange} disabled={disabled}>
@@ -71,8 +75,8 @@ export function BundlePicker({
             <span className='font-medium tabular-nums'>
               {currency} {selected.amount.toLocaleString()}
             </span>
-            {showRequestEstimate && (
-              <RequestEstimate amount={selected.amount} pricePerRequest={pricePerRequest} />
+            {showUnitEstimate && (
+              <UnitEstimate amount={selected.amount} pricePerUnit={pricePerUnit} unit={unit} />
             )}
           </span>
         </SelectValue>
@@ -84,8 +88,8 @@ export function BundlePicker({
               <span className='font-medium tabular-nums'>
                 {currency} {bundle.amount.toLocaleString()}
               </span>
-              {showRequestEstimate && (
-                <RequestEstimate amount={bundle.amount} pricePerRequest={pricePerRequest} />
+              {showUnitEstimate && (
+                <UnitEstimate amount={bundle.amount} pricePerUnit={pricePerUnit} unit={unit} />
               )}
             </span>
           </SelectItem>

--- a/components/frontend/src/components/endpoint/policy-item.tsx
+++ b/components/frontend/src/components/endpoint/policy-item.tsx
@@ -18,7 +18,7 @@ import Zap from 'lucide-react/dist/esm/icons/zap';
 import { Badge } from '@/components/ui/badge';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { cn } from '@/lib/utils';
-import { parseXenditConfig } from '@/lib/xendit-client';
+import { parseXenditConfig, UNIT_LABEL } from '@/lib/xendit-client';
 
 import { GenericPolicyContent } from './generic-policy-content';
 import { formatConfigKey, TransactionPolicyContent } from './transaction-policy-content';
@@ -190,9 +190,9 @@ export const PolicyItem = memo(function PolicyItem({
     () => (isXendit ? parseXenditConfig(policy.config) : null),
     [isXendit, policy.config]
   );
-  const xenditPricePerRequest =
-    xenditParsed && xenditParsed.pricePerRequest !== null && xenditParsed.pricePerRequest > 0
-      ? xenditParsed.pricePerRequest
+  const xenditPricePerUnit =
+    xenditParsed && xenditParsed.pricePerUnit !== null && xenditParsed.pricePerUnit > 0
+      ? xenditParsed.pricePerUnit
       : null;
 
   if (isXendit) {
@@ -255,9 +255,10 @@ export const PolicyItem = memo(function PolicyItem({
               {description && (
                 <p className='text-muted-foreground mt-2 text-xs leading-relaxed'>{description}</p>
               )}
-              {xenditParsed && xenditPricePerRequest !== null && (
+              {xenditParsed && xenditPricePerUnit !== null && (
                 <p className='text-muted-foreground mt-0.5 text-[11px] tabular-nums'>
-                  {xenditParsed.currency} {xenditPricePerRequest.toLocaleString()} per request
+                  {xenditParsed.currency} {xenditPricePerUnit.toLocaleString()} per{' '}
+                  {UNIT_LABEL[xenditParsed.unit].singular}
                 </p>
               )}
 

--- a/components/frontend/src/components/endpoint/xendit-policy-content.tsx
+++ b/components/frontend/src/components/endpoint/xendit-policy-content.tsx
@@ -46,7 +46,7 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
   // Re-parse only when config identity changes — otherwise the bundles array
   // would get a fresh reference each render and re-fire the validation effect.
   const parsed = useMemo(() => parseXenditConfig(config), [config]);
-  const { bundles, currency, paymentUrl, creditsUrl, invoicesUrl, pricePerRequest } = parsed;
+  const { bundles, currency, paymentUrl, creditsUrl, invoicesUrl, pricePerUnit, unit } = parsed;
 
   const [subscription, setSubscription] = useState<SubscriptionState>({ state: 'loading' });
   const [purchase, setPurchase] = useState<PurchaseState>({ state: 'idle' });
@@ -237,7 +237,8 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
             value={selectedBundleName}
             onChange={setSelectedBundleName}
             disabled={isCreatingAny}
-            pricePerRequest={pricePerRequest}
+            pricePerUnit={pricePerUnit}
+            unit={unit}
           />
           <button
             type='button'

--- a/components/frontend/src/hooks/use-xendit-precheck.ts
+++ b/components/frontend/src/hooks/use-xendit-precheck.ts
@@ -15,10 +15,15 @@
 import { useCallback } from 'react';
 
 import type { ChatSource, Policy } from '@/lib/types';
-import type { MoneyBundle, ParsedXenditConfig } from '@/lib/xendit-client';
+import type { MoneyBundle, ParsedXenditConfig, PolicyUnit } from '@/lib/xendit-client';
 
 import { syftClient } from '@/lib/sdk-client';
-import { fetchBalance, getSatelliteToken, parseXenditConfig } from '@/lib/xendit-client';
+import {
+  fetchBalance,
+  getSatelliteToken,
+  normalizeUnit,
+  parseXenditConfig
+} from '@/lib/xendit-client';
 
 export type EndpointRole = 'model' | 'data_source';
 
@@ -48,7 +53,8 @@ export interface PendingSubscription {
   creditsUrl: string;
   bundles: MoneyBundle[];
   currency: string;
-  pricePerRequest: number | null;
+  pricePerUnit: number | null;
+  unit: PolicyUnit;
   /** Last balance reading (0 when unsubscribed; always 0 for mpp). */
   balance: number;
 }
@@ -58,7 +64,8 @@ interface ResolvedXenditPolicy {
   creditsUrl: string;
   bundles: MoneyBundle[];
   currency: string;
-  pricePerRequest: number | null;
+  pricePerUnit: number | null;
+  unit: PolicyUnit;
 }
 
 function resolveXenditPolicy(policy: Policy): ResolvedXenditPolicy | null {
@@ -71,7 +78,8 @@ function resolveXenditPolicy(policy: Policy): ResolvedXenditPolicy | null {
     creditsUrl: parsed.creditsUrl,
     bundles: parsed.bundles,
     currency: parsed.currency,
-    pricePerRequest: parsed.pricePerRequest
+    pricePerUnit: parsed.pricePerUnit,
+    unit: parsed.unit
   };
 }
 
@@ -97,22 +105,24 @@ interface MppCandidate {
   kind: 'mpp';
   endpoint: EndpointReference;
   currency: string;
-  pricePerRequest: number | null;
+  pricePerUnit: number | null;
+  unit: PolicyUnit;
 }
 
 type Candidate = XenditCandidate | MppCandidate;
 
 function resolveMppPolicy(
   policy: Policy
-): { currency: string; pricePerRequest: number | null } | null {
+): { currency: string; pricePerUnit: number | null; unit: PolicyUnit } | null {
   if (!policy.enabled) return null;
   if (policy.type.toLowerCase() !== 'mpp') return null;
   const config = policy.config;
   const rawPrice = config.price ?? config.price_per_request ?? config.pricePerRequest;
-  const pricePerRequest = typeof rawPrice === 'number' ? rawPrice : null;
+  const pricePerUnit = typeof rawPrice === 'number' ? rawPrice : null;
   const rawCurrency = config.currency;
   const currency = typeof rawCurrency === 'string' && rawCurrency ? rawCurrency : 'USD';
-  return { currency, pricePerRequest };
+  const unit = normalizeUnit(config.unit_type ?? config.unitType);
+  return { currency, pricePerUnit, unit };
 }
 
 function candidatesFromSource(source: ChatSource, role: EndpointRole): Candidate[] {
@@ -205,7 +215,7 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
       for (const c of xenditCandidates) {
         const balance = balanceByCreditsUrl.get(c.policy.creditsUrl);
         if (balance === null || balance === undefined) continue;
-        const threshold = c.policy.pricePerRequest ?? 1;
+        const threshold = c.policy.pricePerUnit ?? 1;
         if (balance >= threshold) continue;
         out.push({
           policyType: 'xendit',
@@ -215,7 +225,8 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
           creditsUrl: c.policy.creditsUrl,
           bundles: c.policy.bundles,
           currency: c.policy.currency,
-          pricePerRequest: c.policy.pricePerRequest,
+          pricePerUnit: c.policy.pricePerUnit,
+          unit: c.policy.unit,
           balance
         });
       }
@@ -231,7 +242,8 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
           creditsUrl: '',
           bundles: [],
           currency: c.currency,
-          pricePerRequest: c.pricePerRequest,
+          pricePerUnit: c.pricePerUnit,
+          unit: c.unit,
           balance: 0
         });
       }

--- a/components/frontend/src/lib/xendit-client.ts
+++ b/components/frontend/src/lib/xendit-client.ts
@@ -17,6 +17,23 @@ import { syftClient } from '@/lib/sdk-client';
 
 export const POLL_INTERVAL_MS = 3000;
 
+// Billing unit on a payment policy. Syft Space publishes the field as
+// `unit_type` in policy.config; legacy policies omit it and bill per request.
+export type PolicyUnit = 'request' | 'document';
+
+export const UNIT_LABEL: Record<PolicyUnit, { singular: string; plural: string }> = {
+  request: { singular: 'request', plural: 'requests' },
+  document: { singular: 'document', plural: 'documents' }
+};
+
+export function normalizeUnit(raw: unknown): PolicyUnit {
+  if (typeof raw === 'string') {
+    const lower = raw.toLowerCase();
+    if (lower === 'request' || lower === 'document') return lower;
+  }
+  return 'request';
+}
+
 export interface MoneyBundle {
   name: string;
   amount: number;
@@ -28,7 +45,8 @@ export interface ParsedXenditConfig {
   invoicesUrl: string | null;
   bundles: MoneyBundle[];
   currency: string;
-  pricePerRequest: number | null;
+  pricePerUnit: number | null;
+  unit: PolicyUnit;
   country: string | null;
 }
 
@@ -65,12 +83,11 @@ export function parseXenditConfig(config: Record<string, unknown>): ParsedXendit
   const invoicesUrl = pickConfigValue(config, 'invoices_url', 'invoicesUrl', isValidUrl);
   const currency = pickConfigValue(config, 'currency', 'currency', isStringValue) ?? 'IDR';
   const country = pickConfigValue(config, 'country', 'country', isStringValue);
-  const pricePerRequest = pickConfigValue(
-    config,
-    'price_per_request',
-    'pricePerRequest',
-    isNumberValue
-  );
+  // New shape sends generic `price`; legacy policies used `price_per_request`.
+  const pricePerUnit =
+    pickConfigValue(config, 'price', 'price', isNumberValue) ??
+    pickConfigValue(config, 'price_per_request', 'pricePerRequest', isNumberValue);
+  const unit = normalizeUnit(pickConfigValue(config, 'unit_type', 'unitType', isStringValue));
   const rawBundles = pickConfigValue(config, 'bundles', 'bundles', isUnknownArray) ?? [];
   const bundles: MoneyBundle[] = rawBundles.filter(
     (b): b is MoneyBundle =>
@@ -79,12 +96,12 @@ export function parseXenditConfig(config: Record<string, unknown>): ParsedXendit
       typeof (b as Record<string, unknown>).name === 'string' &&
       typeof (b as Record<string, unknown>).amount === 'number'
   );
-  return { paymentUrl, creditsUrl, invoicesUrl, bundles, currency, pricePerRequest, country };
+  return { paymentUrl, creditsUrl, invoicesUrl, bundles, currency, pricePerUnit, unit, country };
 }
 
-export function formatRequestEstimate(amount: number, pricePerRequest: number): string {
-  const requests = Math.floor(amount / pricePerRequest);
-  return `~${requests.toLocaleString()} requests`;
+export function formatUnitEstimate(amount: number, pricePerUnit: number, unit: PolicyUnit): string {
+  const count = Math.floor(amount / pricePerUnit);
+  return `~${count.toLocaleString()} ${UNIT_LABEL[unit].plural}`;
 }
 
 export function openCheckoutWindow(url: string): void {


### PR DESCRIPTION
This pull request updates the Xendit payment policy implementation to support a more flexible and generic billing model, allowing for different unit types (such as "document" or "request") instead of being hardcoded to "per request". The changes span backend test fixtures, frontend components, and shared logic to ensure consistent handling and display of the new policy shape. Backwards compatibility is maintained for legacy policies.

**Backend changes:**

- Added a new test fixture `_XENDIT_POLICY_PER_DOCUMENT` using the updated wire shape with `price` and `unit_type` fields, and a corresponding test to verify correct behavior and tag injection for per-document billing. [[1]](diffhunk://#diff-985b616ed97df567f69bba09fc6a1d7fbb11e60b0afdfd670a58dcdcde263a2eR1383-R1405) [[2]](diffhunk://#diff-985b616ed97df567f69bba09fc6a1d7fbb11e60b0afdfd670a58dcdcde263a2eR1536-R1561)

**Frontend logic and UI updates:**

*Support for generic billing units:*

- Introduced the `PolicyUnit` type and related helpers (`normalizeUnit`, `UNIT_LABEL`) to handle different billing units (e.g., "request", "document") throughout the frontend.
- Updated all references to `pricePerRequest` to the new generic `pricePerUnit` and made the billing unit explicit in all relevant types and UI components. [[1]](diffhunk://#diff-72aeb55e689ef39f59b0c519416c7ed4df4641489bc32748efd9b9feb440844dL72-R79) [[2]](diffhunk://#diff-72aeb55e689ef39f59b0c519416c7ed4df4641489bc32748efd9b9feb440844dL106-R113) [[3]](diffhunk://#diff-72aeb55e689ef39f59b0c519416c7ed4df4641489bc32748efd9b9feb440844dL260-R264) [[4]](diffhunk://#diff-72aeb55e689ef39f59b0c519416c7ed4df4641489bc32748efd9b9feb440844dL362-R366) [[5]](diffhunk://#diff-3a84237b05702dc8a7cbc32b777f63d22255de72913944ef115807dc02c5ee45L24-R41) [[6]](diffhunk://#diff-3a84237b05702dc8a7cbc32b777f63d22255de72913944ef115807dc02c5ee45L51-R60) [[7]](diffhunk://#diff-3a84237b05702dc8a7cbc32b777f63d22255de72913944ef115807dc02c5ee45L74-R79) [[8]](diffhunk://#diff-3a84237b05702dc8a7cbc32b777f63d22255de72913944ef115807dc02c5ee45L87-R92) [[9]](diffhunk://#diff-d86f13cf76730402b1a0df490d1c82ed796faf5d80dc24e5e8b38eecc66fcd9aL193-R195) [[10]](diffhunk://#diff-d86f13cf76730402b1a0df490d1c82ed796faf5d80dc24e5e8b38eecc66fcd9aL258-R261) [[11]](diffhunk://#diff-ac75b8d44d7f120ce0b7deb0e05ea38d2145bd66c4522d85e9031b5f8311daefL49-R49) [[12]](diffhunk://#diff-ac75b8d44d7f120ce0b7deb0e05ea38d2145bd66c4522d85e9031b5f8311daefL240-R241) [[13]](diffhunk://#diff-0583fadbaea376fcd2f38b3fc03528d4fbc13c53a97dfd2e61fa5d3a87de68d4L51-R57) [[14]](diffhunk://#diff-0583fadbaea376fcd2f38b3fc03528d4fbc13c53a97dfd2e61fa5d3a87de68d4L61-R68) [[15]](diffhunk://#diff-0583fadbaea376fcd2f38b3fc03528d4fbc13c53a97dfd2e61fa5d3a87de68d4L74-R82) [[16]](diffhunk://#diff-0583fadbaea376fcd2f38b3fc03528d4fbc13c53a97dfd2e61fa5d3a87de68d4L100-R125) [[17]](diffhunk://#diff-0583fadbaea376fcd2f38b3fc03528d4fbc13c53a97dfd2e61fa5d3a87de68d4L208-R218) [[18]](diffhunk://#diff-0583fadbaea376fcd2f38b3fc03528d4fbc13c53a97dfd2e61fa5d3a87de68d4L218-R229) [[19]](diffhunk://#diff-0583fadbaea376fcd2f38b3fc03528d4fbc13c53a97dfd2e61fa5d3a87de68d4L234-R246)

*UI improvements:*

- Updated display labels and formatting to show the correct unit ("per request", "per document", etc.) in all bundle pickers, policy cards, and payment gates, using the new `UNIT_LABEL` mapping. [[1]](diffhunk://#diff-72aeb55e689ef39f59b0c519416c7ed4df4641489bc32748efd9b9feb440844dL72-R79) [[2]](diffhunk://#diff-72aeb55e689ef39f59b0c519416c7ed4df4641489bc32748efd9b9feb440844dL106-R113) [[3]](diffhunk://#diff-d86f13cf76730402b1a0df490d1c82ed796faf5d80dc24e5e8b38eecc66fcd9aL258-R261) [[4]](diffhunk://#diff-3a84237b05702dc8a7cbc32b777f63d22255de72913944ef115807dc02c5ee45L24-R41) [[5]](diffhunk://#diff-3a84237b05702dc8a7cbc32b777f63d22255de72913944ef115807dc02c5ee45L74-R79) [[6]](diffhunk://#diff-3a84237b05702dc8a7cbc32b777f63d22255de72913944ef115807dc02c5ee45L87-R92)

*Shared logic and parsing:*

- Refactored the Xendit policy parsing and related hooks to extract and propagate the billing unit, ensuring all components and hooks operate with the updated policy shape. [[1]](diffhunk://#diff-0583fadbaea376fcd2f38b3fc03528d4fbc13c53a97dfd2e61fa5d3a87de68d4L18-R26) [[2]](diffhunk://#diff-0583fadbaea376fcd2f38b3fc03528d4fbc13c53a97dfd2e61fa5d3a87de68d4L51-R57) [[3]](diffhunk://#diff-0583fadbaea376fcd2f38b3fc03528d4fbc13c53a97dfd2e61fa5d3a87de68d4L61-R68) [[4]](diffhunk://#diff-0583fadbaea376fcd2f38b3fc03528d4fbc13c53a97dfd2e61fa5d3a87de68d4L74-R82) [[5]](diffhunk://#diff-0583fadbaea376fcd2f38b3fc03528d4fbc13c53a97dfd2e61fa5d3a87de68d4L100-R125)

These changes together enable more flexible billing models and improved clarity for users interacting with endpoints that use Xendit payment policies.