### PR TITLE
chore(chat): remove MPP payment-gate blocker

### DIFF
--- a/components/frontend/src/components/chat/payment-gate.tsx
+++ b/components/frontend/src/components/chat/payment-gate.tsx
@@ -2,14 +2,10 @@
  * PaymentGate
  *
  * Inline gate rendered in the chat history (right after the user's bubble)
- * when one or more selected endpoints carry an unfunded paid policy.
- *
- * Two row variants:
- *   - xendit: drives its own buy flow (popup checkout window); the parent
- *     polls credits_url to detect when each wallet flips active and unlocks
- *     Send.
- *   - mpp: payment is not implemented yet — shows a "supported in a future
- *     release" notice and forces the user to remove the endpoint to send.
+ * when one or more selected endpoints carry an unfunded Xendit prepaid-
+ * credits policy. Drives the buy flow via a popup checkout window; the
+ * parent polls credits_url to detect when each wallet flips active and
+ * unlocks Send.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -38,7 +34,6 @@ import {
 function distinctOwners(pending: PendingSubscription[]): string[] {
   const owners = new Set<string>();
   for (const p of pending) {
-    if (p.policyType !== 'xendit') continue;
     for (const e of p.endpoints) owners.add(e.owner);
   }
   return [...owners];
@@ -78,66 +73,6 @@ function renderStatusLine(pending: PendingSubscription, isActive: boolean, liveB
       {pending.currency} {pending.pricePerUnit.toLocaleString()} per{' '}
       {UNIT_LABEL[pending.unit].singular}
     </span>
-  );
-}
-
-interface MppRowProperties {
-  pending: PendingSubscription;
-  onRemove: () => void;
-}
-
-function MppPaymentGateRow({ pending, onRemove }: Readonly<MppRowProperties>) {
-  const primaryEndpoint = pending.endpoints[0];
-  const roleLabel = primaryEndpoint?.role === 'model' ? 'Model' : 'Data source';
-
-  return (
-    <div className='dark:bg-card rounded-md border border-amber-200/60 bg-white px-3 py-2.5 dark:border-amber-900/40'>
-      <div className='flex flex-wrap items-center justify-between gap-x-3 gap-y-2'>
-        <div className='flex min-w-0 flex-1 items-center gap-2.5'>
-          <div className='flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-amber-200 bg-amber-50 text-amber-600 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-400'>
-            <CreditCard className='h-3.5 w-3.5' />
-          </div>
-          <div className='min-w-0'>
-            <div className='flex items-center gap-1.5'>
-              <span className='text-foreground truncate text-sm font-medium'>
-                {primaryEndpoint?.path ?? 'Unknown endpoint'}
-              </span>
-              <span className='text-muted-foreground text-[11px]'>· {roleLabel}</span>
-            </div>
-            <div className='text-muted-foreground mt-0.5 text-[11px]'>
-              {pending.pricePerUnit === null ? (
-                <>MPP credits required</>
-              ) : (
-                <span className='tabular-nums'>
-                  {pending.currency} {pending.pricePerUnit.toLocaleString()} per{' '}
-                  {UNIT_LABEL[pending.unit].singular} (MPP)
-                </span>
-              )}
-            </div>
-          </div>
-        </div>
-
-        <div className='flex shrink-0 items-center gap-1.5'>
-          <button
-            type='button'
-            onClick={onRemove}
-            aria-label='Remove from selection'
-            title='Remove from selection'
-            className={cn(
-              'text-muted-foreground hover:text-foreground rounded-md p-1 transition-colors',
-              'hover:bg-muted/60 focus:ring-ring/30 focus:ring-2 focus:outline-none'
-            )}
-          >
-            <X className='h-3.5 w-3.5' />
-          </button>
-        </div>
-      </div>
-
-      <div className='mt-2 text-[11px] text-amber-700 dark:text-amber-400'>
-        MPP endpoints will be supported in a future release. Remove this endpoint from the selection
-        to send your message.
-      </div>
-    </div>
   );
 }
 
@@ -360,8 +295,6 @@ export function PaymentGate({
 
   const isWalletActive = useCallback(
     (p: PendingSubscription) => {
-      // mpp has no payment flow yet — these rows can never become active.
-      if (p.policyType === 'mpp') return false;
       const balance = balances[p.walletKey] ?? 0;
       const threshold = p.pricePerUnit ?? 1;
       return balance >= threshold;
@@ -376,7 +309,6 @@ export function PaymentGate({
   const registeredKeysReference = useRef<Set<string>>(new Set());
   useEffect(() => {
     for (const p of pending) {
-      if (p.policyType !== 'xendit') continue;
       const balance = balances[p.walletKey] ?? 0;
       if (balance <= 0) continue;
       if (registeredKeysReference.current.has(p.walletKey)) continue;
@@ -402,7 +334,6 @@ export function PaymentGate({
     const tick = async () => {
       const inactive = new Map<string, PendingSubscription>();
       for (const p of pending) {
-        if (p.policyType !== 'xendit') continue;
         if (isWalletActive(p)) continue;
         if (!inactive.has(p.walletKey)) inactive.set(p.walletKey, p);
       }
@@ -466,17 +397,6 @@ export function PaymentGate({
       <div className='mt-3 space-y-1.5'>
         {pending.map((p) => {
           const key = `${p.walletKey}::${p.endpoints[0]?.path ?? ''}`;
-          if (p.policyType === 'mpp') {
-            return (
-              <MppPaymentGateRow
-                key={key}
-                pending={p}
-                onRemove={() => {
-                  onRemovePending(p);
-                }}
-              />
-            );
-          }
           return (
             <PaymentGateRow
               key={key}

--- a/components/frontend/src/hooks/use-xendit-precheck.ts
+++ b/components/frontend/src/hooks/use-xendit-precheck.ts
@@ -2,15 +2,11 @@
  * useXenditPrecheck
  *
  * Pre-flight subscription check run before a chat message is sent.
- * Inspects the model + selected data sources for paid-policy gates,
- * dedupes by credits_url (one wallet may back multiple endpoints), and
- * fetches each balance via a satellite token. Returns the rows that
+ * Inspects the model + selected data sources for Xendit prepaid-credits
+ * policies, dedupes by credits_url (one wallet may back multiple endpoints),
+ * and fetches each balance via a satellite token. Returns the rows that
  * still need a paid subscription so the chat view can open the gate
  * modal — or an empty array when the user is clear to send.
- *
- * Also surfaces `mpp`-typed policies as always-pending rows: payment
- * for those endpoints isn't implemented yet, so the gate informs the
- * user and forces them to remove the endpoint to send.
  */
 import { useCallback } from 'react';
 
@@ -18,12 +14,7 @@ import type { ChatSource, Policy } from '@/lib/types';
 import type { MoneyBundle, ParsedXenditConfig, PolicyUnit } from '@/lib/xendit-client';
 
 import { syftClient } from '@/lib/sdk-client';
-import {
-  fetchBalance,
-  getSatelliteToken,
-  normalizeUnit,
-  parseXenditConfig
-} from '@/lib/xendit-client';
+import { fetchBalance, getSatelliteToken, parseXenditConfig } from '@/lib/xendit-client';
 
 export type EndpointRole = 'model' | 'data_source';
 
@@ -38,24 +29,18 @@ export interface EndpointReference {
   role: EndpointRole;
 }
 
-export type PolicyKind = 'xendit' | 'mpp';
-
 export interface PendingSubscription {
-  /** Which policy type this row represents. Drives the gate UI branch. */
-  policyType: PolicyKind;
-  /** Stable identity. credits_url for xendit; synthetic for mpp. */
+  /** Stable identity = credits_url. Rows sharing a wallet share this key. */
   walletKey: string;
   /** All endpoints covered by this single wallet subscription. */
   endpoints: EndpointReference[];
-  /** Empty string for mpp (no payment endpoint yet). */
   paymentUrl: string;
-  /** Empty string for mpp (no balance endpoint yet). */
   creditsUrl: string;
   bundles: MoneyBundle[];
   currency: string;
   pricePerUnit: number | null;
   unit: PolicyUnit;
-  /** Last balance reading (0 when unsubscribed; always 0 for mpp). */
+  /** Last balance reading (0 when unsubscribed). */
   balance: number;
 }
 
@@ -96,56 +81,24 @@ function endpointReferenceFor(source: ChatSource, role: EndpointRole): EndpointR
 }
 
 interface XenditCandidate {
-  kind: 'xendit';
   endpoint: EndpointReference;
   policy: ResolvedXenditPolicy;
 }
 
-interface MppCandidate {
-  kind: 'mpp';
-  endpoint: EndpointReference;
-  currency: string;
-  pricePerUnit: number | null;
-  unit: PolicyUnit;
-}
-
-type Candidate = XenditCandidate | MppCandidate;
-
-function resolveMppPolicy(
-  policy: Policy
-): { currency: string; pricePerUnit: number | null; unit: PolicyUnit } | null {
-  if (!policy.enabled) return null;
-  if (policy.type.toLowerCase() !== 'mpp') return null;
-  const config = policy.config;
-  const rawPrice = config.price ?? config.price_per_request ?? config.pricePerRequest;
-  const pricePerUnit = typeof rawPrice === 'number' ? rawPrice : null;
-  const rawCurrency = config.currency;
-  const currency = typeof rawCurrency === 'string' && rawCurrency ? rawCurrency : 'USD';
-  const unit = normalizeUnit(config.unit_type ?? config.unitType);
-  return { currency, pricePerUnit, unit };
-}
-
-function candidatesFromSource(source: ChatSource, role: EndpointRole): Candidate[] {
+function candidatesFromSource(source: ChatSource, role: EndpointRole): XenditCandidate[] {
   if (!source.policies) return [];
   const ref = endpointReferenceFor(source, role);
   if (!ref) return [];
-  const out: Candidate[] = [];
+  const out: XenditCandidate[] = [];
   for (const policy of source.policies) {
     const xendit = resolveXenditPolicy(policy);
-    if (xendit) {
-      out.push({ kind: 'xendit', endpoint: ref, policy: xendit });
-      continue;
-    }
-    const mpp = resolveMppPolicy(policy);
-    if (mpp) {
-      out.push({ kind: 'mpp', endpoint: ref, ...mpp });
-    }
+    if (xendit) out.push({ endpoint: ref, policy: xendit });
   }
   return out;
 }
 
-function collectCandidates(model: ChatSource | null, dataSources: ChatSource[]): Candidate[] {
-  const out: Candidate[] = [];
+function collectCandidates(model: ChatSource | null, dataSources: ChatSource[]): XenditCandidate[] {
+  const out: XenditCandidate[] = [];
   if (model) out.push(...candidatesFromSource(model, 'model'));
   for (const ds of dataSources) out.push(...candidatesFromSource(ds, 'data_source'));
   return out;
@@ -175,13 +128,9 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
       if (candidates.length === 0) return [];
       if (!syftClient.getTokens()) return [];
 
-      const xenditCandidates = candidates.filter((c): c is XenditCandidate => c.kind === 'xendit');
-      const mppCandidates = candidates.filter((c): c is MppCandidate => c.kind === 'mpp');
-
-      // One satellite token per distinct xendit owner — multiple wallets
-      // owned by the same publisher reuse the token. mpp rows skip this
-      // because they have no balance endpoint to authenticate against.
-      const owners = [...new Set(xenditCandidates.map((c) => c.endpoint.owner))];
+      // One satellite token per distinct owner — multiple wallets owned by
+      // the same publisher reuse the token.
+      const owners = [...new Set(candidates.map((c) => c.endpoint.owner))];
       const tokenByOwner = new Map<string, string>();
       await Promise.all(
         owners.map(async (owner) => {
@@ -194,11 +143,11 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
       // share a wallet — paying once funds them all — but the gate UI lists
       // each endpoint separately, so we need to know each row's status
       // without re-hitting the same credits_url.
-      const distinctCreditsUrls = [...new Set(xenditCandidates.map((c) => c.policy.creditsUrl))];
+      const distinctCreditsUrls = [...new Set(candidates.map((c) => c.policy.creditsUrl))];
       const balanceByCreditsUrl = new Map<string, number | null>();
       await Promise.all(
         distinctCreditsUrls.map(async (creditsUrl) => {
-          const sample = xenditCandidates.find((c) => c.policy.creditsUrl === creditsUrl);
+          const sample = candidates.find((c) => c.policy.creditsUrl === creditsUrl);
           if (!sample) return;
           const token = tokenByOwner.get(sample.endpoint.owner);
           if (!token) return;
@@ -207,18 +156,17 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
         })
       );
 
-      // One PendingSubscription per endpoint. xendit rows that share a
-      // wallet keep the same `walletKey` (= credits_url) so the gate's
-      // polling loop and auto-registration can dedupe by wallet, and a
-      // single payment flips every sibling row to active at once.
+      // One PendingSubscription per endpoint. Rows that share a wallet keep
+      // the same `walletKey` (= credits_url) so the gate's polling loop and
+      // auto-registration can dedupe by wallet, and a single payment flips
+      // every sibling row to active at once.
       const out: PendingSubscription[] = [];
-      for (const c of xenditCandidates) {
+      for (const c of candidates) {
         const balance = balanceByCreditsUrl.get(c.policy.creditsUrl);
         if (balance === null || balance === undefined) continue;
         const threshold = c.policy.pricePerUnit ?? 1;
         if (balance >= threshold) continue;
         out.push({
-          policyType: 'xendit',
           walletKey: c.policy.creditsUrl,
           endpoints: [c.endpoint],
           paymentUrl: c.policy.paymentUrl,
@@ -228,23 +176,6 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
           pricePerUnit: c.policy.pricePerUnit,
           unit: c.policy.unit,
           balance
-        });
-      }
-      // mpp rows are always pending — no payment flow exists yet, so we
-      // surface them in the gate purely to inform the user and force a
-      // remove-or-cancel decision. walletKey is synthetic (per-endpoint).
-      for (const c of mppCandidates) {
-        out.push({
-          policyType: 'mpp',
-          walletKey: `mpp::${c.endpoint.owner}/${c.endpoint.slug}`,
-          endpoints: [c.endpoint],
-          paymentUrl: '',
-          creditsUrl: '',
-          bundles: [],
-          currency: c.currency,
-          pricePerUnit: c.pricePerUnit,
-          unit: c.unit,
-          balance: 0
         });
       }
       return out;


### PR DESCRIPTION
## Summary

- MPP transaction endpoints are fully supported server-side now, so the chat `PaymentGate` no longer needs to block them with the "supported in a future release" yellow card that forced the user to drop the endpoint before sending.
- `useXenditPrecheck` now only inspects Xendit prepaid-credits policies — `PolicyKind`, `MppCandidate`, `resolveMppPolicy`, and the `policyType` field on `PendingSubscription` are gone.
- `PaymentGate` lost `MppPaymentGateRow`, the mpp branch in the row map, the never-active short-circuit in `isWalletActive`, and the xendit-only guards on the polling / auto-registration effects.
- Xendit prepaid-credits flow is unchanged.

## Test plan

- [ ] Open chat with an endpoint that carries an `mpp` policy → message sends through, no yellow card appears.
- [ ] Open chat with an endpoint carrying an unfunded `xendit` policy → yellow card still appears, Buy flow still works, Send unlocks once the balance hits the threshold.
- [ ] Open chat with an endpoint carrying a funded `xendit` policy → no gate, message sends.
- [ ] Mix `mpp` + unfunded `xendit` endpoints in one selection → only the xendit row is gated; sending requires only the xendit wallet to fund.