### PR TITLE
feat(endpoint): render the prepaid-credits policy card for Stripe too

### DIFF
--- a/components/frontend/src/components/endpoint/policy-item.tsx
+++ b/components/frontend/src/components/endpoint/policy-item.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useMemo, useState } from 'react';
 
 import type { Policy } from '@/lib/types';
+import type { PrepaidProvider } from './xendit-policy-content';
 
 import ChevronDown from 'lucide-react/dist/esm/icons/chevron-down';
 import Coins from 'lucide-react/dist/esm/icons/coins';
@@ -23,6 +24,16 @@ import { parseXenditConfig, UNIT_LABEL } from '@/lib/xendit-client';
 import { GenericPolicyContent } from './generic-policy-content';
 import { formatConfigKey, TransactionPolicyContent } from './transaction-policy-content';
 import { XenditPolicyContent } from './xendit-policy-content';
+
+// Policy types that drive the prepaid-credits card. Both providers share the
+// same config shape (bundles + currency + payment_url + credits_url +
+// invoices_url + price + unit_type), so the card and BundlePicker are reused.
+// Adding a future prepaid provider is one entry here plus a theme entry in
+// POLICY_TYPE_CONFIG.
+const PREPAID_BALANCE_TYPES = new Set<PrepaidProvider>(['xendit', 'stripe']);
+function isPrepaidBalanceType(type: string): type is PrepaidProvider {
+  return (PREPAID_BALANCE_TYPES as Set<string>).has(type);
+}
 
 // Policy type configuration for styling and icons
 const POLICY_TYPE_CONFIG: Record<
@@ -59,6 +70,14 @@ const POLICY_TYPE_CONFIG: Record<
     color: 'text-violet-600 dark:text-violet-400',
     bgColor: 'bg-violet-50 dark:bg-violet-950/30',
     borderColor: 'border-violet-200 dark:border-violet-800',
+    description: 'Top up credits to use this endpoint.'
+  },
+  stripe: {
+    icon: CreditCard,
+    label: 'Prepaid credits',
+    color: 'text-indigo-600 dark:text-indigo-400',
+    bgColor: 'bg-indigo-50 dark:bg-indigo-950/30',
+    borderColor: 'border-indigo-200 dark:border-indigo-800',
     description: 'Top up credits to use this endpoint.'
   },
   // Access control policies
@@ -144,16 +163,17 @@ export interface PolicyItemProperties {
 function renderPolicyContent(
   policy: Policy,
   isTransaction: boolean,
-  isXendit: boolean,
+  prepaidProvider: PrepaidProvider | null,
   endpointSlug?: string,
   endpointOwner?: string
 ): React.ReactElement {
   if (isTransaction) {
     return <TransactionPolicyContent config={policy.config} />;
   }
-  if (isXendit) {
+  if (prepaidProvider) {
     return (
       <XenditPolicyContent
+        provider={prepaidProvider}
         config={policy.config}
         enabled={policy.enabled}
         endpointSlug={endpointSlug}
@@ -174,7 +194,13 @@ export const PolicyItem = memo(function PolicyItem({
   const Icon = config.icon;
   const policyTypeLower = policy.type.toLowerCase();
   const isTransaction = policyTypeLower === 'transaction';
-  const isXendit = policyTypeLower === 'xendit';
+  const prepaidProvider: PrepaidProvider | null = isPrepaidBalanceType(policyTypeLower)
+    ? policyTypeLower
+    : null;
+  // Provider-agnostic display name surfaced under the card title (e.g. "via Xendit").
+  const prepaidProviderLabel = prepaidProvider
+    ? prepaidProvider.charAt(0).toUpperCase() + prepaidProvider.slice(1)
+    : null;
 
   // For unknown policy types, use the type as the label
   const displayLabel = POLICY_TYPE_CONFIG[policy.type.toLowerCase()]
@@ -186,16 +212,16 @@ export const PolicyItem = memo(function PolicyItem({
   const rawDescription = policy.description || config.description;
   const description = rawDescription && rawDescription !== displayLabel ? rawDescription : null;
 
-  const xenditParsed = useMemo(
-    () => (isXendit ? parseXenditConfig(policy.config) : null),
-    [isXendit, policy.config]
+  const prepaidParsed = useMemo(
+    () => (prepaidProvider ? parseXenditConfig(policy.config) : null),
+    [prepaidProvider, policy.config]
   );
-  const xenditPricePerUnit =
-    xenditParsed && xenditParsed.pricePerUnit !== null && xenditParsed.pricePerUnit > 0
-      ? xenditParsed.pricePerUnit
+  const prepaidPricePerUnit =
+    prepaidParsed && prepaidParsed.pricePerUnit !== null && prepaidParsed.pricePerUnit > 0
+      ? prepaidParsed.pricePerUnit
       : null;
 
-  if (isXendit) {
+  if (prepaidProvider) {
     return (
       <div
         className={cn(
@@ -223,7 +249,9 @@ export const PolicyItem = memo(function PolicyItem({
                   <h3 className='text-foreground text-sm leading-tight font-semibold'>
                     {displayLabel}
                   </h3>
-                  <p className='text-muted-foreground mt-0.5 text-[11px]'>via Xendit</p>
+                  <p className='text-muted-foreground mt-0.5 text-[11px]'>
+                    via {prepaidProviderLabel}
+                  </p>
                 </div>
                 {policy.version ? (
                   <span className='text-muted-foreground bg-muted/60 shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium tabular-nums'>
@@ -255,15 +283,21 @@ export const PolicyItem = memo(function PolicyItem({
               {description && (
                 <p className='text-muted-foreground mt-2 text-xs leading-relaxed'>{description}</p>
               )}
-              {xenditParsed && xenditPricePerUnit !== null && (
+              {prepaidParsed && prepaidPricePerUnit !== null && (
                 <p className='text-muted-foreground mt-0.5 text-[11px] tabular-nums'>
-                  {xenditParsed.currency} {xenditPricePerUnit.toLocaleString()} per{' '}
-                  {UNIT_LABEL[xenditParsed.unit].singular}
+                  {prepaidParsed.currency} {prepaidPricePerUnit.toLocaleString()} per{' '}
+                  {UNIT_LABEL[prepaidParsed.unit].singular}
                 </p>
               )}
 
               {Object.keys(policy.config).length > 0 &&
-                renderPolicyContent(policy, isTransaction, isXendit, endpointSlug, endpointOwner)}
+                renderPolicyContent(
+                  policy,
+                  isTransaction,
+                  prepaidProvider,
+                  endpointSlug,
+                  endpointOwner
+                )}
             </div>
           </div>
         </div>
@@ -317,7 +351,13 @@ export const PolicyItem = memo(function PolicyItem({
 
           {/* Policy-specific content */}
           {Object.keys(policy.config).length > 0 &&
-            renderPolicyContent(policy, isTransaction, isXendit, endpointSlug, endpointOwner)}
+            renderPolicyContent(
+              policy,
+              isTransaction,
+              prepaidProvider,
+              endpointSlug,
+              endpointOwner
+            )}
 
           {policy.version ? (
             <div className='mt-2'>

--- a/components/frontend/src/components/endpoint/xendit-policy-content.tsx
+++ b/components/frontend/src/components/endpoint/xendit-policy-content.tsx
@@ -30,19 +30,70 @@ type PurchaseState =
   | { state: 'awaiting_payment'; bundleName: string; checkoutUrl: string }
   | { state: 'error'; message: string };
 
+/**
+ * Prepaid-balance providers. Both publish policy.config in the same shape
+ * (bundles + currency + payment_url + credits_url + invoices_url + price +
+ * unit_type), so the buy-credits card body is identical; only the button
+ * theme and the "Sign in to subscribe" copy change per provider.
+ */
+export type PrepaidProvider = 'xendit' | 'stripe';
+
+interface ProviderTheme {
+  label: string;
+  // Tailwind classes for the primary "Buy credits" CTA.
+  buttonClass: string;
+  // Focus ring colour used when the button is keyboard-focused.
+  focusRingClass: string;
+  // Focus ring colour on the bundle dropdown — opens narrower than the CTA
+  // but keeps the same colour family.
+  pickerFocusClass: string;
+}
+
+const PROVIDER_THEME: Record<PrepaidProvider, ProviderTheme> = {
+  xendit: {
+    label: 'Xendit',
+    buttonClass: cn(
+      'bg-violet-600 text-white shadow-sm',
+      'hover:bg-violet-500 active:bg-violet-700',
+      'disabled:cursor-not-allowed disabled:bg-violet-600/40 disabled:shadow-none',
+      'dark:bg-violet-500 dark:hover:bg-violet-400 dark:active:bg-violet-600',
+      'dark:disabled:bg-violet-500/30'
+    ),
+    focusRingClass: 'focus-visible:ring-violet-400/50 dark:focus-visible:ring-violet-500/40',
+    pickerFocusClass: 'focus:ring-violet-400/40 dark:focus:ring-violet-500/30'
+  },
+  stripe: {
+    label: 'Stripe',
+    buttonClass: cn(
+      'bg-indigo-600 text-white shadow-sm',
+      'hover:bg-indigo-500 active:bg-indigo-700',
+      'disabled:cursor-not-allowed disabled:bg-indigo-600/40 disabled:shadow-none',
+      'dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:active:bg-indigo-600',
+      'dark:disabled:bg-indigo-500/30'
+    ),
+    focusRingClass: 'focus-visible:ring-indigo-400/50 dark:focus-visible:ring-indigo-500/40',
+    pickerFocusClass: 'focus:ring-indigo-400/40 dark:focus:ring-indigo-500/30'
+  }
+};
+
 export interface XenditPolicyContentProperties {
   config: Record<string, unknown>;
   enabled: boolean;
   endpointSlug?: string;
   endpointOwner?: string;
+  /** Provider whose theme + label to render. Defaults to xendit for
+   *  back-compat with any caller that hasn't been updated yet. */
+  provider?: PrepaidProvider;
 }
 
 export const XenditPolicyContent = memo(function XenditPolicyContent({
   config,
   enabled,
   endpointSlug,
-  endpointOwner
+  endpointOwner,
+  provider = 'xendit'
 }: Readonly<XenditPolicyContentProperties>) {
+  const theme = PROVIDER_THEME[provider];
   // Re-parse only when config identity changes — otherwise the bundles array
   // would get a fresh reference each render and re-fire the validation effect.
   const parsed = useMemo(() => parseXenditConfig(config), [config]);
@@ -239,6 +290,7 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
             disabled={isCreatingAny}
             pricePerUnit={pricePerUnit}
             unit={unit}
+            triggerClassName={theme.pickerFocusClass}
           />
           <button
             type='button'
@@ -246,12 +298,9 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
             onClick={() => void handleSubscribe(selectedBundleName)}
             className={cn(
               'group inline-flex h-10 w-full items-center justify-center gap-1.5 rounded-md text-sm font-medium transition-colors',
-              'bg-violet-600 text-white shadow-sm',
-              'hover:bg-violet-500 active:bg-violet-700',
-              'focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-violet-400/50 focus-visible:ring-offset-2 focus-visible:outline-none',
-              'disabled:cursor-not-allowed disabled:bg-violet-600/40 disabled:shadow-none',
-              'dark:bg-violet-500 dark:hover:bg-violet-400 dark:active:bg-violet-600',
-              'dark:disabled:bg-violet-500/30'
+              theme.buttonClass,
+              'focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+              theme.focusRingClass
             )}
           >
             {isCreatingAny ? (


### PR DESCRIPTION
Stripe wallets publish policy.config in the same shape as Xendit (bundles + currency + payment_url + credits_url + invoices_url + price + unit_type), so the buy-credits card body, BundlePicker, balance polling, and pending-invoice resume are unchanged. Only the visual theme and the "via X" label vary per provider.

Changes:
- policy-item.tsx: add `stripe` entry to POLICY_TYPE_CONFIG (indigo theme mirroring the violet of Xendit), and dispatch the prepaid card on either `xendit` or `stripe` via a new PREPAID_BALANCE_TYPES set + isPrepaid guard. The provider label under the card title is derived from the policy type instead of being hardcoded to "Xendit".
- xendit-policy-content.tsx: accept an optional `provider` prop (defaults to 'xendit' for back-compat), keyed to a PROVIDER_THEME table that drives the "Buy credits" CTA + focus rings + bundle-picker focus ring. No business logic changes — same purchase flow, same balance polling, same awaiting-payment banner.

Tests + typecheck unchanged (all 292 unit tests pass).

Future cleanup not in scope:
- Rename xendit-policy-content.tsx → prepaid-policy-content.tsx and XenditPolicyContent → PrepaidPolicyContent.
- Promote parseXenditConfig → parsePrepaidPolicyConfig and rename lib/xendit-client.ts → lib/prepaid-client.ts.
- Update useXenditSubscriptions / xendit_subscriptions table to a provider-agnostic name. Today both providers' wallets sit in the same JSON contract under the existing endpoint names — the table is provider-agnostic by accident and works correctly for both.

## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
