### PR TITLE
feat(endpoint-detail): Collectives card on endpoint detail page

### DIFF
--- a/components/backend/src/syfthub/api/endpoints/collectives.py
+++ b/components/backend/src/syfthub/api/endpoints/collectives.py
@@ -76,6 +76,23 @@ async def get_collective_by_slug(
     return service.get_collective_by_slug(slug)
 
 
+@router.get(
+    "/by-endpoint/{owner_username}/{slug}", response_model=List[CollectiveResponse]
+)
+async def list_collectives_for_endpoint(
+    owner_username: str,
+    slug: str,
+    service: Annotated[CollectiveService, Depends(get_collective_service)],
+) -> List[CollectiveResponse]:
+    """List approved collectives an ``owner/slug`` endpoint participates in.
+
+    Public-readable. Backs the Collectives card on the endpoint detail page;
+    returns an empty list when the endpoint exists but isn't an approved
+    member of any collective, or when the endpoint can't be resolved.
+    """
+    return service.list_collectives_for_endpoint(owner_username, slug)
+
+
 @router.get("/by-slug/{slug}/endpoint-paths", response_model=List[str])
 async def get_collective_endpoint_paths(
     slug: str,

--- a/components/backend/src/syfthub/repositories/collective.py
+++ b/components/backend/src/syfthub/repositories/collective.py
@@ -195,6 +195,31 @@ class CollectiveMemberRepository(BaseRepository[CollectiveMemberModel]):
         except SQLAlchemyError:
             return []
 
+    def list_collectives_for_endpoint(
+        self,
+        endpoint_id: int,
+        statuses: Optional[Sequence[str]] = None,
+    ) -> List[CollectiveResponse]:
+        """List the collectives an endpoint participates in.
+
+        Joins ``collective_members`` to ``collectives`` so the caller gets full
+        collective rows without a second round-trip. Ordered by the membership's
+        ``requested_at`` descending — most recently joined first.
+        """
+        try:
+            stmt = (
+                select(CollectiveModel)
+                .join(self.model, self.model.collective_id == CollectiveModel.id)
+                .where(self.model.endpoint_id == endpoint_id)
+            )
+            if statuses:
+                stmt = stmt.where(self.model.status.in_(list(statuses)))
+            stmt = stmt.order_by(self.model.requested_at.desc())
+            models = self.session.execute(stmt).scalars().all()
+            return [CollectiveResponse.model_validate(m) for m in models]
+        except SQLAlchemyError:
+            return []
+
     def count_members(self, collective_id: int, status: str) -> int:
         """Count a single collective's memberships with the given status."""
         try:

--- a/components/backend/src/syfthub/services/collective_service.py
+++ b/components/backend/src/syfthub/services/collective_service.py
@@ -152,6 +152,33 @@ class CollectiveService(BaseService):
             collective.owner_count = owner_counts.get(collective.id, 0)
         return collectives
 
+    def list_collectives_for_endpoint(
+        self, owner_username: str, slug: str
+    ) -> List[CollectiveResponse]:
+        """List approved collectives an ``owner/slug`` endpoint belongs to.
+
+        Public-readable. Returns only ``APPROVED`` memberships so pending /
+        invited / rejected state never leaks to non-owners — mirrors the
+        non-owner view of ``list_members``.
+        """
+        owner = self.user_repo.get_by_username(owner_username)
+        if owner is None:
+            return []
+        endpoint = self.endpoint_repo.get_by_user_and_slug(owner.id, slug)
+        if endpoint is None:
+            return []
+        collectives = self.member_repo.list_collectives_for_endpoint(
+            endpoint.id, [MembershipStatus.APPROVED.value]
+        )
+        ids = [c.id for c in collectives]
+        approved = MembershipStatus.APPROVED.value
+        member_counts = self.member_repo.count_members_bulk(ids, approved)
+        owner_counts = self.member_repo.count_owners_bulk(ids, approved)
+        for collective in collectives:
+            collective.member_count = member_counts.get(collective.id, 0)
+            collective.owner_count = owner_counts.get(collective.id, 0)
+        return collectives
+
     def update_collective(
         self, collective_id: int, data: CollectiveUpdate, current_user: User
     ) -> CollectiveResponse:

--- a/components/frontend/src/components/endpoint/endpoint-collectives-card.tsx
+++ b/components/frontend/src/components/endpoint/endpoint-collectives-card.tsx
@@ -1,0 +1,77 @@
+import Database from 'lucide-react/dist/esm/icons/database';
+import ShieldCheck from 'lucide-react/dist/esm/icons/shield-check';
+import { Link } from 'react-router-dom';
+
+import { CollectiveIcon } from '@/components/collectives/collective-icon';
+import { useCollectivesForEndpoint } from '@/hooks/use-collectives';
+
+interface EndpointCollectivesCardProperties {
+  owner: string | undefined | null;
+  slug: string | undefined | null;
+}
+
+/**
+ * Sidebar card listing the collectives an endpoint is an approved member of.
+ *
+ * Returns ``null`` (and renders nothing) while loading, on error, or when the
+ * endpoint has no approved memberships — the card only appears when it has
+ * something to show, matching the conditional pattern of ``ConnectionCard``.
+ *
+ * Rows are compact and link the whole row to the collective page. The list
+ * area scrolls once it grows past the card's visible height so the sidebar
+ * doesn't stretch arbitrarily.
+ */
+export function EndpointCollectivesCard({
+  owner,
+  slug
+}: Readonly<EndpointCollectivesCardProperties>) {
+  const { data, isLoading, error } = useCollectivesForEndpoint(owner, slug);
+
+  if (isLoading || error) return null;
+  const collectives = data ?? [];
+  if (collectives.length === 0) return null;
+
+  return (
+    <div className='border-border bg-card rounded-xl border p-6'>
+      <div className='mb-4 flex items-center justify-between'>
+        <h3 className='font-rubik text-foreground text-sm font-medium'>Collectives</h3>
+        <span className='bg-accent text-muted-foreground rounded-full px-2 py-0.5 text-xs font-medium'>
+          {collectives.length}
+        </span>
+      </div>
+
+      <div className='scrollbar-thin scrollbar-track-transparent scrollbar-thumb-border/50 hover:scrollbar-thumb-border/80 [&::-webkit-scrollbar-thumb]:bg-border/40 [&::-webkit-scrollbar-thumb:hover]:bg-border/60 -mr-1 max-h-[280px] space-y-1 overflow-y-auto pr-1 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-transparent'>
+        {collectives.map((collective) => (
+          <Link
+            key={collective.id}
+            to={`/c/${collective.slug}`}
+            className='hover:bg-accent/50 -mx-2 flex items-center gap-3 rounded-lg px-2 py-2 transition-colors'
+          >
+            <CollectiveIcon collective={collective} size='md' />
+            <div className='min-w-0 flex-1'>
+              <div className='flex items-center gap-1'>
+                <span className='font-inter text-foreground truncate text-sm font-medium'>
+                  {collective.name}
+                </span>
+                {collective.verified ? (
+                  <ShieldCheck
+                    className='h-3.5 w-3.5 shrink-0 text-green-500'
+                    aria-label='Verified collective'
+                  />
+                ) : null}
+              </div>
+              <div className='text-muted-foreground flex items-center gap-2 text-xs'>
+                <span className='truncate'>@{collective.slug}</span>
+                <span aria-hidden='true'>·</span>
+                <span className='flex items-center gap-1 whitespace-nowrap'>
+                  <Database className='h-3 w-3' />
+                  {collective.member_count}
+                </span>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/frontend/src/components/endpoint/endpoint-detail.tsx
+++ b/components/frontend/src/components/endpoint/endpoint-detail.tsx
@@ -20,6 +20,7 @@ import { getEndpointTypeBadgeStyles, getEndpointTypeLabel } from '@/lib/endpoint
 
 import { AccessPoliciesCard } from './access-policies-card';
 import { ApiTab } from './api-tab';
+import { EndpointCollectivesCard } from './endpoint-collectives-card';
 import { UptimeTab } from './uptime-tab';
 
 type EndpointTabId = 'overview' | 'uptime' | 'api';
@@ -426,6 +427,13 @@ export const EndpointDetail = memo(function EndpointDetail({
                   endpointSlug={endpoint.full_path}
                 />
               ) : null}
+
+              {/* Collectives Card — renders only when the endpoint is an
+                  approved member of at least one collective. */}
+              <EndpointCollectivesCard
+                owner={endpoint.owner_username ?? owner}
+                slug={endpoint.slug}
+              />
             </aside>
           </div>
         </TabsContent>

--- a/components/frontend/src/hooks/use-collectives.ts
+++ b/components/frontend/src/hooks/use-collectives.ts
@@ -25,6 +25,7 @@ import {
   inviteEndpoint,
   inviteEndpointByPath,
   listCollectives,
+  listCollectivesForEndpoint,
   listCollectivesPaginated,
   listMembers,
   removeMember,
@@ -78,6 +79,22 @@ export function useInvitation(collectiveId: number | undefined, endpointId: numb
     queryKey: collectiveKeys.invitation(collectiveId ?? 0, endpointId ?? 0),
     queryFn: () => (collectiveId && endpointId ? getInvitation(collectiveId, endpointId) : null),
     enabled: Boolean(collectiveId && endpointId)
+  });
+}
+
+/**
+ * List approved collectives an `owner/slug` endpoint participates in. Backs the
+ * Collectives card on the endpoint detail page; gated until both parts of the
+ * path are known.
+ */
+export function useCollectivesForEndpoint(
+  owner: string | undefined | null,
+  slug: string | undefined | null
+) {
+  return useQuery({
+    queryKey: collectiveKeys.byEndpoint(owner ?? '', slug ?? ''),
+    queryFn: () => (owner && slug ? listCollectivesForEndpoint(owner, slug) : []),
+    enabled: Boolean(owner && slug)
   });
 }
 

--- a/components/frontend/src/lib/collectives-api.ts
+++ b/components/frontend/src/lib/collectives-api.ts
@@ -237,6 +237,29 @@ export async function listCollectivesPaginated(
   return { items: data.slice(0, limit), hasNextPage };
 }
 
+/**
+ * List approved collectives that an `owner/slug` endpoint participates in.
+ *
+ * Public-readable. Returns an empty array when the endpoint exists but is not
+ * an approved member of any collective, when the endpoint can't be resolved,
+ * or on a 404 — callers render "no card" for both cases.
+ */
+export async function listCollectivesForEndpoint(
+  owner: string,
+  slug: string
+): Promise<Collective[]> {
+  const response = await fetch(
+    `${BASE}/by-endpoint/${encodeURIComponent(owner)}/${encodeURIComponent(slug)}`
+  );
+  if (response.status === 404) return [];
+  if (!response.ok) {
+    throw new Error(
+      await errorMessage(response, `Failed to load collectives (${response.status})`)
+    );
+  }
+  return (await response.json()) as Collective[];
+}
+
 /** Fetch a collective by slug. Returns `null` on 404 so callers can render a not-found state. */
 export async function getCollectiveBySlug(slug: string): Promise<Collective | null> {
   const response = await fetch(`${BASE}/by-slug/${encodeURIComponent(slug)}`);

--- a/components/frontend/src/lib/query-keys.ts
+++ b/components/frontend/src/lib/query-keys.ts
@@ -60,5 +60,7 @@ export const collectiveKeys = {
   members: (collectiveId: number, status?: string) =>
     [...collectiveKeys.all, 'members', collectiveId, status ?? 'all'] as const,
   invitation: (collectiveId: number, endpointId: number) =>
-    [...collectiveKeys.all, 'invitation', collectiveId, endpointId] as const
+    [...collectiveKeys.all, 'invitation', collectiveId, endpointId] as const,
+  byEndpoint: (owner: string, slug: string) =>
+    [...collectiveKeys.all, 'byEndpoint', owner, slug] as const
 };


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/collectives/by-endpoint/{owner}/{slug}` returning the approved collectives an endpoint participates in (public-readable; pending/invited/rejected hidden).
- Adds an `EndpointCollectivesCard` rendered in the endpoint detail sidebar directly below the Connections card. Card is conditional — renders nothing when the endpoint is not an approved member of any collective.
- List area scrolls (`max-h-[280px]`) when an endpoint belongs to many collectives, matching the scrollbar styling already used in `global-directory.tsx`.

## How it looks
- Card shell matches `ConnectionCard` and `About`: `border-border bg-card rounded-xl border p-6`, `font-rubik text-sm font-medium` heading, count pill on the right.
- Each row is a `<Link to="/c/:slug">` with `CollectiveIcon`, name + `ShieldCheck` if verified, and `@slug · {member_count}` meta.

## Test plan
- [ ] Visit `/{owner}/{slug}` for an endpoint that is an approved member of one or more collectives — card appears below Connections, rows link correctly to `/c/:slug`.
- [ ] Visit an endpoint with no collective memberships — card does not render.
- [ ] Visit an endpoint that has been invited or whose join request is pending but not approved — card does not render.
- [ ] With many memberships (>5), confirm the inner list scrolls and the card does not stretch the sidebar.
- [ ] `curl /api/v1/collectives/by-endpoint/{owner}/{slug}` returns approved memberships only; returns `[]` for unknown owner or slug.