### PR TITLE
feat(collectives): invitation landing page, invite-by-path, multi-endpoint join

### DIFF
--- a/components/backend/src/syfthub/api/endpoints/collectives.py
+++ b/components/backend/src/syfthub/api/endpoints/collectives.py
@@ -18,6 +18,7 @@ from syfthub.database.dependencies import get_collective_service
 from syfthub.schemas.collective import (
     CollectiveCreate,
     CollectiveInvitationResponse,
+    CollectiveInviteByPathRequest,
     CollectiveMemberRequest,
     CollectiveMemberResponse,
     CollectiveResponse,
@@ -210,6 +211,50 @@ async def invite_endpoint(
     if email_context is not None:
         background_tasks.add_task(send_collective_invitation_email, email_context)
     return membership
+
+
+@router.post(
+    "/{collective_id}/invitations/by-path",
+    response_model=CollectiveMemberResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def invite_endpoint_by_path(
+    collective_id: int,
+    data: CollectiveInviteByPathRequest,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    service: Annotated[CollectiveService, Depends(get_collective_service)],
+    background_tasks: BackgroundTasks,
+) -> CollectiveMemberResponse:
+    """Invite an endpoint into a collective by its ``owner/slug`` path.
+
+    Same semantics as ``POST /invitations`` — the body identifies the endpoint
+    by its public path instead of by numeric id. Used by the admin invite UI
+    since the public endpoint API does not expose ids.
+    """
+    membership, email_context = service.invite_endpoint_by_path(
+        collective_id, data.owner_username, data.slug, current_user
+    )
+    if email_context is not None:
+        background_tasks.add_task(send_collective_invitation_email, email_context)
+    return membership
+
+
+@router.get(
+    "/{collective_id}/invitations/{endpoint_id}",
+    response_model=CollectiveMemberResponse,
+)
+async def get_invitation(
+    collective_id: int,
+    endpoint_id: int,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    service: Annotated[CollectiveService, Depends(get_collective_service)],
+) -> CollectiveMemberResponse:
+    """Get the membership row for an invitation.
+
+    Readable by the endpoint owner, collective owner, or an admin — used by
+    the invitation landing page that the email links to.
+    """
+    return service.get_invitation(collective_id, endpoint_id, current_user)
 
 
 @router.post(

--- a/components/backend/src/syfthub/schemas/collective.py
+++ b/components/backend/src/syfthub/schemas/collective.py
@@ -227,6 +227,18 @@ class CollectiveMemberRequest(BaseModel):
     endpoint_id: int = Field(..., description="ID of the endpoint")
 
 
+class CollectiveInviteByPathRequest(BaseModel):
+    """Request body for inviting an endpoint identified by ``owner/slug``.
+
+    Used by the admin UI's invite modal, which lookups endpoints by their
+    public path rather than the numeric id (the public endpoint API does not
+    expose the id field).
+    """
+
+    owner_username: str = Field(..., description="Username of the endpoint owner")
+    slug: str = Field(..., description="URL-safe identifier of the endpoint")
+
+
 class CollectiveReviewRequest(BaseModel):
     """Request body for a collective owner reviewing a pending join request."""
 

--- a/components/backend/src/syfthub/services/collective_service.py
+++ b/components/backend/src/syfthub/services/collective_service.py
@@ -387,6 +387,68 @@ class CollectiveService(BaseService):
             reviewed_by_user_id=current_user.id,
         )
 
+    def invite_endpoint_by_path(
+        self,
+        collective_id: int,
+        owner_username: str,
+        slug: str,
+        current_user: User,
+    ) -> tuple[CollectiveMemberResponse, Optional[InvitationEmailContext]]:
+        """Invite an endpoint identified by ``owner/slug``.
+
+        Resolves the path to an endpoint id and delegates to ``invite_endpoint``.
+        Only public endpoints are resolvable here (this is how the admin UI
+        finds them); 404 otherwise.
+        """
+        owner = self.user_repo.get_by_username(owner_username)
+        if owner is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"User '{owner_username}' not found",
+            )
+        endpoint = self.endpoint_repo.get_by_owner_and_slug_any_state(owner.id, slug)
+        if endpoint is None or endpoint.visibility != EndpointVisibility.PUBLIC:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Endpoint '{owner_username}/{slug}' not found",
+            )
+        return self.invite_endpoint(collective_id, endpoint.id, current_user)
+
+    def get_invitation(
+        self, collective_id: int, endpoint_id: int, current_user: User
+    ) -> CollectiveMemberResponse:
+        """Return the membership row for an invitation.
+
+        Used by the invitation-response landing page so the recipient can see
+        the invite even before they accept. Readable by the endpoint owner,
+        the collective owner, and admins; everyone else gets 403. A row that
+        does not exist (or has been removed) yields 404. The status is not
+        constrained — the caller may want to render an "already accepted" or
+        "declined" state.
+        """
+        collective = self._get_collective_or_404(collective_id)
+        endpoint = self._get_endpoint_or_404(endpoint_id)
+
+        allowed = (
+            self._is_admin(current_user)
+            or collective.owner_id == current_user.id
+            or endpoint.user_id == current_user.id
+        )
+        if not allowed:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only the collective owner or the endpoint owner "
+                "can view this invitation",
+            )
+
+        membership = self.member_repo.get_membership(collective_id, endpoint_id)
+        if membership is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Invitation not found",
+            )
+        return self._enrich(membership)
+
     def remove_member(
         self, collective_id: int, endpoint_id: int, current_user: User
     ) -> None:

--- a/components/backend/tests/test_collectives.py
+++ b/components/backend/tests/test_collectives.py
@@ -469,6 +469,154 @@ def test_only_endpoint_owner_responds_to_invitation(
     assert resp.status_code == 403
 
 
+def test_get_invitation_readable_by_endpoint_owner(
+    client: TestClient, owner_headers: dict, member_headers: dict
+) -> None:
+    """The endpoint owner can fetch their own invitation row to render the
+    response landing page (list_members hides non-approved from non-managers)."""
+    collective = _create_collective(client, owner_headers)
+    cid = collective["id"]
+    endpoint_id = _create_endpoint(client, member_headers, "inv-target")
+    client.post(
+        f"{API}/collectives/{cid}/invitations",
+        json={"endpoint_id": endpoint_id},
+        headers=owner_headers,
+    )
+
+    resp = client.get(
+        f"{API}/collectives/{cid}/invitations/{endpoint_id}",
+        headers=member_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "invited"
+    assert body["endpoint_id"] == endpoint_id
+
+
+def test_get_invitation_readable_by_collective_owner(
+    client: TestClient, owner_headers: dict, member_headers: dict
+) -> None:
+    """The collective owner who sent the invitation can also read the row."""
+    collective = _create_collective(client, owner_headers)
+    cid = collective["id"]
+    endpoint_id = _create_endpoint(client, member_headers, "inv-target")
+    client.post(
+        f"{API}/collectives/{cid}/invitations",
+        json={"endpoint_id": endpoint_id},
+        headers=owner_headers,
+    )
+
+    resp = client.get(
+        f"{API}/collectives/{cid}/invitations/{endpoint_id}",
+        headers=owner_headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_get_invitation_forbidden_for_outsider(client: TestClient) -> None:
+    """A user who is neither the endpoint owner nor the collective owner is
+    refused with 403."""
+    owner = _register_and_login(client, "co-owner")
+    ep_owner = _register_and_login(client, "ep-owner")
+    outsider = _register_and_login(client, "nobody")
+
+    collective = _create_collective(client, owner)
+    cid = collective["id"]
+    endpoint_id = _create_endpoint(client, ep_owner, "inv-target")
+    client.post(
+        f"{API}/collectives/{cid}/invitations",
+        json={"endpoint_id": endpoint_id},
+        headers=owner,
+    )
+
+    resp = client.get(
+        f"{API}/collectives/{cid}/invitations/{endpoint_id}",
+        headers=outsider,
+    )
+    assert resp.status_code == 403
+
+
+def test_get_invitation_404_when_missing(
+    client: TestClient, owner_headers: dict, member_headers: dict
+) -> None:
+    """No invitation row → 404, even when caller is otherwise authorized."""
+    collective = _create_collective(client, owner_headers)
+    cid = collective["id"]
+    endpoint_id = _create_endpoint(client, member_headers, "never-invited")
+
+    resp = client.get(
+        f"{API}/collectives/{cid}/invitations/{endpoint_id}",
+        headers=owner_headers,
+    )
+    assert resp.status_code == 404
+
+
+def test_invite_endpoint_by_path(
+    client: TestClient, owner_headers: dict, member_headers: dict
+) -> None:
+    """Invite-by-path resolves owner/slug and creates the same invited row
+    that the numeric-id route would."""
+    collective = _create_collective(client, owner_headers)
+    cid = collective["id"]
+    endpoint_id = _create_endpoint(client, member_headers, "by-path-target")
+
+    resp = client.post(
+        f"{API}/collectives/{cid}/invitations/by-path",
+        json={"owner_username": "member", "slug": "by-path-target"},
+        headers=owner_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["status"] == "invited"
+    assert body["endpoint_id"] == endpoint_id
+
+
+def test_invite_by_path_404_when_endpoint_missing(
+    client: TestClient, owner_headers: dict
+) -> None:
+    """Invite-by-path returns 404 when the path doesn't resolve."""
+    collective = _create_collective(client, owner_headers)
+    cid = collective["id"]
+    resp = client.post(
+        f"{API}/collectives/{cid}/invitations/by-path",
+        json={"owner_username": "nobody", "slug": "nothing"},
+        headers=owner_headers,
+    )
+    assert resp.status_code == 404
+
+
+def test_invite_by_path_rejects_private_endpoint(
+    client: TestClient, owner_headers: dict, member_headers: dict
+) -> None:
+    """Invite-by-path only resolves public endpoints — private endpoints are
+    not discoverable via owner/slug so the route refuses them with 404."""
+    collective = _create_collective(client, owner_headers)
+    cid = collective["id"]
+    _create_endpoint(client, member_headers, "secret-data", visibility="private")
+    resp = client.post(
+        f"{API}/collectives/{cid}/invitations/by-path",
+        json={"owner_username": "member", "slug": "secret-data"},
+        headers=owner_headers,
+    )
+    assert resp.status_code == 404
+
+
+def test_invite_by_path_requires_collective_owner(
+    client: TestClient, owner_headers: dict, member_headers: dict
+) -> None:
+    """A non-owner cannot invite via the path-based route either."""
+    collective = _create_collective(client, owner_headers)
+    cid = collective["id"]
+    _create_endpoint(client, member_headers, "by-path-target")
+
+    resp = client.post(
+        f"{API}/collectives/{cid}/invitations/by-path",
+        json={"owner_username": "member", "slug": "by-path-target"},
+        headers=member_headers,
+    )
+    assert resp.status_code == 403
+
+
 # ----------------------------------------------------------------------
 # Membership — endpoint type eligibility (data sources only)
 # ----------------------------------------------------------------------

--- a/components/frontend/src/app.tsx
+++ b/components/frontend/src/app.tsx
@@ -32,6 +32,7 @@ const CollectivesPage = lazyWithRetry(() => import('./pages/collectives'));
 const CollectiveDetailPage = lazyWithRetry(() => import('./pages/collective-detail'));
 const CollectiveAdminPage = lazyWithRetry(() => import('./pages/collective-admin'));
 const CreateCollectivePage = lazyWithRetry(() => import('./pages/create-collective'));
+const CollectiveInvitationPage = lazyWithRetry(() => import('./pages/collective-invitation'));
 // TODO(agent-feature): Uncomment when agent endpoint UI is re-enabled
 // const AgentPage = lazyWithRetry(() => import('./pages/agent'));
 const NotFoundPage = lazyWithRetry(() => import('./pages/not-found'));
@@ -155,6 +156,19 @@ export default function App() {
                           <ProtectedRoute>
                             <RouteBoundary>
                               <CreateCollectivePage />
+                            </RouteBoundary>
+                          </ProtectedRoute>
+                        }
+                      />
+                      {/* Invitation-response landing page linked from the
+                          invitation email — auth required so we know who
+                          is responding. */}
+                      <Route
+                        path='collectives/:slug/invitations/:endpointId'
+                        element={
+                          <ProtectedRoute>
+                            <RouteBoundary>
+                              <CollectiveInvitationPage />
                             </RouteBoundary>
                           </ProtectedRoute>
                         }

--- a/components/frontend/src/hooks/use-collectives.ts
+++ b/components/frontend/src/hooks/use-collectives.ts
@@ -21,7 +21,9 @@ import {
   createCollective,
   deleteCollective,
   getCollectiveBySlug,
+  getInvitation,
   inviteEndpoint,
+  inviteEndpointByPath,
   listCollectives,
   listCollectivesPaginated,
   listMembers,
@@ -66,6 +68,19 @@ export function useCollectiveBySlug(slug: string | undefined) {
   });
 }
 
+/**
+ * Fetch a single invitation (membership row) by collective + endpoint id.
+ * Readable by the endpoint owner, the collective owner, or an admin — backs
+ * the invitation-response landing page reached from the invitation email.
+ */
+export function useInvitation(collectiveId: number | undefined, endpointId: number | undefined) {
+  return useQuery({
+    queryKey: collectiveKeys.invitation(collectiveId ?? 0, endpointId ?? 0),
+    queryFn: () => (collectiveId && endpointId ? getInvitation(collectiveId, endpointId) : null),
+    enabled: Boolean(collectiveId && endpointId)
+  });
+}
+
 /** List a collective's memberships, optionally filtered by workflow status. */
 export function useCollectiveMembers(collectiveId: number | undefined, status?: MembershipStatus) {
   return useQuery({
@@ -91,7 +106,9 @@ function useInvalidateMembers() {
   const queryClient = useQueryClient();
   return useCallback(
     (collectiveId: number) =>
-      void queryClient.invalidateQueries({ queryKey: collectiveKeys.members(collectiveId) }),
+      void queryClient.invalidateQueries({
+        queryKey: collectiveKeys.membersByCollective(collectiveId)
+      }),
     [queryClient]
   );
 }
@@ -140,6 +157,53 @@ export function useRequestJoin() {
   });
 }
 
+/** Outcome of a {@link useRequestJoinMany} call. */
+export interface RequestJoinManyResult {
+  /** Endpoints whose join request succeeded. */
+  succeeded: number[];
+  /** Per-endpoint failures, surfaced so the UI can report a partial result. */
+  failed: { endpointId: number; error: Error }[];
+}
+
+/**
+ * Submit join requests for multiple endpoints in parallel.
+ *
+ * The backend exposes only the single-endpoint route, so we fan out and gather
+ * results with `Promise.allSettled` — every endpoint succeeds or fails on its
+ * own and the caller renders a partial-success summary if any fail.
+ */
+export function useRequestJoinMany() {
+  const invalidateMembers = useInvalidateMembers();
+  return useMutation<RequestJoinManyResult, Error, { collectiveId: number; endpointIds: number[] }>(
+    {
+      mutationFn: async ({ collectiveId, endpointIds }) => {
+        const settled = await Promise.allSettled(
+          endpointIds.map((endpointId) => requestJoin(collectiveId, endpointId))
+        );
+        const succeeded: number[] = [];
+        const failed: { endpointId: number; error: Error }[] = [];
+        for (const [index, outcome] of settled.entries()) {
+          const endpointId = endpointIds[index];
+          if (endpointId === undefined) continue;
+          if (outcome.status === 'fulfilled') {
+            succeeded.push(endpointId);
+          } else {
+            failed.push({
+              endpointId,
+              error:
+                outcome.reason instanceof Error ? outcome.reason : new Error(String(outcome.reason))
+            });
+          }
+        }
+        return { succeeded, failed };
+      },
+      onSuccess: (_data, { collectiveId }) => {
+        invalidateMembers(collectiveId);
+      }
+    }
+  );
+}
+
 /** Approve or reject a pending join request (collective owner). */
 export function useReviewRequest() {
   const invalidateMembers = useInvalidateMembers();
@@ -183,8 +247,31 @@ export function useInviteEndpoint() {
   });
 }
 
+/**
+ * Invite an endpoint into a collective by its `owner/slug` path. Backs the
+ * admin invite-endpoint modal.
+ */
+export function useInviteEndpointByPath() {
+  const invalidateMembers = useInvalidateMembers();
+  return useMutation({
+    mutationFn: ({
+      collectiveId,
+      ownerUsername,
+      slug
+    }: {
+      collectiveId: number;
+      ownerUsername: string;
+      slug: string;
+    }) => inviteEndpointByPath(collectiveId, ownerUsername, slug),
+    onSuccess: (_data, { collectiveId }) => {
+      invalidateMembers(collectiveId);
+    }
+  });
+}
+
 /** Accept or decline a collective invitation (endpoint owner). */
 export function useRespondToInvitation() {
+  const queryClient = useQueryClient();
   const invalidateMembers = useInvalidateMembers();
   return useMutation({
     mutationFn: ({
@@ -196,8 +283,11 @@ export function useRespondToInvitation() {
       endpointId: number;
       decision: InvitationDecision;
     }) => respondToInvitation(collectiveId, endpointId, decision),
-    onSuccess: (_data, { collectiveId }) => {
+    onSuccess: (_data, { collectiveId, endpointId }) => {
       invalidateMembers(collectiveId);
+      void queryClient.invalidateQueries({
+        queryKey: collectiveKeys.invitation(collectiveId, endpointId)
+      });
     }
   });
 }

--- a/components/frontend/src/lib/collectives-api.ts
+++ b/components/frontend/src/lib/collectives-api.ts
@@ -321,6 +321,34 @@ export function inviteEndpoint(
   });
 }
 
+/**
+ * Invite an endpoint into a collective by its `owner/slug` path. Collective
+ * owner only. Used by the admin invite UI since the public endpoint API does
+ * not expose numeric ids.
+ */
+export function inviteEndpointByPath(
+  collectiveId: number,
+  ownerUsername: string,
+  slug: string
+): Promise<CollectiveMember> {
+  return request<CollectiveMember>(`/${collectiveId}/invitations/by-path`, {
+    method: 'POST',
+    body: { owner_username: ownerUsername, slug },
+    auth: true
+  });
+}
+
+/**
+ * Fetch the membership row for an invitation. Readable by the endpoint owner,
+ * the collective owner, or an admin — backs the invitation-response landing
+ * page reached from the invitation email.
+ */
+export function getInvitation(collectiveId: number, endpointId: number): Promise<CollectiveMember> {
+  return request<CollectiveMember>(`/${collectiveId}/invitations/${endpointId}`, {
+    auth: true
+  });
+}
+
 /** Accept or decline a collective invitation. Endpoint owner only. */
 export function respondToInvitation(
   collectiveId: number,

--- a/components/frontend/src/lib/query-keys.ts
+++ b/components/frontend/src/lib/query-keys.ts
@@ -55,6 +55,10 @@ export const collectiveKeys = {
   paginated: (page: number, limit: number, search?: string) =>
     [...collectiveKeys.all, 'list', 'paginated', page, limit, search ?? ''] as const,
   detail: (slug: string) => [...collectiveKeys.all, 'detail', slug] as const,
+  membersByCollective: (collectiveId: number) =>
+    [...collectiveKeys.all, 'members', collectiveId] as const,
   members: (collectiveId: number, status?: string) =>
-    [...collectiveKeys.all, 'members', collectiveId, status ?? 'all'] as const
+    [...collectiveKeys.all, 'members', collectiveId, status ?? 'all'] as const,
+  invitation: (collectiveId: number, endpointId: number) =>
+    [...collectiveKeys.all, 'invitation', collectiveId, endpointId] as const
 };

--- a/components/frontend/src/pages/collective-admin.tsx
+++ b/components/frontend/src/pages/collective-admin.tsx
@@ -1,14 +1,18 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { Collective, CollectiveMember } from '@/lib/collectives-api';
+import type { ChatSource } from '@/lib/types';
 import type { ReactNode } from 'react';
 
 import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left';
+import Mail from 'lucide-react/dist/esm/icons/mail';
 import ShieldCheck from 'lucide-react/dist/esm/icons/shield-check';
 import Trash2 from 'lucide-react/dist/esm/icons/trash-2';
 import UserCheck from 'lucide-react/dist/esm/icons/user-check';
+import UserPlus from 'lucide-react/dist/esm/icons/user-plus';
 import UserX from 'lucide-react/dist/esm/icons/user-x';
 import Users from 'lucide-react/dist/esm/icons/users';
+import X from 'lucide-react/dist/esm/icons/x';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
@@ -25,14 +29,16 @@ import {
   useCollectiveBySlug,
   useCollectiveMembers,
   useDeleteCollective,
+  useInviteEndpointByPath,
   useRemoveMember,
   useReviewRequest,
   useUpdateCollective
 } from '@/hooks/use-collectives';
-import { parseTags } from '@/lib/collectives-api';
+import { useEndpointByPath } from '@/hooks/use-endpoint-queries';
+import { isJoinableEndpointType, parseTags } from '@/lib/collectives-api';
 import { formatDate } from '@/lib/date-utils';
 
-type AdminTab = 'members' | 'requests' | 'settings';
+type AdminTab = 'members' | 'requests' | 'invitations' | 'settings';
 
 /**
  * Collective administration (`/c/:slug/admin`). Owner only — the route is
@@ -84,18 +90,22 @@ export default function CollectiveAdminPage() {
 
 function CollectiveAdminContent({ collective }: Readonly<{ collective: Collective }>) {
   const [activeTab, setActiveTab] = useState<AdminTab>('members');
+  const [inviteModalOpen, setInviteModalOpen] = useState(false);
 
   const { data: approvedMembers } = useCollectiveMembers(collective.id, 'approved');
   const { data: pendingMembers } = useCollectiveMembers(collective.id, 'pending');
+  const { data: invitedMembers } = useCollectiveMembers(collective.id, 'invited');
   const removeMember = useRemoveMember();
   const reviewRequest = useReviewRequest();
 
   const members = approvedMembers ?? [];
   const requests = pendingMembers ?? [];
+  const invitations = invitedMembers ?? [];
 
   const tabs: { id: AdminTab; label: string; badge?: number }[] = [
     { id: 'members', label: 'Members' },
     { id: 'requests', label: 'Requests', badge: requests.length },
+    { id: 'invitations', label: 'Invitations', badge: invitations.length },
     { id: 'settings', label: 'Settings' }
   ];
 
@@ -113,15 +123,28 @@ function CollectiveAdminContent({ collective }: Readonly<{ collective: Collectiv
             Back to {collective.name}
           </Link>
         </Button>
-        <h1 className='font-rubik text-foreground flex items-center gap-2 text-3xl font-semibold'>
-          Manage {collective.name}
-          {collective.verified && (
-            <ShieldCheck className='h-6 w-6 text-green-500' aria-label='Verified collective' />
-          )}
-        </h1>
-        <p className='font-inter text-muted-foreground mt-1'>
-          Administer this collective's members, join requests and settings
-        </p>
+        <div className='flex items-start justify-between gap-4'>
+          <div>
+            <h1 className='font-rubik text-foreground flex items-center gap-2 text-3xl font-semibold'>
+              Manage {collective.name}
+              {collective.verified && (
+                <ShieldCheck className='h-6 w-6 text-green-500' aria-label='Verified collective' />
+              )}
+            </h1>
+            <p className='font-inter text-muted-foreground mt-1'>
+              Administer this collective's members, join requests and settings
+            </p>
+          </div>
+          <Button
+            onClick={() => {
+              setInviteModalOpen(true);
+            }}
+            className='shrink-0'
+          >
+            <UserPlus className='mr-2 h-4 w-4' />
+            Invite endpoint
+          </Button>
+        </div>
       </div>
 
       <div className='mb-8 grid grid-cols-2 gap-4'>
@@ -195,8 +218,9 @@ function CollectiveAdminContent({ collective }: Readonly<{ collective: Collectiv
                       });
                     }}
                     title='Remove from collective'
+                    className='text-muted-foreground hover:text-destructive'
                   >
-                    <UserX className='h-4 w-4' />
+                    <Trash2 className='h-4 w-4' />
                   </Button>
                 }
               />
@@ -267,7 +291,67 @@ function CollectiveAdminContent({ collective }: Readonly<{ collective: Collectiv
         </div>
       )}
 
+      {activeTab === 'invitations' && (
+        <div className='space-y-3'>
+          {invitations.length > 0 ? (
+            invitations.map((invitation) => (
+              <MemberRow
+                key={invitation.id}
+                member={invitation}
+                subtitle={
+                  <>
+                    {invitation.endpoint_owner_username
+                      ? `@${invitation.endpoint_owner_username}`
+                      : 'owner unknown'}{' '}
+                    · invited {formatDate(invitation.requested_at)}
+                  </>
+                }
+                actions={
+                  <Button
+                    size='sm'
+                    variant='outline'
+                    disabled={removeMember.isPending}
+                    onClick={() => {
+                      removeMember.mutate({
+                        collectiveId: collective.id,
+                        endpointId: invitation.endpoint_id
+                      });
+                    }}
+                    title='Cancel invitation'
+                  >
+                    <X className='mr-1 h-4 w-4' />
+                    Cancel
+                  </Button>
+                }
+              />
+            ))
+          ) : (
+            <Card className='text-muted-foreground p-12 text-center text-sm'>
+              <Mail className='mx-auto mb-3 h-8 w-8 opacity-50' />
+              <p>No pending invitations.</p>
+              <p className='mt-2 text-xs'>
+                Use the "Invite endpoint" button above to invite an endpoint by its
+                <code className='mx-1'>owner/slug</code>
+                path.
+              </p>
+            </Card>
+          )}
+        </div>
+      )}
+
       {activeTab === 'settings' && <CollectiveSettingsForm collective={collective} />}
+
+      <InviteEndpointModal
+        isOpen={inviteModalOpen}
+        collective={collective}
+        onClose={() => {
+          setInviteModalOpen(false);
+        }}
+        onInvited={() => {
+          setInviteModalOpen(false);
+          setActiveTab('invitations');
+        }}
+      />
     </div>
   );
 }
@@ -294,6 +378,203 @@ function MemberRow({
       </div>
     </Card>
   );
+}
+
+/**
+ * Modal for inviting an endpoint into the collective by `owner/slug` path.
+ *
+ * The collective owner enters a path (e.g. `alice/genome-data`), we preview
+ * the resolved endpoint via the public-by-path API, and on confirm send an
+ * invitation. Only data-source endpoints are joinable; the modal blocks
+ * submission when the resolved endpoint isn't eligible.
+ */
+function InviteEndpointModal({
+  isOpen,
+  collective,
+  onClose,
+  onInvited
+}: Readonly<{
+  isOpen: boolean;
+  collective: Collective;
+  onClose: () => void;
+  onInvited: () => void;
+}>) {
+  const [path, setPath] = useState('');
+  // Debounced path used for the actual lookup so we don't spam the API while
+  // the user is still typing.
+  const [debouncedPath, setDebouncedPath] = useState('');
+  const inviteMutation = useInviteEndpointByPath();
+  const resetInvite = inviteMutation.reset;
+
+  useEffect(() => {
+    const trimmed = path.trim();
+    if (!trimmed) {
+      setDebouncedPath('');
+      return;
+    }
+    const timer = setTimeout(() => {
+      setDebouncedPath(trimmed);
+    }, 300);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [path]);
+
+  // Reset when the modal closes so reopening starts fresh. Depend on the
+  // stable `reset` method, not the mutation object — `useMutation` returns a
+  // fresh result object every render, which would re-fire this effect on
+  // every render.
+  useEffect(() => {
+    if (!isOpen) {
+      setPath('');
+      setDebouncedPath('');
+      resetInvite();
+    }
+  }, [isOpen, resetInvite]);
+
+  const parsed = parseOwnerSlug(debouncedPath);
+  const { data: endpoint, isFetching: isResolving } = useEndpointByPath(
+    parsed ? `${parsed.owner}/${parsed.slug}` : undefined
+  );
+
+  const ineligibleType = endpoint?.type != null && !isJoinableEndpointType(endpoint.type);
+
+  const canSubmit =
+    parsed != null && endpoint != null && !ineligibleType && !inviteMutation.isPending;
+
+  const handleSubmit = () => {
+    if (!parsed) return;
+    inviteMutation.mutate(
+      { collectiveId: collective.id, ownerUsername: parsed.owner, slug: parsed.slug },
+      { onSuccess: onInvited }
+    );
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title='Invite an endpoint'>
+      <div className='space-y-4'>
+        <div>
+          <Label htmlFor='invite-path'>Endpoint path</Label>
+          <Input
+            id='invite-path'
+            placeholder='owner/endpoint-slug'
+            value={path}
+            onChange={(e) => {
+              setPath(e.target.value);
+            }}
+            className='mt-1 font-mono text-sm'
+          />
+          <p className='text-muted-foreground mt-1 text-xs'>
+            Enter the public path of a data-source endpoint, e.g. <code>alice/genome-data</code>.
+            The endpoint owner receives an email and decides whether to accept.
+          </p>
+        </div>
+
+        <InvitePreview
+          path={debouncedPath}
+          parsed={parsed}
+          endpoint={endpoint ?? null}
+          isResolving={isResolving}
+          ineligibleType={ineligibleType}
+        />
+
+        {inviteMutation.isError && (
+          <p className='text-destructive text-sm'>
+            {inviteMutation.error instanceof Error
+              ? inviteMutation.error.message
+              : 'Failed to send invitation'}
+          </p>
+        )}
+
+        <div className='flex justify-end gap-2 pt-2'>
+          <Button variant='outline' onClick={onClose}>
+            Cancel
+          </Button>
+          <Button disabled={!canSubmit} onClick={handleSubmit}>
+            <Mail className='mr-2 h-4 w-4' />
+            {inviteMutation.isPending ? 'Sending...' : 'Send invitation'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+/**
+ * Render the resolved-endpoint preview block beneath the path input — empty
+ * state, loading, error, mismatch, or a confirmed match.
+ */
+function InvitePreview({
+  path,
+  parsed,
+  endpoint,
+  isResolving,
+  ineligibleType
+}: Readonly<{
+  path: string;
+  parsed: { owner: string; slug: string } | null;
+  endpoint: ChatSource | null;
+  isResolving: boolean;
+  ineligibleType: boolean;
+}>) {
+  if (!path) {
+    return null;
+  }
+  if (!parsed) {
+    return (
+      <p className='text-destructive text-sm'>
+        Path must look like <code>owner/endpoint-slug</code>.
+      </p>
+    );
+  }
+  if (isResolving) {
+    return <p className='text-muted-foreground text-sm'>Looking up endpoint...</p>;
+  }
+  if (!endpoint) {
+    return (
+      <p className='text-destructive text-sm'>
+        No public endpoint at{' '}
+        <code>
+          {parsed.owner}/{parsed.slug}
+        </code>
+        .
+      </p>
+    );
+  }
+  if (ineligibleType) {
+    return (
+      <Card className='border-destructive/30 bg-destructive/5 p-3 text-sm'>
+        <p className='font-medium'>{endpoint.name}</p>
+        <p className='text-muted-foreground text-xs'>
+          @{endpoint.owner_username} · {endpoint.type}
+        </p>
+        <p className='text-destructive mt-2 text-xs'>
+          Only data-source endpoints can join a collective.
+        </p>
+      </Card>
+    );
+  }
+  return (
+    <Card className='border-primary/30 bg-primary/5 p-3 text-sm'>
+      <p className='font-medium'>{endpoint.name}</p>
+      <p className='text-muted-foreground text-xs'>
+        @{endpoint.owner_username} · {endpoint.type}
+      </p>
+      {endpoint.description && (
+        <p className='text-muted-foreground mt-2 text-xs'>{endpoint.description}</p>
+      )}
+    </Card>
+  );
+}
+
+function parseOwnerSlug(path: string): { owner: string; slug: string } | null {
+  const trimmed = path.trim().replace(/^@/, '').replace(/^\//, '');
+  if (!trimmed) return null;
+  const parts = trimmed.split('/');
+  if (parts.length !== 2) return null;
+  const [owner, slug] = parts;
+  if (!owner || !slug) return null;
+  return { owner, slug };
 }
 
 /** General-settings form + danger zone for the collective. */

--- a/components/frontend/src/pages/collective-detail.tsx
+++ b/components/frontend/src/pages/collective-detail.tsx
@@ -19,10 +19,15 @@ import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { Modal } from '@/components/ui/modal';
 import { useAuth } from '@/context/auth-context';
-import { useCollectiveBySlug, useCollectiveMembers, useRequestJoin } from '@/hooks/use-collectives';
+import {
+  useCollectiveBySlug,
+  useCollectiveMembers,
+  useRequestJoinMany
+} from '@/hooks/use-collectives';
 import { useMyEndpoints } from '@/hooks/use-endpoint-queries';
 import { isJoinableEndpointType } from '@/lib/collectives-api';
 import { getEndpointTypeLabel } from '@/lib/endpoint-utils';
@@ -443,8 +448,10 @@ function JoinCollectiveModal({
   collectiveName,
   username
 }: Readonly<JoinModalProps>) {
-  const [selectedEndpointId, setSelectedEndpointId] = useState<number | null>(null);
-  const requestJoin = useRequestJoin();
+  const [selectedEndpointIds, setSelectedEndpointIds] = useState<ReadonlySet<number>>(
+    () => new Set()
+  );
+  const requestJoinMany = useRequestJoinMany();
 
   const { data: endpoints, isLoading } = useMyEndpoints(username, isOpen);
 
@@ -455,19 +462,67 @@ function JoinCollectiveModal({
     [endpoints]
   );
 
+  const allSelected =
+    joinableEndpoints.length > 0 && selectedEndpointIds.size === joinableEndpoints.length;
+  const someSelected = selectedEndpointIds.size > 0 && !allSelected;
+  let selectAllChecked: boolean | 'indeterminate' = false;
+  if (allSelected) {
+    selectAllChecked = true;
+  } else if (someSelected) {
+    selectAllChecked = 'indeterminate';
+  }
+
+  const toggleEndpoint = (endpointId: number) => {
+    setSelectedEndpointIds((current) => {
+      const next = new Set(current);
+      if (next.has(endpointId)) {
+        next.delete(endpointId);
+      } else {
+        next.add(endpointId);
+      }
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    setSelectedEndpointIds((current) =>
+      current.size === joinableEndpoints.length
+        ? new Set()
+        : new Set(joinableEndpoints.map((endpoint) => endpoint.id))
+    );
+  };
+
   const handleClose = () => {
-    setSelectedEndpointId(null);
-    requestJoin.reset();
+    setSelectedEndpointIds(new Set());
+    requestJoinMany.reset();
     onClose();
   };
 
   const handleSubmit = () => {
-    if (selectedEndpointId == null) return;
-    requestJoin.mutate(
-      { collectiveId, endpointId: selectedEndpointId },
-      { onSuccess: handleClose }
+    if (selectedEndpointIds.size === 0) return;
+    requestJoinMany.mutate(
+      { collectiveId, endpointIds: [...selectedEndpointIds] },
+      {
+        onSuccess: (result) => {
+          // Only close when every request succeeded — otherwise stay open so
+          // the user can see which endpoints failed and retry just those.
+          if (result.failed.length === 0) {
+            handleClose();
+          } else {
+            setSelectedEndpointIds(new Set(result.failed.map((failure) => failure.endpointId)));
+          }
+        }
+      }
     );
   };
+
+  const failureById = useMemo(() => {
+    const map = new Map<number, string>();
+    for (const { endpointId, error } of requestJoinMany.data?.failed ?? []) {
+      map.set(endpointId, error.message);
+    }
+    return map;
+  }, [requestJoinMany.data]);
 
   let endpointPicker: ReactNode;
   if (isLoading) {
@@ -478,26 +533,50 @@ function JoinCollectiveModal({
     );
   } else if (joinableEndpoints.length > 0) {
     endpointPicker = (
-      <div className='max-h-64 space-y-2 overflow-y-auto'>
-        {joinableEndpoints.map((endpoint) => (
-          <button
-            key={endpoint.id}
-            type='button'
-            onClick={() => {
-              setSelectedEndpointId(endpoint.id);
-            }}
-            className={`w-full rounded-lg border p-3 text-left transition-colors ${
-              selectedEndpointId === endpoint.id
-                ? 'border-primary bg-primary/5'
-                : 'border-border hover:bg-muted/50'
-            }`}
-          >
-            <p className='text-sm font-medium'>{endpoint.name}</p>
-            <p className='text-muted-foreground text-xs'>
-              @{username}/{endpoint.slug}
-            </p>
-          </button>
-        ))}
+      <div className='space-y-2'>
+        <label className='hover:bg-muted/50 flex cursor-pointer items-center gap-3 rounded-lg border border-dashed px-3 py-2'>
+          <Checkbox
+            checked={selectAllChecked}
+            onCheckedChange={toggleAll}
+            aria-label='Select all data source endpoints'
+          />
+          <span className='text-sm font-medium'>Select all</span>
+          <span className='text-muted-foreground ml-auto text-xs'>
+            {selectedEndpointIds.size} of {joinableEndpoints.length} selected
+          </span>
+        </label>
+        <div className='max-h-64 space-y-2 overflow-y-auto'>
+          {joinableEndpoints.map((endpoint) => {
+            const checked = selectedEndpointIds.has(endpoint.id);
+            const failureMessage = failureById.get(endpoint.id);
+            return (
+              <label
+                key={endpoint.id}
+                className={`flex w-full cursor-pointer items-start gap-3 rounded-lg border p-3 text-left transition-colors ${
+                  checked ? 'border-primary bg-primary/5' : 'border-border hover:bg-muted/50'
+                }`}
+              >
+                <Checkbox
+                  checked={checked}
+                  onCheckedChange={() => {
+                    toggleEndpoint(endpoint.id);
+                  }}
+                  className='mt-0.5'
+                  aria-label={`Submit ${endpoint.name}`}
+                />
+                <div className='min-w-0 flex-1'>
+                  <p className='text-sm font-medium'>{endpoint.name}</p>
+                  <p className='text-muted-foreground truncate text-xs'>
+                    @{username}/{endpoint.slug}
+                  </p>
+                  {failureMessage && (
+                    <p className='text-destructive mt-1 text-xs'>{failureMessage}</p>
+                  )}
+                </div>
+              </label>
+            );
+          })}
+        </div>
       </div>
     );
   } else {
@@ -508,21 +587,39 @@ function JoinCollectiveModal({
     );
   }
 
+  const submitLabel = (() => {
+    if (requestJoinMany.isPending) return 'Submitting...';
+    const count = selectedEndpointIds.size;
+    if (count <= 1) return 'Submit';
+    return `Submit ${count} endpoints`;
+  })();
+
   return (
     <Modal isOpen={isOpen} onClose={handleClose} title={`Join ${collectiveName}`}>
       <div className='space-y-4'>
         <p className='text-muted-foreground text-sm'>
-          Choose one of your data source endpoints to submit to this collective. Model and agent
-          endpoints aren't eligible to join.
+          Choose one or more of your data source endpoints to submit to this collective. Model and
+          agent endpoints aren't eligible to join.
         </p>
 
         {endpointPicker}
 
-        {requestJoin.isError && (
+        {requestJoinMany.isError && (
           <p className='text-destructive text-sm'>
-            {requestJoin.error instanceof Error
-              ? requestJoin.error.message
+            {requestJoinMany.error instanceof Error
+              ? requestJoinMany.error.message
               : 'Failed to submit request'}
+          </p>
+        )}
+        {requestJoinMany.data && requestJoinMany.data.failed.length > 0 && (
+          <p className='text-destructive text-sm'>
+            {requestJoinMany.data.succeeded.length > 0
+              ? `Submitted ${requestJoinMany.data.succeeded.length} endpoint${
+                  requestJoinMany.data.succeeded.length === 1 ? '' : 's'
+                }, but ${requestJoinMany.data.failed.length} failed.`
+              : `Failed to submit ${requestJoinMany.data.failed.length} endpoint${
+                  requestJoinMany.data.failed.length === 1 ? '' : 's'
+                }.`}
           </p>
         )}
 
@@ -532,9 +629,9 @@ function JoinCollectiveModal({
           </Button>
           <Button
             onClick={handleSubmit}
-            disabled={selectedEndpointId == null || requestJoin.isPending}
+            disabled={selectedEndpointIds.size === 0 || requestJoinMany.isPending}
           >
-            {requestJoin.isPending ? 'Submitting...' : 'Submit'}
+            {submitLabel}
           </Button>
         </div>
       </div>

--- a/components/frontend/src/pages/collective-invitation.tsx
+++ b/components/frontend/src/pages/collective-invitation.tsx
@@ -1,0 +1,284 @@
+import { useState } from 'react';
+
+import type { Collective, CollectiveMember } from '@/lib/collectives-api';
+
+import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left';
+import Check from 'lucide-react/dist/esm/icons/check';
+import ShieldCheck from 'lucide-react/dist/esm/icons/shield-check';
+import X from 'lucide-react/dist/esm/icons/x';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import { CollectiveIcon } from '@/components/collectives/collective-icon';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { useAuth } from '@/context/auth-context';
+import {
+  useCollectiveBySlug,
+  useInvitation,
+  useRespondToInvitation
+} from '@/hooks/use-collectives';
+import { formatDate } from '@/lib/date-utils';
+
+/**
+ * Invitation-response landing page (`/collectives/:slug/invitations/:endpointId`).
+ *
+ * Linked from the invitation email. The recipient (endpoint owner) sees the
+ * invitation details and can accept or decline; the page also handles the
+ * already-responded states so re-visiting the email link doesn't 409.
+ */
+export default function CollectiveInvitationPage() {
+  const { slug, endpointId } = useParams<{ slug: string; endpointId: string }>();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const endpointIdNumber = endpointId ? Number(endpointId) : undefined;
+
+  const {
+    data: collective,
+    isLoading: collectiveLoading,
+    isError: collectiveError
+  } = useCollectiveBySlug(slug);
+  const {
+    data: invitation,
+    isLoading: invitationLoading,
+    error: invitationError
+  } = useInvitation(collective?.id, endpointIdNumber);
+
+  if (collectiveLoading || invitationLoading) {
+    return (
+      <div className='flex min-h-[60vh] items-center justify-center'>
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (collectiveError || !collective) {
+    return (
+      <ErrorState
+        title='Collective not found'
+        message="The collective in this invitation link doesn't exist or has been deleted."
+      />
+    );
+  }
+
+  if (invitationError || !invitation) {
+    const message =
+      invitationError instanceof Error
+        ? invitationError.message
+        : 'This invitation no longer exists.';
+    return <ErrorState title='Invitation unavailable' message={message} slug={collective.slug} />;
+  }
+
+  return (
+    <InvitationContent
+      collective={collective}
+      invitation={invitation}
+      currentUsername={user?.username ?? null}
+      onBack={() => {
+        void navigate(`/c/${collective.slug}`);
+      }}
+    />
+  );
+}
+
+interface InvitationContentProps {
+  readonly collective: Collective;
+  readonly invitation: CollectiveMember;
+  readonly currentUsername: string | null;
+  readonly onBack: () => void;
+}
+
+function InvitationContent({
+  collective,
+  invitation,
+  currentUsername,
+  onBack
+}: InvitationContentProps) {
+  const respond = useRespondToInvitation();
+  const [pendingDecision, setPendingDecision] = useState<'accept' | 'decline' | null>(null);
+
+  // The collective owner CAN read this page (they invited the endpoint), but
+  // only the endpoint owner can accept/decline. Hide the action buttons for
+  // anyone else so the page still renders informatively.
+  const isEndpointOwner =
+    currentUsername != null && invitation.endpoint_owner_username === currentUsername;
+
+  const onDecide = (decision: 'accept' | 'decline') => {
+    setPendingDecision(decision);
+    respond.mutate({
+      collectiveId: invitation.collective_id,
+      endpointId: invitation.endpoint_id,
+      decision
+    });
+  };
+
+  return (
+    <div className='mx-auto max-w-2xl px-6 py-12'>
+      <Button
+        variant='ghost'
+        size='sm'
+        className='text-muted-foreground hover:text-foreground mb-6 -ml-2'
+        onClick={onBack}
+      >
+        <ArrowLeft className='mr-2 h-4 w-4' />
+        Back to {collective.name}
+      </Button>
+
+      <Card className='p-8'>
+        <div className='mb-6 flex items-start gap-4'>
+          <CollectiveIcon collective={collective} size='lg' />
+          <div className='min-w-0 flex-1'>
+            <h1 className='font-rubik text-foreground flex flex-wrap items-center gap-2 text-2xl font-semibold'>
+              You're invited to {collective.name}
+              {collective.verified && (
+                <ShieldCheck className='h-5 w-5 text-green-500' aria-label='Verified collective' />
+              )}
+            </h1>
+            {collective.description && (
+              <p className='font-inter text-muted-foreground mt-2 text-sm'>
+                {collective.description}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className='border-border bg-muted/30 mb-6 rounded-md border p-4 text-sm'>
+          <p className='text-muted-foreground'>
+            Endpoint{' '}
+            <span className='text-foreground font-medium'>
+              {invitation.endpoint_name ?? `#${invitation.endpoint_id}`}
+            </span>
+            {invitation.endpoint_owner_username && (
+              <>
+                {' '}
+                · <span>@{invitation.endpoint_owner_username}</span>
+              </>
+            )}
+            {invitation.endpoint_type && (
+              <>
+                {' '}
+                · <Badge variant='secondary'>{invitation.endpoint_type}</Badge>
+              </>
+            )}
+          </p>
+          <p className='text-muted-foreground mt-1 text-xs'>
+            Invited {formatDate(invitation.requested_at)}
+          </p>
+        </div>
+
+        <StatusPanel invitation={invitation} isEndpointOwner={isEndpointOwner} />
+
+        {invitation.status === 'invited' && isEndpointOwner && (
+          <div className='mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end'>
+            <Button
+              variant='outline'
+              disabled={respond.isPending}
+              onClick={() => {
+                onDecide('decline');
+              }}
+            >
+              <X className='mr-2 h-4 w-4' />
+              {respond.isPending && pendingDecision === 'decline' ? 'Declining...' : 'Decline'}
+            </Button>
+            <Button
+              disabled={respond.isPending}
+              onClick={() => {
+                onDecide('accept');
+              }}
+            >
+              <Check className='mr-2 h-4 w-4' />
+              {respond.isPending && pendingDecision === 'accept'
+                ? 'Accepting...'
+                : 'Accept invitation'}
+            </Button>
+          </div>
+        )}
+
+        {respond.isError && (
+          <p className='text-destructive mt-4 text-sm'>
+            {respond.error instanceof Error
+              ? respond.error.message
+              : 'Failed to record your response. Please try again.'}
+          </p>
+        )}
+
+        {invitation.status === 'approved' && (
+          <div className='mt-6'>
+            <Button asChild>
+              <Link to={`/c/${collective.slug}`}>View collective</Link>
+            </Button>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}
+
+function StatusPanel({
+  invitation,
+  isEndpointOwner
+}: Readonly<{ invitation: CollectiveMember; isEndpointOwner: boolean }>) {
+  switch (invitation.status) {
+    case 'invited': {
+      return isEndpointOwner ? (
+        <p className='text-muted-foreground text-sm'>
+          Accepting the invitation makes this endpoint a member of the collective. Members can be
+          discovered through the collective and used as shared data sources.
+        </p>
+      ) : (
+        <p className='text-muted-foreground text-sm'>
+          This invitation is awaiting a response from{' '}
+          <span className='text-foreground font-medium'>
+            @{invitation.endpoint_owner_username ?? 'the endpoint owner'}
+          </span>
+          . Only the endpoint owner can accept or decline it.
+        </p>
+      );
+    }
+    case 'approved': {
+      return (
+        <div className='border-border rounded-md border bg-emerald-500/10 p-4 text-sm text-emerald-700 dark:text-emerald-300'>
+          This invitation has already been accepted — the endpoint is a member of the collective.
+        </div>
+      );
+    }
+    case 'rejected': {
+      return (
+        <div className='border-border bg-muted text-muted-foreground rounded-md border p-4 text-sm'>
+          This invitation was declined. You can re-issue it from the collective admin page if you
+          change your mind.
+        </div>
+      );
+    }
+    case 'pending': {
+      return (
+        <div className='border-border bg-muted text-muted-foreground rounded-md border p-4 text-sm'>
+          The endpoint owner already requested to join this collective — the collective owner just
+          needs to approve the request from the admin page.
+        </div>
+      );
+    }
+    default: {
+      return null;
+    }
+  }
+}
+
+function ErrorState({
+  title,
+  message,
+  slug
+}: Readonly<{ title: string; message: string; slug?: string }>) {
+  return (
+    <div className='mx-auto max-w-xl px-6 py-16 text-center'>
+      <h1 className='font-rubik text-foreground mb-4 text-2xl font-semibold'>{title}</h1>
+      <p className='text-muted-foreground mb-6'>{message}</p>
+      <Button asChild>
+        <Link to={slug ? `/c/${slug}` : '/browse?tab=collectives'}>
+          {slug ? 'Back to collective' : 'Browse collectives'}
+        </Link>
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Three coordinated additions to the Collectives flow, landing the
follow-up UX for the collectives feature merged in #423:

- **Invitation-response landing page.** New
  `/collectives/:slug/invitations/:endpointId` route, linked from the
  invitation email. The endpoint owner accepts/declines from one Card
  and re-visiting the link no longer 409s — the page renders the
  current status (`invited` / `approved` / `rejected` / `pending`)
  with appropriate copy and a route into the collective on success.

- **Admin "Invite endpoint" modal.** Collective owners can invite an
  endpoint by its public `owner/slug` path (the public endpoint API
  doesn't expose numeric ids). A debounced preview confirms the
  resolved endpoint and blocks ineligible types (only data sources
  can join). A new Invitations tab on the admin page lists pending
  invitations with a Cancel action.

- **Multi-endpoint join.** The Join modal now accepts a multi-select
  of joinable endpoints with Select-all. Submissions fan out in
  parallel; on partial failure the modal stays open with the failed
  endpoints re-selected and per-row error messages so the user can
  retry without losing context.

Backend
- `POST /collectives/{id}/invitations/by-path` resolves `(owner, slug)`
  to a public endpoint and delegates to the existing invite flow.
- `GET /collectives/{id}/invitations/{endpoint_id}` reads a single
  membership row, readable by the endpoint owner, the collective
  owner, or an admin. Status-tolerant so the landing page can render
  already-responded states.
- 9 new endpoint tests covering both routes.

Other
- Fix: `useInvalidateMembers` now invalidates with a `[..., 'members',
  collectiveId]` prefix so per-status `useCollectiveMembers` queries
  (approved / pending / invited) actually refetch after membership
  mutations. The previous key only matched the `'all'` status variant.
- The Remove-from-collective icon switches from `UserX` to `Trash2`
  to match its destructive intent.

## Test plan

- [x] Backend test suite: `make test` (backend) — 9 new tests pass
- [x] Frontend `tsc --noEmit` clean
- [x] Frontend ESLint + Prettier clean
- [ ] Manual: open invitation email link → land on response page → accept → redirected into collective
- [ ] Manual: re-visit the same email link after accepting → "already accepted" state, no 409
- [ ] Manual: admin invite modal — invalid path, missing user, private endpoint, model endpoint (all show appropriate errors); valid data-source path resolves preview and sends invitation
- [ ] Manual: cancel a pending invitation from the Invitations tab
- [ ] Manual: join collective with multiple endpoints; verify partial-failure path keeps the failed selections and surfaces per-row errors