### PR TITLE
feat(collectives): shared endpoints — curated subsets of approved members

### DIFF
--- a/components/backend/alembic/versions/20260525_000000_add_collective_shared_endpoints.py
+++ b/components/backend/alembic/versions/20260525_000000_add_collective_shared_endpoints.py
@@ -1,0 +1,107 @@
+"""Add collective_shared_endpoints and collective_shared_endpoint_members tables.
+
+Adds "shared endpoints" to a collective: named, curated subsets of approved
+member endpoints. The implicit ``all`` subset is hardcoded as an alias and is
+NOT stored. Existing ``collective/<slug>`` paths continue to fan out to every
+approved member.
+
+Revision ID: 018_collective_shared_endpoints
+Revises: 017_collective_about
+Create Date: 2026-05-25 00:00:00.000000+00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "018_collective_shared_endpoints"
+down_revision: str | None = "017_collective_about"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "collective_shared_endpoints",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "collective_id",
+            sa.Integer(),
+            sa.ForeignKey("collectives.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("slug", sa.String(63), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "collective_id", "slug", name="uq_shared_endpoint_collective_slug"
+        ),
+    )
+    op.create_index(
+        "idx_shared_endpoint_collective_id",
+        "collective_shared_endpoints",
+        ["collective_id"],
+    )
+
+    op.create_table(
+        "collective_shared_endpoint_members",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "shared_endpoint_id",
+            sa.Integer(),
+            sa.ForeignKey("collective_shared_endpoints.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "endpoint_id",
+            sa.Integer(),
+            sa.ForeignKey("endpoints.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "shared_endpoint_id",
+            "endpoint_id",
+            name="uq_shared_endpoint_member_pair",
+        ),
+    )
+    op.create_index(
+        "idx_shared_endpoint_member_shared_id",
+        "collective_shared_endpoint_members",
+        ["shared_endpoint_id"],
+    )
+    op.create_index(
+        "idx_shared_endpoint_member_endpoint_id",
+        "collective_shared_endpoint_members",
+        ["endpoint_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_shared_endpoint_member_endpoint_id",
+        table_name="collective_shared_endpoint_members",
+    )
+    op.drop_index(
+        "idx_shared_endpoint_member_shared_id",
+        table_name="collective_shared_endpoint_members",
+    )
+    op.drop_table("collective_shared_endpoint_members")
+
+    op.drop_index(
+        "idx_shared_endpoint_collective_id",
+        table_name="collective_shared_endpoints",
+    )
+    op.drop_table("collective_shared_endpoints")

--- a/components/backend/src/syfthub/api/endpoints/collectives.py
+++ b/components/backend/src/syfthub/api/endpoints/collectives.py
@@ -122,6 +122,32 @@ async def get_collective_endpoint_paths(
 
 
 @router.get(
+    "/shared-endpoints/bulk",
+    response_model=List[CollectiveSharedEndpointResponse],
+)
+async def list_shared_endpoints_bulk(
+    service: Annotated[CollectiveService, Depends(get_collective_service)],
+    collective_ids: Annotated[
+        Optional[List[int]],
+        Query(
+            alias="collective_id",
+            description=(
+                "Repeat the parameter to request multiple collectives in one "
+                "shot, e.g. ``?collective_id=1&collective_id=2``."
+            ),
+        ),
+    ] = None,
+) -> List[CollectiveSharedEndpointResponse]:
+    """Bulk list of shared endpoints for a set of collectives (public).
+
+    Powers the chat-view's add-sources modal — collapses N per-collective
+    fetches into one round trip. Unknown ids are silently skipped so a
+    stale id doesn't 404 the whole batch.
+    """
+    return service.list_shared_endpoints_bulk(collective_ids or [])
+
+
+@router.get(
     "/by-slug/{slug}/shared-endpoints",
     response_model=List[CollectiveSharedEndpointResponse],
 )

--- a/components/backend/src/syfthub/api/endpoints/collectives.py
+++ b/components/backend/src/syfthub/api/endpoints/collectives.py
@@ -23,6 +23,9 @@ from syfthub.schemas.collective import (
     CollectiveMemberResponse,
     CollectiveResponse,
     CollectiveReviewRequest,
+    CollectiveSharedEndpointCreate,
+    CollectiveSharedEndpointResponse,
+    CollectiveSharedEndpointUpdate,
     CollectiveUpdate,
     MembershipStatus,
 )
@@ -105,6 +108,63 @@ async def get_collective_endpoint_paths(
     Returns an empty list when the collective exists but has no approved members.
     """
     return service.get_collective_endpoint_paths(slug)
+
+
+# ----------------------------------------------------------------------
+# Shared endpoints — named, curated subsets of approved members
+# ----------------------------------------------------------------------
+#
+# Public read routes are nested under ``/by-slug/{slug}/shared-endpoints``
+# (no auth) and MUST be declared before the catch-all ``/{collective_id}``
+# routes so FastAPI's path resolver picks the more-specific match.
+# Management routes (auth required) are mounted under
+# ``/{collective_id}/shared-endpoints``.
+
+
+@router.get(
+    "/by-slug/{slug}/shared-endpoints",
+    response_model=List[CollectiveSharedEndpointResponse],
+)
+async def list_shared_endpoints_by_slug(
+    slug: str,
+    service: Annotated[CollectiveService, Depends(get_collective_service)],
+) -> List[CollectiveSharedEndpointResponse]:
+    """List a collective's shared endpoints by parent slug (public-readable)."""
+    return service.list_shared_endpoints_by_slug(slug)
+
+
+@router.get(
+    "/by-slug/{slug}/shared-endpoints/{shared_slug}",
+    response_model=CollectiveSharedEndpointResponse,
+)
+async def get_shared_endpoint_by_slug(
+    slug: str,
+    shared_slug: str,
+    service: Annotated[CollectiveService, Depends(get_collective_service)],
+) -> CollectiveSharedEndpointResponse:
+    """Get one shared endpoint by collective slug + shared slug (public)."""
+    return service.get_shared_endpoint_by_slugs(slug, shared_slug)
+
+
+@router.get(
+    "/by-slug/{slug}/shared-endpoints/{shared_slug}/endpoint-paths",
+    response_model=List[str],
+)
+async def get_shared_endpoint_endpoint_paths(
+    slug: str,
+    shared_slug: str,
+    service: Annotated[CollectiveService, Depends(get_collective_service)],
+) -> List[str]:
+    """Return owner/slug paths of a shared endpoint's active member endpoints.
+
+    Used by the TypeScript SDK to resolve ``collective/<X>/<Y>`` paths. The
+    result is the intersection of the configured endpoint set with the
+    collective's currently approved members; configured endpoints that have
+    since left the collective are silently filtered out. The ``all`` shared
+    slug short-circuits to "every approved member" (same payload as
+    ``/by-slug/{slug}/endpoint-paths``).
+    """
+    return service.get_shared_endpoint_paths(slug, shared_slug)
 
 
 @router.get("/{collective_id}", response_model=CollectiveResponse)
@@ -289,3 +349,87 @@ async def respond_to_invitation(
     return service.respond_to_invitation(
         collective_id, endpoint_id, data.decision, current_user
     )
+
+
+# ----------------------------------------------------------------------
+# Shared endpoints — management routes (auth required for mutations)
+# ----------------------------------------------------------------------
+
+
+@router.get(
+    "/{collective_id}/shared-endpoints",
+    response_model=List[CollectiveSharedEndpointResponse],
+)
+async def list_shared_endpoints(
+    collective_id: int,
+    service: Annotated[CollectiveService, Depends(get_collective_service)],
+) -> List[CollectiveSharedEndpointResponse]:
+    """List a collective's shared endpoints. Public-readable."""
+    return service.list_shared_endpoints(collective_id)
+
+
+@router.post(
+    "/{collective_id}/shared-endpoints",
+    response_model=CollectiveSharedEndpointResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_shared_endpoint(
+    collective_id: int,
+    data: CollectiveSharedEndpointCreate,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    service: Annotated[CollectiveService, Depends(get_collective_service)],
+) -> CollectiveSharedEndpointResponse:
+    """Create a shared endpoint under a collective. Collective owner only.
+
+    Every ``endpoint_ids`` entry must be an approved member of the parent
+    collective. The slug is auto-derived from the name when omitted.
+    """
+    return service.create_shared_endpoint(collective_id, data, current_user)
+
+
+@router.get(
+    "/{collective_id}/shared-endpoints/{shared_slug}",
+    response_model=CollectiveSharedEndpointResponse,
+)
+async def get_shared_endpoint(
+    collective_id: int,
+    shared_slug: str,
+    service: Annotated[CollectiveService, Depends(get_collective_service)],
+) -> CollectiveSharedEndpointResponse:
+    """Get one shared endpoint by parent id + own slug. Public-readable."""
+    return service.get_shared_endpoint(collective_id, shared_slug)
+
+
+@router.patch(
+    "/{collective_id}/shared-endpoints/{shared_slug}",
+    response_model=CollectiveSharedEndpointResponse,
+)
+async def update_shared_endpoint(
+    collective_id: int,
+    shared_slug: str,
+    data: CollectiveSharedEndpointUpdate,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    service: Annotated[CollectiveService, Depends(get_collective_service)],
+) -> CollectiveSharedEndpointResponse:
+    """Update a shared endpoint. Collective owner only.
+
+    ``endpoint_ids`` is a full replacement when present; omit it to leave the
+    membership untouched. Slug is immutable.
+    """
+    return service.update_shared_endpoint(
+        collective_id, shared_slug, data, current_user
+    )
+
+
+@router.delete(
+    "/{collective_id}/shared-endpoints/{shared_slug}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_shared_endpoint(
+    collective_id: int,
+    shared_slug: str,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    service: Annotated[CollectiveService, Depends(get_collective_service)],
+) -> None:
+    """Delete a shared endpoint and its member rows. Collective owner only."""
+    service.delete_shared_endpoint(collective_id, shared_slug, current_user)

--- a/components/backend/src/syfthub/models/collective.py
+++ b/components/backend/src/syfthub/models/collective.py
@@ -68,6 +68,11 @@ class CollectiveModel(BaseModel, TimestampMixin):
         back_populates="collective",
         cascade="all, delete-orphan",
     )
+    shared_endpoints: Mapped[List["CollectiveSharedEndpointModel"]] = relationship(
+        "CollectiveSharedEndpointModel",
+        back_populates="collective",
+        cascade="all, delete-orphan",
+    )
 
     __table_args__ = (
         Index("idx_collectives_owner_id", "owner_id"),
@@ -149,4 +154,97 @@ class CollectiveMemberModel(BaseModel):
         return (
             f"<CollectiveMember(collective={self.collective_id}, "
             f"endpoint={self.endpoint_id}, status='{self.status}')>"
+        )
+
+
+class CollectiveSharedEndpointModel(BaseModel, TimestampMixin):
+    """A named, curated subset of a collective's approved member endpoints.
+
+    Resolves at chat-time as ``collective/<collective_slug>/<slug>`` and fans
+    out only to the configured endpoints intersected with the collective's
+    *currently* approved members. The implicit ``all`` shared endpoint
+    (``collective/<collective_slug>/all``) is never stored — it is hardcoded
+    as an alias for "every approved member".
+    """
+
+    __tablename__ = "collective_shared_endpoints"
+
+    collective_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("collectives.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    # Unique per collective (not globally) — see uq_shared_endpoint_collective_slug.
+    slug: Mapped[str] = mapped_column(String(63), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+
+    # Relationships
+    collective: Mapped["CollectiveModel"] = relationship(
+        "CollectiveModel", back_populates="shared_endpoints"
+    )
+    members: Mapped[List["CollectiveSharedEndpointMemberModel"]] = relationship(
+        "CollectiveSharedEndpointMemberModel",
+        back_populates="shared_endpoint",
+        cascade="all, delete-orphan",
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "collective_id", "slug", name="uq_shared_endpoint_collective_slug"
+        ),
+        Index("idx_shared_endpoint_collective_id", "collective_id"),
+    )
+
+    def __repr__(self) -> str:
+        """String representation of CollectiveSharedEndpoint."""
+        return (
+            f"<CollectiveSharedEndpoint(id={self.id}, "
+            f"collective={self.collective_id}, slug='{self.slug}')>"
+        )
+
+
+class CollectiveSharedEndpointMemberModel(BaseModel):
+    """An endpoint configured into a collective shared-endpoint subset.
+
+    A row here means "the collective owner picked this endpoint as part of the
+    subset"; whether the endpoint *currently* participates in chat fan-out
+    depends on the intersection with the collective's approved members, which
+    is computed at read time.
+    """
+
+    __tablename__ = "collective_shared_endpoint_members"
+
+    shared_endpoint_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("collective_shared_endpoints.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    endpoint_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("endpoints.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    # Relationships
+    shared_endpoint: Mapped["CollectiveSharedEndpointModel"] = relationship(
+        "CollectiveSharedEndpointModel", back_populates="members"
+    )
+    endpoint: Mapped["EndpointModel"] = relationship(
+        "EndpointModel", back_populates="shared_endpoint_memberships"
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "shared_endpoint_id", "endpoint_id", name="uq_shared_endpoint_member_pair"
+        ),
+        Index("idx_shared_endpoint_member_shared_id", "shared_endpoint_id"),
+        Index("idx_shared_endpoint_member_endpoint_id", "endpoint_id"),
+    )
+
+    def __repr__(self) -> str:
+        """String representation of CollectiveSharedEndpointMember."""
+        return (
+            f"<CollectiveSharedEndpointMember(shared={self.shared_endpoint_id}, "
+            f"endpoint={self.endpoint_id})>"
         )

--- a/components/backend/src/syfthub/models/endpoint.py
+++ b/components/backend/src/syfthub/models/endpoint.py
@@ -23,7 +23,10 @@ from syfthub.models.base import Base, BaseModel, TimestampMixin
 JSONType = JSON().with_variant(JSONB(), "postgresql")  # type: ignore[no-untyped-call]
 
 if TYPE_CHECKING:
-    from syfthub.models.collective import CollectiveMemberModel
+    from syfthub.models.collective import (
+        CollectiveMemberModel,
+        CollectiveSharedEndpointMemberModel,
+    )
     from syfthub.models.user import UserModel
 
 
@@ -104,6 +107,13 @@ class EndpointModel(BaseModel, TimestampMixin):
         "CollectiveMemberModel",
         back_populates="endpoint",
         cascade="all, delete-orphan",
+    )
+    shared_endpoint_memberships: Mapped[List["CollectiveSharedEndpointMemberModel"]] = (
+        relationship(
+            "CollectiveSharedEndpointMemberModel",
+            back_populates="endpoint",
+            cascade="all, delete-orphan",
+        )
     )
 
     # Indexes for performance - slug uniqueness is per-user

--- a/components/backend/src/syfthub/repositories/collective.py
+++ b/components/backend/src/syfthub/repositories/collective.py
@@ -12,10 +12,19 @@ from typing import TYPE_CHECKING, Any, List, Optional, Sequence
 from sqlalchemy import Text, and_, cast, func, or_, select
 from sqlalchemy.exc import SQLAlchemyError
 
-from syfthub.models.collective import CollectiveMemberModel, CollectiveModel
+from syfthub.models.collective import (
+    CollectiveMemberModel,
+    CollectiveModel,
+    CollectiveSharedEndpointMemberModel,
+    CollectiveSharedEndpointModel,
+)
 from syfthub.models.endpoint import EndpointModel
 from syfthub.repositories.base import BaseRepository
-from syfthub.schemas.collective import CollectiveMemberResponse, CollectiveResponse
+from syfthub.schemas.collective import (
+    CollectiveMemberResponse,
+    CollectiveResponse,
+    CollectiveSharedEndpointResponse,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -349,3 +358,309 @@ class CollectiveMemberRepository(BaseRepository[CollectiveMemberModel]):
         except SQLAlchemyError:
             self.session.rollback()
             return None
+
+
+class CollectiveSharedEndpointRepository(BaseRepository[CollectiveSharedEndpointModel]):
+    """Repository for collective shared-endpoint operations.
+
+    Returns Pydantic responses pre-populated with the parent collective's slug
+    so callers can render the public ``collective/<collective_slug>/<slug>``
+    path without a second round-trip. Configured-member ids and active/inactive
+    state are computed in the service layer (intersection with the parent
+    collective's approved members).
+    """
+
+    def __init__(self, session: Session):
+        """Initialize repository with database session."""
+        super().__init__(session, CollectiveSharedEndpointModel)
+
+    @staticmethod
+    def _to_response(
+        model: CollectiveSharedEndpointModel,
+        collective_slug: str,
+    ) -> CollectiveSharedEndpointResponse:
+        """Build a response payload carrying the parent collective's slug.
+
+        The ``shared_endpoint_path`` is derived here so every callsite gets a
+        consistent ``collective/<collective_slug>/<slug>`` without having to
+        rebuild the path manually.
+        """
+        return CollectiveSharedEndpointResponse(
+            id=model.id,
+            collective_id=model.collective_id,
+            collective_slug=collective_slug,
+            name=model.name,
+            slug=model.slug,
+            shared_endpoint_path=f"collective/{collective_slug}/{model.slug}",
+            description=model.description,
+            members=[],
+            member_count=0,
+            active_member_count=0,
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+        )
+
+    def get_by_id_with_collective_slug(
+        self, shared_endpoint_id: int
+    ) -> Optional[tuple[CollectiveSharedEndpointResponse, int]]:
+        """Get a shared endpoint and its parent collective id by id.
+
+        Returns ``(response, collective_id)`` or ``None``. The collective id
+        lets the service layer validate ``collective_id`` parameters from the
+        URL against the actual parent without an extra query.
+        """
+        try:
+            stmt = (
+                select(self.model, CollectiveModel.slug)
+                .join(CollectiveModel, CollectiveModel.id == self.model.collective_id)
+                .where(self.model.id == shared_endpoint_id)
+            )
+            row = self.session.execute(stmt).first()
+            if row is None:
+                return None
+            model, collective_slug = row
+            return self._to_response(model, collective_slug), model.collective_id
+        except SQLAlchemyError:
+            return None
+
+    def get_by_collective_and_slug(
+        self, collective_id: int, slug: str
+    ) -> Optional[CollectiveSharedEndpointResponse]:
+        """Get a shared endpoint by its parent collective id and own slug."""
+        try:
+            stmt = (
+                select(self.model, CollectiveModel.slug)
+                .join(CollectiveModel, CollectiveModel.id == self.model.collective_id)
+                .where(
+                    and_(
+                        self.model.collective_id == collective_id,
+                        self.model.slug == slug.lower(),
+                    )
+                )
+            )
+            row = self.session.execute(stmt).first()
+            if row is None:
+                return None
+            model, collective_slug = row
+            return self._to_response(model, collective_slug)
+        except SQLAlchemyError:
+            return None
+
+    def get_by_collective_slugs(
+        self, collective_slug: str, shared_slug: str
+    ) -> Optional[CollectiveSharedEndpointResponse]:
+        """Get a shared endpoint by collective slug + shared slug.
+
+        Used by the public ``/by-slug/{slug}/shared-endpoints/{shared_slug}``
+        route so the resolver doesn't need to look up the collective id first.
+        """
+        try:
+            stmt = (
+                select(self.model, CollectiveModel.slug)
+                .join(CollectiveModel, CollectiveModel.id == self.model.collective_id)
+                .where(
+                    and_(
+                        CollectiveModel.slug == collective_slug.lower(),
+                        self.model.slug == shared_slug.lower(),
+                    )
+                )
+            )
+            row = self.session.execute(stmt).first()
+            if row is None:
+                return None
+            model, fetched_slug = row
+            return self._to_response(model, fetched_slug)
+        except SQLAlchemyError:
+            return None
+
+    def slug_exists(self, collective_id: int, slug: str) -> bool:
+        """Check whether a slug is already taken within the collective."""
+        try:
+            stmt = select(self.model.id).where(
+                and_(
+                    self.model.collective_id == collective_id,
+                    self.model.slug == slug.lower(),
+                )
+            )
+            return self.session.execute(stmt.limit(1)).scalar() is not None
+        except SQLAlchemyError:
+            return False
+
+    def list_for_collective(
+        self, collective_id: int
+    ) -> List[CollectiveSharedEndpointResponse]:
+        """List a collective's shared endpoints, newest first."""
+        try:
+            stmt = (
+                select(self.model, CollectiveModel.slug)
+                .join(CollectiveModel, CollectiveModel.id == self.model.collective_id)
+                .where(self.model.collective_id == collective_id)
+                .order_by(self.model.created_at.desc())
+            )
+            rows = self.session.execute(stmt).all()
+            return [self._to_response(model, slug) for model, slug in rows]
+        except SQLAlchemyError:
+            return []
+
+    def list_for_collective_slug(
+        self, collective_slug: str
+    ) -> List[CollectiveSharedEndpointResponse]:
+        """List shared endpoints by parent collective slug."""
+        try:
+            stmt = (
+                select(self.model, CollectiveModel.slug)
+                .join(CollectiveModel, CollectiveModel.id == self.model.collective_id)
+                .where(CollectiveModel.slug == collective_slug.lower())
+                .order_by(self.model.created_at.desc())
+            )
+            rows = self.session.execute(stmt).all()
+            return [self._to_response(model, slug) for model, slug in rows]
+        except SQLAlchemyError:
+            return []
+
+    def create_shared_endpoint(
+        self,
+        *,
+        collective_id: int,
+        name: str,
+        slug: str,
+        description: str,
+        endpoint_ids: Sequence[int],
+        collective_slug: str,
+    ) -> Optional[CollectiveSharedEndpointResponse]:
+        """Insert a new shared endpoint with its configured member rows.
+
+        Both rows commit in a single transaction so a created shared endpoint
+        never exists without its initial members. The caller must have already
+        validated that every ``endpoint_id`` is an approved collective member.
+        """
+        try:
+            model = CollectiveSharedEndpointModel(
+                collective_id=collective_id,
+                name=name,
+                slug=slug,
+                description=description,
+            )
+            self.session.add(model)
+            self.session.flush()
+            for endpoint_id in endpoint_ids:
+                self.session.add(
+                    CollectiveSharedEndpointMemberModel(
+                        shared_endpoint_id=model.id,
+                        endpoint_id=endpoint_id,
+                    )
+                )
+            self.session.commit()
+            self.session.refresh(model)
+            return self._to_response(model, collective_slug)
+        except SQLAlchemyError:
+            self.session.rollback()
+            return None
+
+    def update_shared_endpoint(
+        self,
+        shared_endpoint_id: int,
+        *,
+        fields: dict[str, Any],
+        endpoint_ids: Optional[Sequence[int]],
+        collective_slug: str,
+    ) -> Optional[CollectiveSharedEndpointResponse]:
+        """Update a shared endpoint's fields and (optionally) its member set.
+
+        When ``endpoint_ids`` is ``None`` the member rows are untouched;
+        otherwise the membership is fully replaced with the provided set.
+        """
+        try:
+            model = self.session.get(self.model, shared_endpoint_id)
+            if model is None:
+                return None
+            for key, value in fields.items():
+                if key == "slug":
+                    # Slug is immutable — see the schema docstring.
+                    continue
+                if hasattr(model, key):
+                    setattr(model, key, value)
+
+            if endpoint_ids is not None:
+                self.session.execute(
+                    CollectiveSharedEndpointMemberModel.__table__.delete().where(
+                        CollectiveSharedEndpointMemberModel.shared_endpoint_id
+                        == shared_endpoint_id
+                    )
+                )
+                for endpoint_id in endpoint_ids:
+                    self.session.add(
+                        CollectiveSharedEndpointMemberModel(
+                            shared_endpoint_id=shared_endpoint_id,
+                            endpoint_id=endpoint_id,
+                        )
+                    )
+
+            self.session.commit()
+            self.session.refresh(model)
+            return self._to_response(model, collective_slug)
+        except SQLAlchemyError:
+            self.session.rollback()
+            return None
+
+    def delete_shared_endpoint(self, shared_endpoint_id: int) -> bool:
+        """Delete a shared endpoint by id (cascades to member rows)."""
+        try:
+            model = self.session.get(self.model, shared_endpoint_id)
+            if model is None:
+                return False
+            self.session.delete(model)
+            self.session.commit()
+            return True
+        except SQLAlchemyError:
+            self.session.rollback()
+            return False
+
+
+class CollectiveSharedEndpointMemberRepository(
+    BaseRepository[CollectiveSharedEndpointMemberModel]
+):
+    """Repository for shared-endpoint member rows.
+
+    Most mutations go through ``CollectiveSharedEndpointRepository`` so that a
+    shared endpoint and its members commit atomically; this repository is for
+    read paths (resolution, reverse lookups) and bulk lookups.
+    """
+
+    def __init__(self, session: Session):
+        """Initialize repository with database session."""
+        super().__init__(session, CollectiveSharedEndpointMemberModel)
+
+    def list_endpoint_ids(self, shared_endpoint_id: int) -> List[int]:
+        """List the endpoint ids configured into a shared endpoint."""
+        try:
+            stmt = select(self.model.endpoint_id).where(
+                self.model.shared_endpoint_id == shared_endpoint_id
+            )
+            return [row[0] for row in self.session.execute(stmt).all()]
+        except SQLAlchemyError:
+            return []
+
+    def list_endpoint_ids_bulk(
+        self, shared_endpoint_ids: Sequence[int]
+    ) -> dict[int, List[int]]:
+        """Bulk-load configured endpoint ids per shared endpoint.
+
+        Returns ``{shared_endpoint_id: [endpoint_id, ...]}``. Shared endpoints
+        with zero configured members are omitted; callers should default to
+        ``[]`` when looking up.
+        """
+        if not shared_endpoint_ids:
+            return {}
+        try:
+            stmt = (
+                select(self.model.shared_endpoint_id, self.model.endpoint_id)
+                .where(self.model.shared_endpoint_id.in_(list(shared_endpoint_ids)))
+                .order_by(self.model.id.asc())
+            )
+            result: dict[int, List[int]] = {}
+            for shared_id, endpoint_id in self.session.execute(stmt).all():
+                result.setdefault(shared_id, []).append(endpoint_id)
+            return result
+        except SQLAlchemyError:
+            return {}

--- a/components/backend/src/syfthub/repositories/collective.py
+++ b/components/backend/src/syfthub/repositories/collective.py
@@ -502,6 +502,30 @@ class CollectiveSharedEndpointRepository(BaseRepository[CollectiveSharedEndpoint
         except SQLAlchemyError:
             return []
 
+    def list_for_collectives(
+        self, collective_ids: Sequence[int]
+    ) -> List[CollectiveSharedEndpointResponse]:
+        """Bulk-list shared endpoints across multiple collectives.
+
+        Powers the chat-view modal's single-shot fetch (replaces the
+        per-collective fan-out). Rows are returned newest-first overall —
+        callers that need them grouped by parent should bucket by
+        ``collective_id`` themselves.
+        """
+        if not collective_ids:
+            return []
+        try:
+            stmt = (
+                select(self.model, CollectiveModel.slug)
+                .join(CollectiveModel, CollectiveModel.id == self.model.collective_id)
+                .where(self.model.collective_id.in_(list(collective_ids)))
+                .order_by(self.model.created_at.desc())
+            )
+            rows = self.session.execute(stmt).all()
+            return [self._to_response(model, slug) for model, slug in rows]
+        except SQLAlchemyError:
+            return []
+
     def list_for_collective_slug(
         self, collective_slug: str
     ) -> List[CollectiveSharedEndpointResponse]:
@@ -569,9 +593,16 @@ class CollectiveSharedEndpointRepository(BaseRepository[CollectiveSharedEndpoint
 
         When ``endpoint_ids`` is ``None`` the member rows are untouched;
         otherwise the membership is fully replaced with the provided set.
+
+        The parent row is locked with ``FOR UPDATE`` so two concurrent owner
+        PATCHes can't interleave the DELETE+INSERT replacement step — the
+        second waiter sees the first writer's committed state before
+        applying its own change.
         """
         try:
-            model = self.session.get(self.model, shared_endpoint_id)
+            model = self.session.get(
+                self.model, shared_endpoint_id, with_for_update=True
+            )
             if model is None:
                 return None
             for key, value in fields.items():
@@ -632,10 +663,16 @@ class CollectiveSharedEndpointMemberRepository(
         super().__init__(session, CollectiveSharedEndpointMemberModel)
 
     def list_endpoint_ids(self, shared_endpoint_id: int) -> List[int]:
-        """List the endpoint ids configured into a shared endpoint."""
+        """List the endpoint ids configured into a shared endpoint.
+
+        Returned in insertion order (id ASC) so the fan-out order matches the
+        order surfaced by ``list_endpoint_ids_bulk`` (which the admin UI uses).
+        """
         try:
-            stmt = select(self.model.endpoint_id).where(
-                self.model.shared_endpoint_id == shared_endpoint_id
+            stmt = (
+                select(self.model.endpoint_id)
+                .where(self.model.shared_endpoint_id == shared_endpoint_id)
+                .order_by(self.model.id.asc())
             )
             return [row[0] for row in self.session.execute(stmt).all()]
         except SQLAlchemyError:

--- a/components/backend/src/syfthub/schemas/collective.py
+++ b/components/backend/src/syfthub/schemas/collective.py
@@ -294,6 +294,201 @@ class CollectiveMemberResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+# ----------------------------------------------------------------------
+# Shared endpoints — named, curated subsets of a collective's members
+# ----------------------------------------------------------------------
+
+
+# ``all`` is the implicit shared-endpoint slug that fans out to every approved
+# member (equivalent to plain ``collective/<slug>``). It is never stored as a
+# row — the resolver short-circuits on this slug — so explicit creation of an
+# "all" subset is rejected. Other reserved slugs may be added later as the
+# routing surface grows; keep it as a set for forward-compat.
+RESERVED_SHARED_ENDPOINT_SLUGS = {"all"}
+
+
+def _validate_shared_endpoint_slug(v: str) -> str:
+    """Validate a user-provided shared-endpoint slug.
+
+    Reuses the collective slug pattern (lowercase + hyphens, 1-63 chars) but
+    against a smaller reserved set — these slugs are scoped under a collective
+    and don't share the public URL space.
+    """
+    if v != v.lower():
+        raise ValueError("Slug must contain only lowercase letters")
+    if v in RESERVED_SHARED_ENDPOINT_SLUGS:
+        raise ValueError(f"'{v}' is a reserved shared-endpoint slug")
+    if "--" in v:
+        raise ValueError("Slug cannot contain consecutive hyphens")
+    if not _SLUG_PATTERN.match(v):
+        raise ValueError(
+            "Slug must contain only lowercase letters, numbers, and hyphens. "
+            "Cannot start or end with a hyphen."
+        )
+    return v
+
+
+def slugify_shared_endpoint_name(name: str) -> str:
+    """Derive a URL-safe base slug from a shared-endpoint name.
+
+    The result is not guaranteed unique — the service resolves collisions.
+    Falls back to a generic ``shared`` slug when the input has no
+    alphanumerics so the slug always meets the 1+ char minimum.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower().strip()).strip("-")
+    if not slug:
+        slug = "shared"
+    if len(slug) > 63:
+        slug = slug[:63].rstrip("-")
+    return slug
+
+
+class CollectiveSharedEndpointBase(BaseModel):
+    """Fields a user supplies when creating or updating a shared endpoint."""
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description="Display name of the shared endpoint",
+    )
+    description: str = Field(
+        "",
+        max_length=500,
+        description="Short one-liner describing the shared endpoint",
+    )
+
+
+class CollectiveSharedEndpointCreate(CollectiveSharedEndpointBase):
+    """Schema for creating a new shared endpoint under a collective."""
+
+    slug: Optional[str] = Field(
+        None,
+        min_length=1,
+        max_length=63,
+        description="URL-safe identifier (auto-generated from name if omitted)",
+    )
+    endpoint_ids: List[int] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Endpoints to include in this subset. Every id MUST be an "
+            "approved member of the parent collective at creation time."
+        ),
+    )
+
+    @field_validator("slug")
+    @classmethod
+    def validate_slug(cls, v: Optional[str]) -> Optional[str]:
+        """Validate the optional user-provided slug."""
+        return None if v is None else _validate_shared_endpoint_slug(v)
+
+    @field_validator("endpoint_ids")
+    @classmethod
+    def deduplicate_ids(cls, v: List[int]) -> List[int]:
+        """Drop duplicates from the endpoint id list, preserving order."""
+        seen: set[int] = set()
+        result: List[int] = []
+        for endpoint_id in v:
+            if endpoint_id not in seen:
+                seen.add(endpoint_id)
+                result.append(endpoint_id)
+        return result
+
+
+class CollectiveSharedEndpointUpdate(BaseModel):
+    """Schema for updating a shared endpoint — all fields optional, owner-only.
+
+    ``endpoint_ids`` is a *full replacement* when present; pass the complete
+    new set, not a delta. Pass ``None`` (omit the field) to leave membership
+    untouched. Slug is not updatable — it is part of the public path and
+    renaming it would silently break callers.
+    """
+
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    description: Optional[str] = Field(None, max_length=500)
+    endpoint_ids: Optional[List[int]] = Field(default=None, min_length=1)
+
+    @field_validator("endpoint_ids")
+    @classmethod
+    def deduplicate_ids(cls, v: Optional[List[int]]) -> Optional[List[int]]:
+        """Drop duplicates while preserving order."""
+        if v is None:
+            return None
+        seen: set[int] = set()
+        result: List[int] = []
+        for endpoint_id in v:
+            if endpoint_id not in seen:
+                seen.add(endpoint_id)
+                result.append(endpoint_id)
+        return result
+
+
+class CollectiveSharedEndpointMemberSummary(BaseModel):
+    """One member endpoint inside a shared endpoint, enriched for UI rendering."""
+
+    endpoint_id: int = Field(..., description="Endpoint's unique identifier")
+    endpoint_name: Optional[str] = Field(
+        None, description="Display name of the member endpoint"
+    )
+    endpoint_slug: Optional[str] = Field(
+        None, description="URL slug of the member endpoint"
+    )
+    endpoint_owner_username: Optional[str] = Field(
+        None, description="Username of the member endpoint's owner"
+    )
+    endpoint_type: Optional[str] = Field(
+        None, description="Type of the member endpoint"
+    )
+    is_active: bool = Field(
+        ...,
+        description=(
+            "True when the endpoint is currently an approved member of the "
+            "parent collective. When False, the endpoint was configured into "
+            "this subset but has since left the collective; it is silently "
+            "skipped at fan-out time."
+        ),
+    )
+
+
+class CollectiveSharedEndpointResponse(BaseModel):
+    """Schema for a shared endpoint in API responses."""
+
+    id: int = Field(..., description="Shared endpoint's unique identifier")
+    collective_id: int = Field(..., description="Parent collective's ID")
+    collective_slug: str = Field(..., description="Parent collective's slug")
+    name: str = Field(..., description="Display name")
+    slug: str = Field(..., description="URL-safe identifier (unique per collective)")
+    shared_endpoint_path: str = Field(
+        ...,
+        description=(
+            "Public path for this shared endpoint, "
+            "``collective/<collective_slug>/<slug>``. Derived from the parent "
+            "collective's slug and this entity's slug; never user-settable."
+        ),
+    )
+    description: str = Field(..., description="Short one-liner")
+    members: List[CollectiveSharedEndpointMemberSummary] = Field(
+        default_factory=list,
+        description=(
+            "Configured member endpoints with their current active state. "
+            "Active = currently an approved member of the parent collective."
+        ),
+    )
+    member_count: int = Field(0, description="Total configured members")
+    active_member_count: int = Field(
+        0,
+        description=(
+            "Members that are currently approved in the parent collective and "
+            "will participate in chat fan-out."
+        ),
+    )
+    created_at: datetime = Field(..., description="When the row was created")
+    updated_at: datetime = Field(..., description="When the row was last updated")
+
+    model_config = {"from_attributes": True}
+
+
 class InvitationEmailContext(BaseModel):
     """Context for the collective-invitation notification email.
 

--- a/components/backend/src/syfthub/schemas/collective.py
+++ b/components/backend/src/syfthub/schemas/collective.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -315,7 +315,7 @@ def _validate_shared_endpoint_slug(v: str) -> str:
     and don't share the public URL space.
     """
     if v != v.lower():
-        raise ValueError("Slug must contain only lowercase letters")
+        raise ValueError("Slug must be lowercase")
     if v in RESERVED_SHARED_ENDPOINT_SLUGS:
         raise ValueError(f"'{v}' is a reserved shared-endpoint slug")
     if "--" in v:
@@ -408,6 +408,21 @@ class CollectiveSharedEndpointUpdate(BaseModel):
     name: Optional[str] = Field(None, min_length=1, max_length=100)
     description: Optional[str] = Field(None, max_length=500)
     endpoint_ids: Optional[List[int]] = Field(default=None, min_length=1)
+
+    @field_validator("name", "description", mode="before")
+    @classmethod
+    def reject_explicit_null(cls, v: Any) -> Any:
+        """Reject ``{"name": null}`` / ``{"description": null}`` PATCH bodies.
+
+        ``Optional[str] = None`` is the schema's way of marking the field
+        unset; an explicit null would hit a NOT NULL column at the repository
+        layer and surface as a generic 500. ``mode='before'`` only fires when
+        the field is supplied, so the default ``None`` (field omitted) still
+        round-trips cleanly.
+        """
+        if v is None:
+            raise ValueError("must not be null")
+        return v
 
     @field_validator("endpoint_ids")
     @classmethod

--- a/components/backend/src/syfthub/services/collective_service.py
+++ b/components/backend/src/syfthub/services/collective_service.py
@@ -10,13 +10,15 @@ from __future__ import annotations
 
 import secrets
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence
 
 from fastapi import HTTPException, status
 
 from syfthub.repositories.collective import (
     CollectiveMemberRepository,
     CollectiveRepository,
+    CollectiveSharedEndpointMemberRepository,
+    CollectiveSharedEndpointRepository,
 )
 from syfthub.repositories.endpoint import EndpointRepository
 from syfthub.repositories.user import UserRepository
@@ -25,12 +27,17 @@ from syfthub.schemas.collective import (
     CollectiveCreate,
     CollectiveMemberResponse,
     CollectiveResponse,
+    CollectiveSharedEndpointCreate,
+    CollectiveSharedEndpointMemberSummary,
+    CollectiveSharedEndpointResponse,
+    CollectiveSharedEndpointUpdate,
     CollectiveUpdate,
     InvitationDecision,
     InvitationEmailContext,
     MembershipStatus,
     ReviewDecision,
     slugify_collective_name,
+    slugify_shared_endpoint_name,
 )
 from syfthub.schemas.endpoint import (
     Endpoint,
@@ -64,6 +71,10 @@ class CollectiveService(BaseService):
         self.member_repo = CollectiveMemberRepository(session)
         self.endpoint_repo = EndpointRepository(session)
         self.user_repo = UserRepository(session)
+        self.shared_endpoint_repo = CollectiveSharedEndpointRepository(session)
+        self.shared_endpoint_member_repo = CollectiveSharedEndpointMemberRepository(
+            session
+        )
 
     # ------------------------------------------------------------------
     # Collective CRUD
@@ -109,8 +120,9 @@ class CollectiveService(BaseService):
         """Return owner/slug paths of all approved member endpoints.
 
         Called by the SDK's collective-resolution step to expand a
-        ``collective/<slug>`` path into the individual endpoint paths that
-        participate in the aggregator request.
+        ``collective/<slug>`` (or the equivalent ``collective/<slug>/all``)
+        path into the individual endpoint paths that participate in the
+        aggregator request.
         """
         collective = self.collective_repo.get_by_slug(slug)
         if collective is None:
@@ -118,15 +130,39 @@ class CollectiveService(BaseService):
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Collective not found",
             )
-        memberships = self.member_repo.list_members(
-            collective.id, [MembershipStatus.APPROVED.value]
+        return self._collective_approved_paths(collective.id)
+
+    def get_shared_endpoint_paths(
+        self, collective_slug: str, shared_slug: str
+    ) -> List[str]:
+        """Resolve a ``collective/<X>/<Y>`` path to owner/slug endpoint paths.
+
+        The result is the intersection of the configured endpoint set with the
+        parent collective's currently approved members — endpoints that have
+        since left the collective are silently filtered out. The ``all`` slug
+        short-circuits to "every approved member".
+        """
+        collective = self.collective_repo.get_by_slug(collective_slug)
+        if collective is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Collective not found",
+            )
+        if shared_slug == "all":
+            return self._collective_approved_paths(collective.id)
+
+        shared = self.shared_endpoint_repo.get_by_collective_and_slug(
+            collective.id, shared_slug
         )
-        enriched = self._enrich_many(memberships)
-        return [
-            f"{m.endpoint_owner_username}/{m.endpoint_slug}"
-            for m in enriched
-            if m.endpoint_owner_username and m.endpoint_slug
-        ]
+        if shared is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Shared endpoint not found",
+            )
+        configured_ids = self.shared_endpoint_member_repo.list_endpoint_ids(shared.id)
+        approved_ids = self._approved_endpoint_ids(collective.id)
+        active_ids = [eid for eid in configured_ids if eid in approved_ids]
+        return self._resolve_endpoint_paths(active_ids)
 
     def list_collectives(
         self,
@@ -768,3 +804,324 @@ class CollectiveService(BaseService):
             status_code=status.HTTP_409_CONFLICT,
             detail="Could not generate a unique slug; please supply one explicitly",
         )
+
+    # ------------------------------------------------------------------
+    # Shared endpoints — curated subsets of approved members
+    # ------------------------------------------------------------------
+
+    def list_shared_endpoints(
+        self, collective_id: int
+    ) -> List[CollectiveSharedEndpointResponse]:
+        """List a collective's shared endpoints with active/inactive enrichment."""
+        self._get_collective_or_404(collective_id)
+        rows = self.shared_endpoint_repo.list_for_collective(collective_id)
+        return self._enrich_shared_endpoints(collective_id, rows)
+
+    def list_shared_endpoints_by_slug(
+        self, collective_slug: str
+    ) -> List[CollectiveSharedEndpointResponse]:
+        """List shared endpoints by parent collective slug (public)."""
+        collective = self.collective_repo.get_by_slug(collective_slug)
+        if collective is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Collective not found",
+            )
+        rows = self.shared_endpoint_repo.list_for_collective(collective.id)
+        return self._enrich_shared_endpoints(collective.id, rows)
+
+    def get_shared_endpoint(
+        self, collective_id: int, shared_slug: str
+    ) -> CollectiveSharedEndpointResponse:
+        """Get one shared endpoint by collective id + slug."""
+        self._get_collective_or_404(collective_id)
+        shared = self.shared_endpoint_repo.get_by_collective_and_slug(
+            collective_id, shared_slug
+        )
+        if shared is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Shared endpoint not found",
+            )
+        return self._enrich_shared_endpoint(collective_id, shared)
+
+    def get_shared_endpoint_by_slugs(
+        self, collective_slug: str, shared_slug: str
+    ) -> CollectiveSharedEndpointResponse:
+        """Get one shared endpoint by collective slug + own slug (public)."""
+        collective = self.collective_repo.get_by_slug(collective_slug)
+        if collective is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Collective not found",
+            )
+        shared = self.shared_endpoint_repo.get_by_collective_and_slug(
+            collective.id, shared_slug
+        )
+        if shared is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Shared endpoint not found",
+            )
+        return self._enrich_shared_endpoint(collective.id, shared)
+
+    def create_shared_endpoint(
+        self,
+        collective_id: int,
+        data: CollectiveSharedEndpointCreate,
+        current_user: User,
+    ) -> CollectiveSharedEndpointResponse:
+        """Create a shared endpoint under a collective.
+
+        Validates that every ``endpoint_ids`` entry is currently an approved
+        member of the collective — owners can't smuggle in pending, rejected,
+        or unrelated endpoints. Slug is auto-derived from the name when
+        omitted, with collision resolution mirroring the collective slug
+        helper.
+        """
+        collective = self._get_collective_or_404(collective_id)
+        self._require_owner(collective, current_user)
+
+        approved_ids = self._approved_endpoint_ids(collective_id)
+        unknown = [eid for eid in data.endpoint_ids if eid not in approved_ids]
+        if unknown:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "Every endpoint must be an approved member of this "
+                    "collective. Not approved: "
+                    f"{', '.join(str(eid) for eid in unknown)}"
+                ),
+            )
+
+        slug = self._resolve_shared_endpoint_slug(collective_id, data)
+        created = self.shared_endpoint_repo.create_shared_endpoint(
+            collective_id=collective_id,
+            name=data.name,
+            slug=slug,
+            description=data.description,
+            endpoint_ids=data.endpoint_ids,
+            collective_slug=collective.slug,
+        )
+        if created is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to create shared endpoint",
+            )
+        return self._enrich_shared_endpoint(collective_id, created)
+
+    def update_shared_endpoint(
+        self,
+        collective_id: int,
+        shared_slug: str,
+        data: CollectiveSharedEndpointUpdate,
+        current_user: User,
+    ) -> CollectiveSharedEndpointResponse:
+        """Update a shared endpoint's name/description and (optionally) members."""
+        collective = self._get_collective_or_404(collective_id)
+        self._require_owner(collective, current_user)
+        shared = self.shared_endpoint_repo.get_by_collective_and_slug(
+            collective_id, shared_slug
+        )
+        if shared is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Shared endpoint not found",
+            )
+
+        endpoint_ids: Optional[List[int]] = None
+        if data.endpoint_ids is not None:
+            approved_ids = self._approved_endpoint_ids(collective_id)
+            unknown = [eid for eid in data.endpoint_ids if eid not in approved_ids]
+            if unknown:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        "Every endpoint must be an approved member of this "
+                        "collective. Not approved: "
+                        f"{', '.join(str(eid) for eid in unknown)}"
+                    ),
+                )
+            endpoint_ids = list(data.endpoint_ids)
+
+        fields = data.model_dump(exclude_unset=True, exclude={"endpoint_ids"})
+        if not fields and endpoint_ids is None:
+            return self._enrich_shared_endpoint(collective_id, shared)
+
+        updated = self.shared_endpoint_repo.update_shared_endpoint(
+            shared.id,
+            fields=fields,
+            endpoint_ids=endpoint_ids,
+            collective_slug=collective.slug,
+        )
+        if updated is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to update shared endpoint",
+            )
+        return self._enrich_shared_endpoint(collective_id, updated)
+
+    def delete_shared_endpoint(
+        self,
+        collective_id: int,
+        shared_slug: str,
+        current_user: User,
+    ) -> None:
+        """Delete a shared endpoint (cascades to its member rows)."""
+        collective = self._get_collective_or_404(collective_id)
+        self._require_owner(collective, current_user)
+        shared = self.shared_endpoint_repo.get_by_collective_and_slug(
+            collective_id, shared_slug
+        )
+        if shared is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Shared endpoint not found",
+            )
+        if not self.shared_endpoint_repo.delete_shared_endpoint(shared.id):
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to delete shared endpoint",
+            )
+
+    # ------------------------------------------------------------------
+    # Shared-endpoint helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_shared_endpoint_slug(
+        self, collective_id: int, data: CollectiveSharedEndpointCreate
+    ) -> str:
+        """Determine a unique slug for a new shared endpoint within a collective."""
+        if data.slug:
+            if self.shared_endpoint_repo.slug_exists(collective_id, data.slug):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Shared endpoint slug already taken in this collective",
+                )
+            return data.slug
+
+        base = slugify_shared_endpoint_name(data.name)
+        if not self.shared_endpoint_repo.slug_exists(collective_id, base):
+            return base
+        for _ in range(5):
+            candidate = f"{base[:56]}-{secrets.token_hex(3)}"
+            if not self.shared_endpoint_repo.slug_exists(collective_id, candidate):
+                return candidate
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Could not generate a unique slug; please supply one explicitly",
+        )
+
+    def _approved_endpoint_ids(self, collective_id: int) -> set[int]:
+        """Set of endpoint ids currently approved in the collective."""
+        memberships = self.member_repo.list_members(
+            collective_id, [MembershipStatus.APPROVED.value]
+        )
+        return {m.endpoint_id for m in memberships}
+
+    def _collective_approved_paths(self, collective_id: int) -> List[str]:
+        """Owner/slug paths of every approved member endpoint."""
+        memberships = self.member_repo.list_members(
+            collective_id, [MembershipStatus.APPROVED.value]
+        )
+        enriched = self._enrich_many(memberships)
+        return [
+            f"{m.endpoint_owner_username}/{m.endpoint_slug}"
+            for m in enriched
+            if m.endpoint_owner_username and m.endpoint_slug
+        ]
+
+    def _resolve_endpoint_paths(self, endpoint_ids: Sequence[int]) -> List[str]:
+        """Resolve endpoint ids to ``owner/slug`` strings, preserving input order."""
+        if not endpoint_ids:
+            return []
+        endpoints = {
+            ep.id: ep for ep in self.endpoint_repo.get_by_ids(list(endpoint_ids))
+        }
+        owners = {
+            owner.id: owner
+            for owner in self.user_repo.get_by_ids(
+                list({ep.user_id for ep in endpoints.values()})
+            )
+        }
+        paths: List[str] = []
+        for endpoint_id in endpoint_ids:
+            endpoint = endpoints.get(endpoint_id)
+            if endpoint is None:
+                continue
+            owner = owners.get(endpoint.user_id)
+            if owner is None:
+                continue
+            paths.append(f"{owner.username}/{endpoint.slug}")
+        return paths
+
+    def _enrich_shared_endpoint(
+        self,
+        collective_id: int,
+        shared: CollectiveSharedEndpointResponse,
+    ) -> CollectiveSharedEndpointResponse:
+        """Populate ``members``, ``member_count`` and ``active_member_count``."""
+        return self._enrich_shared_endpoints(collective_id, [shared])[0]
+
+    def _enrich_shared_endpoints(
+        self,
+        collective_id: int,
+        rows: List[CollectiveSharedEndpointResponse],
+    ) -> List[CollectiveSharedEndpointResponse]:
+        """Bulk-enrich shared endpoints with member summaries + counts."""
+        if not rows:
+            return rows
+        approved_ids = self._approved_endpoint_ids(collective_id)
+        configured = self.shared_endpoint_member_repo.list_endpoint_ids_bulk(
+            [row.id for row in rows]
+        )
+        endpoint_ids_all: set[int] = set()
+        for ids in configured.values():
+            endpoint_ids_all.update(ids)
+        endpoint_map = {
+            ep.id: ep for ep in self.endpoint_repo.get_by_ids(list(endpoint_ids_all))
+        }
+        owners = {
+            owner.id: owner
+            for owner in self.user_repo.get_by_ids(
+                list({ep.user_id for ep in endpoint_map.values()})
+            )
+        }
+
+        enriched: List[CollectiveSharedEndpointResponse] = []
+        for row in rows:
+            ids = configured.get(row.id, [])
+            members: List[CollectiveSharedEndpointMemberSummary] = []
+            active = 0
+            for endpoint_id in ids:
+                endpoint = endpoint_map.get(endpoint_id)
+                if endpoint is None:
+                    # Endpoint was hard-deleted (CASCADE removed the join row)
+                    # so this should never fire in practice, but be defensive.
+                    continue
+                is_active = endpoint_id in approved_ids
+                if is_active:
+                    active += 1
+                owner = owners.get(endpoint.user_id)
+                members.append(
+                    CollectiveSharedEndpointMemberSummary(
+                        endpoint_id=endpoint.id,
+                        endpoint_name=endpoint.name,
+                        endpoint_slug=endpoint.slug,
+                        endpoint_owner_username=(
+                            owner.username if owner is not None else None
+                        ),
+                        endpoint_type=endpoint.type.value,
+                        is_active=is_active,
+                    )
+                )
+            enriched.append(
+                row.model_copy(
+                    update={
+                        "members": members,
+                        "member_count": len(members),
+                        "active_member_count": active,
+                    }
+                )
+            )
+        return enriched

--- a/components/backend/src/syfthub/services/collective_service.py
+++ b/components/backend/src/syfthub/services/collective_service.py
@@ -24,6 +24,7 @@ from syfthub.repositories.endpoint import EndpointRepository
 from syfthub.repositories.user import UserRepository
 from syfthub.schemas.auth import UserRole
 from syfthub.schemas.collective import (
+    RESERVED_SHARED_ENDPOINT_SLUGS,
     CollectiveCreate,
     CollectiveMemberResponse,
     CollectiveResponse,
@@ -817,6 +818,29 @@ class CollectiveService(BaseService):
         rows = self.shared_endpoint_repo.list_for_collective(collective_id)
         return self._enrich_shared_endpoints(collective_id, rows)
 
+    def list_shared_endpoints_bulk(
+        self, collective_ids: Sequence[int]
+    ) -> List[CollectiveSharedEndpointResponse]:
+        """Bulk-list shared endpoints for several collectives in one shot.
+
+        Powers the chat-view's add-sources modal — a single request replaces
+        the prior fan-out of one GET per collective. Unknown collective ids
+        are silently skipped (they contribute zero rows) rather than 404ing
+        the whole batch.
+        """
+        if not collective_ids:
+            return []
+        rows = self.shared_endpoint_repo.list_for_collectives(collective_ids)
+        # Enrichment is per-collective (active membership is collective-
+        # scoped), so bucket rows by parent before enriching.
+        by_collective: dict[int, List[CollectiveSharedEndpointResponse]] = {}
+        for row in rows:
+            by_collective.setdefault(row.collective_id, []).append(row)
+        enriched: List[CollectiveSharedEndpointResponse] = []
+        for collective_id, group in by_collective.items():
+            enriched.extend(self._enrich_shared_endpoints(collective_id, group))
+        return enriched
+
     def list_shared_endpoints_by_slug(
         self, collective_slug: str
     ) -> List[CollectiveSharedEndpointResponse]:
@@ -1001,11 +1025,23 @@ class CollectiveService(BaseService):
             return data.slug
 
         base = slugify_shared_endpoint_name(data.name)
-        if not self.shared_endpoint_repo.slug_exists(collective_id, base):
+        # Reserved slugs (e.g. ``all``) short-circuit the resolver before the
+        # row is consulted, so a persisted reserved slug is unreachable. Treat
+        # the collision the same way as a duplicate and fall through.
+        if (
+            base not in RESERVED_SHARED_ENDPOINT_SLUGS
+            and not self.shared_endpoint_repo.slug_exists(collective_id, base)
+        ):
             return base
+        # Strip the trailing '-' that ``[:56]`` may have exposed so the
+        # appended random token doesn't introduce a forbidden '--' sequence.
+        prefix = base[:56].rstrip("-") or "shared"
         for _ in range(5):
-            candidate = f"{base[:56]}-{secrets.token_hex(3)}"
-            if not self.shared_endpoint_repo.slug_exists(collective_id, candidate):
+            candidate = f"{prefix}-{secrets.token_hex(3)}"
+            if (
+                candidate not in RESERVED_SHARED_ENDPOINT_SLUGS
+                and not self.shared_endpoint_repo.slug_exists(collective_id, candidate)
+            ):
                 return candidate
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -1096,8 +1132,23 @@ class CollectiveService(BaseService):
             for endpoint_id in ids:
                 endpoint = endpoint_map.get(endpoint_id)
                 if endpoint is None:
-                    # Endpoint was hard-deleted (CASCADE removed the join row)
-                    # so this should never fire in practice, but be defensive.
+                    # Endpoint is configured but missing from endpoint_repo —
+                    # owner soft-deleted it (is_active=False) so the join row
+                    # outlived the endpoint. Emit a placeholder so the owner
+                    # can still see and remove the dangling configuration; an
+                    # endpoint that is missing cannot be approved, so it
+                    # contributes to ``member_count`` but never to
+                    # ``active_member_count``.
+                    members.append(
+                        CollectiveSharedEndpointMemberSummary(
+                            endpoint_id=endpoint_id,
+                            endpoint_name=None,
+                            endpoint_slug=None,
+                            endpoint_owner_username=None,
+                            endpoint_type=None,
+                            is_active=False,
+                        )
+                    )
                     continue
                 is_active = endpoint_id in approved_ids
                 if is_active:
@@ -1119,7 +1170,10 @@ class CollectiveService(BaseService):
                 row.model_copy(
                     update={
                         "members": members,
-                        "member_count": len(members),
+                        # ``len(ids)`` rather than ``len(members)`` so the
+                        # count matches the schema's "Total configured
+                        # members" contract even when an endpoint is missing.
+                        "member_count": len(ids),
                         "active_member_count": active,
                     }
                 )

--- a/components/backend/tests/test_collectives.py
+++ b/components/backend/tests/test_collectives.py
@@ -1020,3 +1020,436 @@ def test_get_collective_endpoint_paths_format(
         assert len(parts) == 2 and all(parts), (
             f"Path {path!r} does not match 'owner/slug' format"
         )
+
+
+# ----------------------------------------------------------------------
+# Shared endpoints — named, curated subsets of approved members
+# ----------------------------------------------------------------------
+
+
+def _approve_endpoint_into_collective(
+    client: TestClient,
+    *,
+    collective_id: int,
+    endpoint_id: int,
+    member_headers: dict,
+    owner_headers: dict,
+) -> None:
+    """End-to-end helper: request join + owner approves, leaving status=approved."""
+    resp = client.post(
+        f"{API}/collectives/{collective_id}/members",
+        json={"endpoint_id": endpoint_id},
+        headers=member_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    resp = client.post(
+        f"{API}/collectives/{collective_id}/members/{endpoint_id}/review",
+        json={"decision": "approve"},
+        headers=owner_headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.fixture
+def collective_with_two_members(
+    client: TestClient, owner_headers: dict, member_headers: dict
+) -> dict:
+    """A collective with two approved data-source endpoints from a separate user.
+
+    Yields a dict carrying the collective id/slug and the two approved endpoint
+    ids so each shared-endpoint test can curate subsets without rebuilding the
+    base graph.
+    """
+    collective = _create_collective(client, owner_headers, name="Genomics Collective")
+    endpoint_one = _create_endpoint(client, member_headers, name="Source One")
+    endpoint_two = _create_endpoint(client, member_headers, name="Source Two")
+    for endpoint_id in (endpoint_one, endpoint_two):
+        _approve_endpoint_into_collective(
+            client,
+            collective_id=collective["id"],
+            endpoint_id=endpoint_id,
+            member_headers=member_headers,
+            owner_headers=owner_headers,
+        )
+    return {
+        "id": collective["id"],
+        "slug": collective["slug"],
+        "endpoint_one": endpoint_one,
+        "endpoint_two": endpoint_two,
+    }
+
+
+def test_create_shared_endpoint(
+    client: TestClient,
+    owner_headers: dict,
+    collective_with_two_members: dict,
+) -> None:
+    """Owner creates a shared endpoint with one of two approved members."""
+    collective = collective_with_two_members
+    resp = client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json={
+            "name": "Health News",
+            "description": "Subset focused on health",
+            "endpoint_ids": [collective["endpoint_one"]],
+        },
+        headers=owner_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["name"] == "Health News"
+    assert body["slug"] == "health-news"
+    assert body["collective_slug"] == collective["slug"]
+    assert (
+        body["shared_endpoint_path"] == f"collective/{collective['slug']}/health-news"
+    )
+    assert body["member_count"] == 1
+    assert body["active_member_count"] == 1
+    assert len(body["members"]) == 1
+    assert body["members"][0]["endpoint_id"] == collective["endpoint_one"]
+    assert body["members"][0]["is_active"] is True
+
+
+def test_create_shared_endpoint_explicit_slug(
+    client: TestClient,
+    owner_headers: dict,
+    collective_with_two_members: dict,
+) -> None:
+    """Explicit slug is honored when valid."""
+    collective = collective_with_two_members
+    resp = client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json={
+            "name": "Curated",
+            "slug": "alpha",
+            "endpoint_ids": [collective["endpoint_one"]],
+        },
+        headers=owner_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["slug"] == "alpha"
+
+
+def test_reserved_slug_all_rejected(
+    client: TestClient,
+    owner_headers: dict,
+    collective_with_two_members: dict,
+) -> None:
+    """The reserved 'all' slug cannot be used for a custom shared endpoint."""
+    collective = collective_with_two_members
+    resp = client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json={
+            "name": "All Endpoints",
+            "slug": "all",
+            "endpoint_ids": [collective["endpoint_one"]],
+        },
+        headers=owner_headers,
+    )
+    assert resp.status_code == 422, resp.text
+
+
+def test_duplicate_slug_per_collective_rejected(
+    client: TestClient,
+    owner_headers: dict,
+    collective_with_two_members: dict,
+) -> None:
+    """Two shared endpoints in the same collective cannot share a slug."""
+    collective = collective_with_two_members
+    payload = {
+        "name": "Health",
+        "slug": "health",
+        "endpoint_ids": [collective["endpoint_one"]],
+    }
+    resp = client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json=payload,
+        headers=owner_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    resp = client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json=payload,
+        headers=owner_headers,
+    )
+    assert resp.status_code == 409, resp.text
+
+
+def test_non_approved_endpoint_rejected_on_create(
+    client: TestClient,
+    owner_headers: dict,
+    member_headers: dict,
+    collective_with_two_members: dict,
+) -> None:
+    """An endpoint that isn't an approved member can't be added to a subset."""
+    collective = collective_with_two_members
+    # A second collective with an endpoint that's NOT approved in the first one.
+    outsider = _create_endpoint(client, member_headers, name="Outsider")
+    resp = client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json={
+            "name": "Bad",
+            "endpoint_ids": [collective["endpoint_one"], outsider],
+        },
+        headers=owner_headers,
+    )
+    assert resp.status_code == 400, resp.text
+    assert str(outsider) in resp.json()["detail"]
+
+
+def test_empty_endpoint_ids_rejected(
+    client: TestClient,
+    owner_headers: dict,
+    collective_with_two_members: dict,
+) -> None:
+    """A shared endpoint must have at least one configured member."""
+    collective = collective_with_two_members
+    resp = client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json={"name": "Empty", "endpoint_ids": []},
+        headers=owner_headers,
+    )
+    assert resp.status_code == 422, resp.text
+
+
+def test_create_requires_collective_owner(
+    client: TestClient,
+    member_headers: dict,
+    collective_with_two_members: dict,
+) -> None:
+    """Non-owners cannot create shared endpoints."""
+    collective = collective_with_two_members
+    resp = client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json={
+            "name": "Sneaky",
+            "endpoint_ids": [collective["endpoint_one"]],
+        },
+        headers=member_headers,
+    )
+    assert resp.status_code == 403, resp.text
+
+
+def test_list_and_get_shared_endpoints(
+    client: TestClient,
+    owner_headers: dict,
+    collective_with_two_members: dict,
+) -> None:
+    """List + get-by-slug return the created shared endpoints."""
+    collective = collective_with_two_members
+    resp = client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json={
+            "name": "Health News",
+            "endpoint_ids": [collective["endpoint_one"]],
+        },
+        headers=owner_headers,
+    )
+    assert resp.status_code == 201, resp.text
+
+    # By collective id (public-readable).
+    resp = client.get(f"{API}/collectives/{collective['id']}/shared-endpoints")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    # By collective slug (public-readable).
+    resp = client.get(
+        f"{API}/collectives/by-slug/{collective['slug']}/shared-endpoints"
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    # By slug pair.
+    resp = client.get(
+        f"{API}/collectives/by-slug/{collective['slug']}/shared-endpoints/health-news"
+    )
+    assert resp.status_code == 200
+    assert resp.json()["slug"] == "health-news"
+
+
+def test_update_shared_endpoint_replaces_members(
+    client: TestClient,
+    owner_headers: dict,
+    collective_with_two_members: dict,
+) -> None:
+    """PATCH with endpoint_ids replaces the full member set."""
+    collective = collective_with_two_members
+    create = client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json={
+            "name": "Curated",
+            "endpoint_ids": [collective["endpoint_one"]],
+        },
+        headers=owner_headers,
+    )
+    assert create.status_code == 201
+
+    resp = client.patch(
+        f"{API}/collectives/{collective['id']}/shared-endpoints/curated",
+        json={
+            "name": "Curated v2",
+            "endpoint_ids": [collective["endpoint_two"]],
+        },
+        headers=owner_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["name"] == "Curated v2"
+    assert body["member_count"] == 1
+    assert body["members"][0]["endpoint_id"] == collective["endpoint_two"]
+
+
+def test_update_shared_endpoint_omitting_endpoints_leaves_members(
+    client: TestClient,
+    owner_headers: dict,
+    collective_with_two_members: dict,
+) -> None:
+    """Omitting endpoint_ids in PATCH leaves the membership untouched."""
+    collective = collective_with_two_members
+    client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json={
+            "name": "Curated",
+            "endpoint_ids": [
+                collective["endpoint_one"],
+                collective["endpoint_two"],
+            ],
+        },
+        headers=owner_headers,
+    )
+    resp = client.patch(
+        f"{API}/collectives/{collective['id']}/shared-endpoints/curated",
+        json={"description": "Just a description tweak"},
+        headers=owner_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["member_count"] == 2
+
+
+def test_delete_shared_endpoint(
+    client: TestClient,
+    owner_headers: dict,
+    collective_with_two_members: dict,
+) -> None:
+    """Owner can delete; subsequent GET returns 404."""
+    collective = collective_with_two_members
+    client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json={"name": "Bye", "endpoint_ids": [collective["endpoint_one"]]},
+        headers=owner_headers,
+    )
+    resp = client.delete(
+        f"{API}/collectives/{collective['id']}/shared-endpoints/bye",
+        headers=owner_headers,
+    )
+    assert resp.status_code == 204, resp.text
+    resp = client.get(f"{API}/collectives/{collective['id']}/shared-endpoints/bye")
+    assert resp.status_code == 404
+
+
+def test_endpoint_paths_intersect_with_approved(
+    client: TestClient,
+    owner_headers: dict,
+    member_headers: dict,
+    collective_with_two_members: dict,
+) -> None:
+    """When a configured endpoint is removed from the collective, it drops from fan-out."""
+    collective = collective_with_two_members
+    client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json={
+            "name": "Both",
+            "endpoint_ids": [
+                collective["endpoint_one"],
+                collective["endpoint_two"],
+            ],
+        },
+        headers=owner_headers,
+    )
+
+    # Sanity check: both members are in the fan-out before removal.
+    resp = client.get(
+        f"{API}/collectives/by-slug/{collective['slug']}"
+        f"/shared-endpoints/both/endpoint-paths"
+    )
+    assert resp.status_code == 200, resp.text
+    assert sorted(resp.json()) == ["member/source-one", "member/source-two"]
+
+    # Endpoint owner leaves the collective with endpoint_two.
+    resp = client.delete(
+        f"{API}/collectives/{collective['id']}/members/{collective['endpoint_two']}",
+        headers=member_headers,
+    )
+    assert resp.status_code == 204, resp.text
+
+    # endpoint_two silently drops from the shared endpoint at resolve time.
+    resp = client.get(
+        f"{API}/collectives/by-slug/{collective['slug']}"
+        f"/shared-endpoints/both/endpoint-paths"
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == ["member/source-one"]
+
+    # The shared-endpoint detail surfaces the inactive state in `members`.
+    resp = client.get(
+        f"{API}/collectives/by-slug/{collective['slug']}/shared-endpoints/both"
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["member_count"] == 2
+    assert body["active_member_count"] == 1
+    inactive = [m for m in body["members"] if not m["is_active"]]
+    assert len(inactive) == 1
+    assert inactive[0]["endpoint_id"] == collective["endpoint_two"]
+
+
+def test_all_slug_resolves_to_full_membership(
+    client: TestClient,
+    collective_with_two_members: dict,
+) -> None:
+    """``collective/<X>/all`` and ``collective/<X>`` resolve identically."""
+    collective = collective_with_two_members
+    resp_all = client.get(
+        f"{API}/collectives/by-slug/{collective['slug']}"
+        f"/shared-endpoints/all/endpoint-paths"
+    )
+    resp_default = client.get(
+        f"{API}/collectives/by-slug/{collective['slug']}/endpoint-paths"
+    )
+    assert resp_all.status_code == 200, resp_all.text
+    assert resp_default.status_code == 200, resp_default.text
+    assert sorted(resp_all.json()) == sorted(resp_default.json())
+
+
+def test_unknown_shared_slug_404(
+    client: TestClient,
+    collective_with_two_members: dict,
+) -> None:
+    """Querying an unknown shared slug yields 404."""
+    collective = collective_with_two_members
+    resp = client.get(
+        f"{API}/collectives/by-slug/{collective['slug']}"
+        f"/shared-endpoints/does-not-exist/endpoint-paths"
+    )
+    assert resp.status_code == 404
+
+
+def test_deleting_collective_cascades_to_shared_endpoints(
+    client: TestClient,
+    owner_headers: dict,
+    collective_with_two_members: dict,
+) -> None:
+    """Cascade: deleting the collective removes its shared endpoints."""
+    collective = collective_with_two_members
+    client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json={"name": "Sub", "endpoint_ids": [collective["endpoint_one"]]},
+        headers=owner_headers,
+    )
+    resp = client.delete(f"{API}/collectives/{collective['id']}", headers=owner_headers)
+    assert resp.status_code == 204, resp.text
+    # The parent is gone, so the by-slug lookup 404s.
+    resp = client.get(
+        f"{API}/collectives/by-slug/{collective['slug']}/shared-endpoints"
+    )
+    assert resp.status_code == 404

--- a/components/backend/tests/test_collectives.py
+++ b/components/backend/tests/test_collectives.py
@@ -1453,3 +1453,103 @@ def test_deleting_collective_cascades_to_shared_endpoints(
         f"{API}/collectives/by-slug/{collective['slug']}/shared-endpoints"
     )
     assert resp.status_code == 404
+
+
+# ----------------------------------------------------------------------
+# Regression tests for the post-review hardening pass
+# ----------------------------------------------------------------------
+
+
+def test_auto_derived_reserved_slug_falls_through(
+    client: TestClient,
+    owner_headers: dict,
+    collective_with_two_members: dict,
+) -> None:
+    """A name that slugifies to a reserved slug must not persist as that slug.
+
+    Without the resolver guard, ``name='All'`` would slugify to ``'all'`` and
+    create an unaddressable subset (the resolver short-circuits on ``all``).
+    Expect either a generated fallback slug (NOT in the reserved set) or a
+    rejection — never the reserved slug itself.
+    """
+    collective = collective_with_two_members
+    resp = client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json={
+            "name": "All",
+            "endpoint_ids": [collective["endpoint_one"]],
+        },
+        headers=owner_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["slug"] != "all"
+
+
+def test_patch_explicit_null_description_rejected_as_422(
+    client: TestClient,
+    owner_headers: dict,
+    collective_with_two_members: dict,
+) -> None:
+    """PATCH ``{"description": null}`` must 422, not 500.
+
+    The DB column is NOT NULL; passing an explicit null used to bubble up as
+    a generic 500 IntegrityError because the schema accepted ``Optional[str]
+    = None`` as a valid explicit value.
+    """
+    collective = collective_with_two_members
+    client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json={"name": "Doc", "endpoint_ids": [collective["endpoint_one"]]},
+        headers=owner_headers,
+    )
+    resp = client.patch(
+        f"{API}/collectives/{collective['id']}/shared-endpoints/doc",
+        json={"description": None},
+        headers=owner_headers,
+    )
+    assert resp.status_code == 422, resp.text
+
+    resp = client.patch(
+        f"{API}/collectives/{collective['id']}/shared-endpoints/doc",
+        json={"name": None},
+        headers=owner_headers,
+    )
+    assert resp.status_code == 422, resp.text
+
+
+def test_bulk_list_shared_endpoints(
+    client: TestClient,
+    owner_headers: dict,
+    collective_with_two_members: dict,
+) -> None:
+    """``GET /shared-endpoints/bulk`` returns rows across every requested collective.
+
+    The chat-view modal relies on this endpoint to avoid the
+    one-request-per-collective fan-out.
+    """
+    collective = collective_with_two_members
+    # Create one shared endpoint to be discovered by the bulk read.
+    create = client.post(
+        f"{API}/collectives/{collective['id']}/shared-endpoints",
+        json={"name": "First", "endpoint_ids": [collective["endpoint_one"]]},
+        headers=owner_headers,
+    )
+    assert create.status_code == 201
+
+    # An unknown id is silently skipped rather than 404ing the whole batch.
+    resp = client.get(
+        f"{API}/collectives/shared-endpoints/bulk",
+        params=[("collective_id", collective["id"]), ("collective_id", 999_999)],
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["slug"] == "first"
+    assert body[0]["collective_id"] == collective["id"]
+
+
+def test_bulk_list_empty_request(client: TestClient) -> None:
+    """No ``collective_id`` query params → empty list (no 422)."""
+    resp = client.get(f"{API}/collectives/shared-endpoints/bulk")
+    assert resp.status_code == 200
+    assert resp.json() == []

--- a/components/frontend/src/components/chat/__tests__/add-sources-modal.test.tsx
+++ b/components/frontend/src/components/chat/__tests__/add-sources-modal.test.tsx
@@ -263,6 +263,48 @@ describe('AddSourcesModal', () => {
       });
       expect(screen.getByText(/no matching collectives found/i)).toBeInTheDocument();
     });
+
+    it('keeps the parent collective visible when only a shared endpoint matches', async () => {
+      // Regression: previously the search only matched parent fields, so a
+      // user typing a shared-endpoint name saw an empty list even when a
+      // matching shared endpoint existed under one of the visible collectives.
+      const user = userEvent.setup();
+      const collective = createMockCollective({
+        name: 'Genomics Research',
+        slug: 'genomics',
+        description: 'Sequencing endpoints',
+        tags: ['bio']
+      });
+      const shared = {
+        id: 11,
+        collective_id: collective.id,
+        collective_slug: collective.slug,
+        name: 'Health News',
+        slug: 'health-news',
+        shared_endpoint_path: 'collective/genomics/health-news',
+        description: '',
+        members: [],
+        member_count: 0,
+        active_member_count: 0,
+        created_at: '2024-01-01T00:00:00.000Z',
+        updated_at: '2024-01-01T00:00:00.000Z'
+      };
+      renderModal(
+        defaultProps({
+          availableCollectives: [collective],
+          availableSharedEndpoints: [{ collective, shared }]
+        })
+      );
+
+      await user.click(screen.getByRole('button', { name: /collectives/i }));
+      const searchInput = screen.getByPlaceholderText(/search collectives/i);
+      fireEvent.change(searchInput, { target: { value: 'health-news' } });
+
+      await waitFor(() => {
+        expect(screen.getByText('Genomics Research')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Health News')).toBeInTheDocument();
+    });
   });
 
   // --------------------------------------------------------------------------

--- a/components/frontend/src/components/chat/add-sources-modal.tsx
+++ b/components/frontend/src/components/chat/add-sources-modal.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import type { Collective } from '@/lib/collectives-api';
+import type { Collective, CollectiveSharedEndpoint } from '@/lib/collectives-api';
 import type { ChatSource } from '@/lib/types';
 
 import Check from 'lucide-react/dist/esm/icons/check';
@@ -26,6 +26,32 @@ import { getPublicEndpointsPaginated, isDataSourceEndpoint } from '@/lib/endpoin
  * the TypeScript SDK detects and resolves to individual endpoint paths before
  * building the aggregator request.
  */
+/**
+ * Convert a shared endpoint into a ChatSource keyed by both the collective and
+ * shared slug. The `full_path` is `collective/<collective-slug>/<shared-slug>`,
+ * which the TypeScript SDK recognises and expands to the configured-and-active
+ * subset of members at chat time.
+ */
+function sharedEndpointToChatSource(shared: CollectiveSharedEndpoint): ChatSource {
+  return {
+    id: `collective:${shared.collective_slug}/${shared.slug}`,
+    name: shared.name,
+    tags: [],
+    description: shared.description,
+    type: 'data_source',
+    updated: '',
+    updated_at: shared.updated_at,
+    status: 'active',
+    slug: shared.slug,
+    stars_count: 0,
+    version: '',
+    readme: '',
+    contributors_count: 0,
+    owner_username: undefined,
+    full_path: shared.shared_endpoint_path
+  };
+}
+
 function collectiveToChatSource(collective: Collective): ChatSource {
   return {
     // The id prefix "collective:" makes it unique and avoids clashing with
@@ -257,6 +283,86 @@ const CollectiveItem = memo(function CollectiveItem({
   );
 });
 
+interface SharedEndpointItemProps {
+  collective: Collective;
+  shared: CollectiveSharedEndpoint;
+  isSelected: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * Indented child row representing a curated subset of a collective's members.
+ * Visually nested under its parent collective in the Collectives tab so the
+ * relationship is obvious without a heavyweight expandable component tree.
+ */
+const SharedEndpointItem = memo(function SharedEndpointItem({
+  collective,
+  shared,
+  isSelected,
+  onToggle
+}: Readonly<SharedEndpointItemProps>) {
+  return (
+    <div
+      className={`group ml-6 flex w-full items-start gap-3 rounded-lg border border-l-2 p-3 transition-all ${
+        isSelected
+          ? 'border-indigo-500 bg-indigo-50 dark:border-indigo-600 dark:bg-indigo-950/30'
+          : 'border-border bg-card border-l-indigo-300 hover:border-indigo-300 hover:bg-indigo-50/40 dark:border-l-indigo-700 dark:hover:border-indigo-700 dark:hover:bg-indigo-950/20'
+      }`}
+    >
+      <button
+        type='button'
+        onClick={onToggle}
+        aria-pressed={isSelected}
+        className='mt-1 shrink-0 rounded focus-visible:ring-2 focus-visible:ring-indigo-500/50 focus-visible:outline-none'
+      >
+        <div
+          className={`flex h-5 w-5 items-center justify-center rounded border transition-colors ${
+            isSelected
+              ? 'border-indigo-500 bg-indigo-500 dark:border-indigo-600 dark:bg-indigo-600'
+              : 'border-input bg-background'
+          }`}
+          aria-hidden='true'
+        >
+          {isSelected && <Check className='h-3 w-3 text-white' />}
+        </div>
+      </button>
+
+      <button
+        type='button'
+        onClick={onToggle}
+        className='min-w-0 flex-1 text-left focus-visible:outline-none'
+        tabIndex={-1}
+      >
+        <span className='font-inter text-foreground block truncate text-sm font-medium'>
+          {shared.name}
+        </span>
+        <span className='font-inter text-muted-foreground block truncate text-xs'>
+          {shared.shared_endpoint_path} &middot; {shared.active_member_count}/{shared.member_count}{' '}
+          active
+        </span>
+        {shared.description && (
+          <p className='font-inter text-muted-foreground mt-1 line-clamp-2 text-xs'>
+            {shared.description}
+          </p>
+        )}
+      </button>
+
+      <Link
+        to={`/c/${collective.slug}`}
+        target='_blank'
+        rel='noopener noreferrer'
+        className='text-muted-foreground hover:text-foreground mt-1 shrink-0 transition-colors'
+        aria-label={`View ${collective.name} collective`}
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <ExternalLink className='h-4 w-4' />
+      </Link>
+    </div>
+  );
+});
+
 // ============================================================================
 // Main Component
 // ============================================================================
@@ -271,6 +377,17 @@ export interface AddSourcesModalProps {
   onConfirm: (selectedSources: ChatSource[]) => void;
   /** Collectives to show in the Collectives tab. Pass an empty array to hide the tab. */
   availableCollectives?: Collective[];
+  /**
+   * Curated shared-endpoint subsets, paired with their parent collective.
+   *
+   * Rendered as indented child rows under each parent in the Collectives tab.
+   * Empty when no collective in `availableCollectives` has any named subsets;
+   * the parent rows still work as before in that case.
+   */
+  availableSharedEndpoints?: Array<{
+    collective: Collective;
+    shared: CollectiveSharedEndpoint;
+  }>;
 }
 
 export const AddSourcesModal = memo(function AddSourcesModal({
@@ -279,7 +396,8 @@ export const AddSourcesModal = memo(function AddSourcesModal({
   availableSources,
   selectedSourceIds,
   onConfirm,
-  availableCollectives = []
+  availableCollectives = [],
+  availableSharedEndpoints = []
 }: Readonly<AddSourcesModalProps>) {
   const [activeTab, setActiveTab] = useState<ActiveTab>('endpoints');
   // Local selection state — only committed on confirm
@@ -312,6 +430,13 @@ export const AddSourcesModal = memo(function AddSourcesModal({
           initialMap.set(id, collectiveToChatSource(collective));
         }
       }
+      // ... and any selected shared-endpoint subsets.
+      for (const { shared } of availableSharedEndpoints) {
+        const id = `collective:${shared.collective_slug}/${shared.slug}`;
+        if (selectedSourceIds.has(id)) {
+          initialMap.set(id, sharedEndpointToChatSource(shared));
+        }
+      }
       setResolvedSourcesMap(initialMap);
       setSearchQuery('');
       setDebouncedSearchQuery('');
@@ -319,7 +444,7 @@ export const AddSourcesModal = memo(function AddSourcesModal({
       setActiveTab('endpoints');
     }
     previousOpenReference.current = isOpen;
-  }, [isOpen, selectedSourceIds, availableSources, availableCollectives]);
+  }, [isOpen, selectedSourceIds, availableSources, availableCollectives, availableSharedEndpoints]);
 
   // Reset search when switching tabs
   const handleTabChange = useCallback((tab: ActiveTab) => {
@@ -407,6 +532,22 @@ export const AddSourcesModal = memo(function AddSourcesModal({
     });
   }, [filteredCollectives, localSelected]);
 
+  // Shared endpoints indexed by parent collective slug. The grouping is cheap
+  // even for thousands of entries (single pass) and saves a per-row lookup
+  // while rendering.
+  const sharedByCollective = useMemo(() => {
+    const map = new Map<string, CollectiveSharedEndpoint[]>();
+    for (const { collective, shared } of availableSharedEndpoints) {
+      const list = map.get(collective.slug);
+      if (list) {
+        list.push(shared);
+      } else {
+        map.set(collective.slug, [shared]);
+      }
+    }
+    return map;
+  }, [availableSharedEndpoints]);
+
   const toggleEndpoint = useCallback((source: ChatSource) => {
     setLocalSelected((previous) => {
       const next = new Set(previous);
@@ -431,6 +572,29 @@ export const AddSourcesModal = memo(function AddSourcesModal({
   const toggleCollective = useCallback((collective: Collective) => {
     const id = `collective:${collective.slug}`;
     const chatSource = collectiveToChatSource(collective);
+    setLocalSelected((previous) => {
+      const next = new Set(previous);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+    setResolvedSourcesMap((previous) => {
+      const next = new Map(previous);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.set(id, chatSource);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleSharedEndpoint = useCallback((shared: CollectiveSharedEndpoint) => {
+    const id = `collective:${shared.collective_slug}/${shared.slug}`;
+    const chatSource = sharedEndpointToChatSource(shared);
     setLocalSelected((previous) => {
       const next = new Set(previous);
       if (next.has(id)) {
@@ -560,16 +724,41 @@ export const AddSourcesModal = memo(function AddSourcesModal({
             </div>
           )
         ) : sortedCollectives.length > 0 ? (
-          sortedCollectives.map((collective) => (
-            <CollectiveItem
-              key={collective.slug}
-              collective={collective}
-              isSelected={localSelected.has(`collective:${collective.slug}`)}
-              onToggle={() => {
-                toggleCollective(collective);
-              }}
-            />
-          ))
+          sortedCollectives.flatMap((collective) => {
+            const sharedEndpoints = sharedByCollective.get(collective.slug) ?? [];
+            const queryLower = debouncedSearchQuery.toLowerCase();
+            // Filter shared endpoints by the same search query so the parent +
+            // children render consistently when the user is searching.
+            const matchingShared = queryLower
+              ? sharedEndpoints.filter(
+                  (shared) =>
+                    shared.name.toLowerCase().includes(queryLower) ||
+                    shared.slug.toLowerCase().includes(queryLower) ||
+                    shared.description.toLowerCase().includes(queryLower)
+                )
+              : sharedEndpoints;
+            return [
+              <CollectiveItem
+                key={collective.slug}
+                collective={collective}
+                isSelected={localSelected.has(`collective:${collective.slug}`)}
+                onToggle={() => {
+                  toggleCollective(collective);
+                }}
+              />,
+              ...matchingShared.map((shared) => (
+                <SharedEndpointItem
+                  key={`${collective.slug}/${shared.slug}`}
+                  collective={collective}
+                  shared={shared}
+                  isSelected={localSelected.has(`collective:${collective.slug}/${shared.slug}`)}
+                  onToggle={() => {
+                    toggleSharedEndpoint(shared);
+                  }}
+                />
+              ))
+            ];
+          })
         ) : (
           <div className='py-8 text-center'>
             <p className='font-inter text-muted-foreground text-sm'>

--- a/components/frontend/src/components/chat/add-sources-modal.tsx
+++ b/components/frontend/src/components/chat/add-sources-modal.tsx
@@ -498,18 +498,41 @@ export const AddSourcesModal = memo(function AddSourcesModal({
     [availableSources]
   );
 
-  // Collectives filtered locally by search query
+  // Collectives filtered locally by search query. A collective is included
+  // when EITHER the parent fields match OR at least one of its shared
+  // endpoints matches — shared endpoints are first-class selectable items,
+  // so 'health-news' must surface its parent collective even when the
+  // parent name doesn't mention 'health-news'.
   const filteredCollectives = useMemo(() => {
     if (!debouncedSearchQuery.trim()) return availableCollectives;
     const q = debouncedSearchQuery.toLowerCase();
-    return availableCollectives.filter(
-      (c) =>
+    const sharedByParentSlug = new Map<string, CollectiveSharedEndpoint[]>();
+    for (const { collective, shared } of availableSharedEndpoints) {
+      const list = sharedByParentSlug.get(collective.slug);
+      if (list) {
+        list.push(shared);
+      } else {
+        sharedByParentSlug.set(collective.slug, [shared]);
+      }
+    }
+    return availableCollectives.filter((c) => {
+      if (
         c.name.toLowerCase().includes(q) ||
         c.description.toLowerCase().includes(q) ||
         c.slug.toLowerCase().includes(q) ||
         c.tags.some((t) => t.toLowerCase().includes(q))
-    );
-  }, [availableCollectives, debouncedSearchQuery]);
+      ) {
+        return true;
+      }
+      const shared = sharedByParentSlug.get(c.slug) ?? [];
+      return shared.some(
+        (s) =>
+          s.name.toLowerCase().includes(q) ||
+          s.slug.toLowerCase().includes(q) ||
+          s.description.toLowerCase().includes(q)
+      );
+    });
+  }, [availableCollectives, availableSharedEndpoints, debouncedSearchQuery]);
 
   // Sorted endpoints: selected bubble to top
   const sortedSources = useMemo(() => {

--- a/components/frontend/src/components/chat/chat-view.tsx
+++ b/components/frontend/src/components/chat/chat-view.tsx
@@ -30,6 +30,7 @@ import { useChatWorkflow } from '@/hooks/use-chat-workflow';
 import { useCollectives } from '@/hooks/use-collectives';
 import { useDataSources } from '@/hooks/use-data-sources';
 import { useModels } from '@/hooks/use-models';
+import { useSharedEndpointsForCollectives } from '@/hooks/use-shared-endpoints';
 import { useSuggestedSources } from '@/hooks/use-suggested-sources';
 import { useXenditPrecheck } from '@/hooks/use-xendit-precheck';
 import { useContextSelectionStore } from '@/stores/context-selection-store';
@@ -90,6 +91,7 @@ export function ChatView({
   });
   const { sources, sourcesById, isLoading: isLoadingDataSources } = useDataSources();
   const { data: collectives } = useCollectives();
+  const { data: collectiveSharedEndpoints } = useSharedEndpointsForCollectives(collectives ?? []);
   const showSourcesStep = useOnboardingStore((s) => s.showSourcesStep);
   const showQueryInputStep = useOnboardingStore((s) => s.showQueryInputStep);
 
@@ -660,6 +662,7 @@ export function ChatView({
         selectedSourceIds={new Set(contextStore.getSourcesArray().map((s) => s.id))}
         onConfirm={handleSourceModalConfirm}
         availableCollectives={collectives ?? []}
+        availableSharedEndpoints={collectiveSharedEndpoints ?? []}
       />
 
       {/* Onboarding welcome banner */}

--- a/components/frontend/src/components/collectives/shared-endpoints-tab.tsx
+++ b/components/frontend/src/components/collectives/shared-endpoints-tab.tsx
@@ -1,0 +1,651 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import type {
+  Collective,
+  CollectiveMember,
+  CollectiveSharedEndpoint,
+  CollectiveSharedEndpointMember
+} from '@/lib/collectives-api';
+
+import AlertTriangle from 'lucide-react/dist/esm/icons/alert-triangle';
+import Check from 'lucide-react/dist/esm/icons/check';
+import Copy from 'lucide-react/dist/esm/icons/copy';
+import Database from 'lucide-react/dist/esm/icons/database';
+import Pencil from 'lucide-react/dist/esm/icons/pencil';
+import Plus from 'lucide-react/dist/esm/icons/plus';
+import Trash2 from 'lucide-react/dist/esm/icons/trash-2';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { Modal } from '@/components/ui/modal';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  useCreateSharedEndpoint,
+  useDeleteSharedEndpoint,
+  useSharedEndpoints,
+  useUpdateSharedEndpoint
+} from '@/hooks/use-shared-endpoints';
+
+interface SharedEndpointsTabProperties {
+  collective: Collective;
+  /** Currently approved member endpoints — used to populate the picker. */
+  approvedMembers: CollectiveMember[];
+}
+
+/**
+ * Admin tab listing a collective's shared endpoints (named, curated subsets
+ * of approved members) with create / edit / delete affordances.
+ *
+ * When a configured endpoint later leaves the collective the row stays in the
+ * shared endpoint (and is silently dropped from chat fan-out); we surface
+ * that as an "inactive" badge so owners can either re-invite the endpoint
+ * or remove it from the subset.
+ */
+export function SharedEndpointsTab({
+  collective,
+  approvedMembers
+}: Readonly<SharedEndpointsTabProperties>) {
+  const { data: sharedEndpoints, isLoading } = useSharedEndpoints(collective.id);
+  const [modalState, setModalState] = useState<
+    { mode: 'create' } | { mode: 'edit'; shared: CollectiveSharedEndpoint } | null
+  >(null);
+
+  const noMembers = approvedMembers.length === 0;
+
+  return (
+    <div className='space-y-4'>
+      <div className='flex items-center justify-between'>
+        <div>
+          <h2 className='font-rubik text-foreground text-lg font-medium'>Shared Endpoints</h2>
+          <p className='text-muted-foreground text-sm'>
+            Curated subsets of this collective's approved members. Each one is addressable as{' '}
+            <code>{collective.shared_endpoint_path}/&lt;slug&gt;</code>.
+          </p>
+        </div>
+        <Button
+          onClick={() => {
+            setModalState({ mode: 'create' });
+          }}
+          disabled={noMembers}
+          title={
+            noMembers
+              ? 'Approve at least one member endpoint before creating a shared endpoint'
+              : undefined
+          }
+        >
+          <Plus className='mr-2 h-4 w-4' />
+          New shared endpoint
+        </Button>
+      </div>
+
+      {/* Default-all row pinned at the top — not a stored entity, just a
+          shortcut so owners can see and copy the implicit catch-all path. */}
+      <DefaultAllRow collective={collective} approvedMemberCount={approvedMembers.length} />
+
+      <SharedEndpointsList
+        collective={collective}
+        sharedEndpoints={sharedEndpoints ?? []}
+        isLoading={isLoading}
+        noMembers={noMembers}
+        onEdit={(shared) => {
+          setModalState({ mode: 'edit', shared });
+        }}
+      />
+
+      {modalState != null && (
+        <SharedEndpointModal
+          collective={collective}
+          approvedMembers={approvedMembers}
+          mode={modalState.mode}
+          existing={modalState.mode === 'edit' ? modalState.shared : null}
+          onClose={() => {
+            setModalState(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+interface DefaultAllRowProperties {
+  collective: Collective;
+  approvedMemberCount: number;
+}
+
+interface SharedEndpointsListProperties {
+  collective: Collective;
+  sharedEndpoints: CollectiveSharedEndpoint[];
+  isLoading: boolean;
+  noMembers: boolean;
+  onEdit: (shared: CollectiveSharedEndpoint) => void;
+}
+
+/**
+ * Body of the tab: a loading spinner, an empty-state card, or the list of
+ * shared-endpoint rows. Extracted so the parent stays a thin shell and the
+ * nested-ternary lint rule is satisfied.
+ */
+function SharedEndpointsList({
+  collective,
+  sharedEndpoints,
+  isLoading,
+  noMembers,
+  onEdit
+}: Readonly<SharedEndpointsListProperties>) {
+  if (isLoading) {
+    return (
+      <div className='flex justify-center py-12'>
+        <LoadingSpinner />
+      </div>
+    );
+  }
+  if (sharedEndpoints.length === 0) {
+    return (
+      <Card className='text-muted-foreground p-12 text-center text-sm'>
+        {noMembers
+          ? 'Approve at least one data-source endpoint to start creating shared subsets.'
+          : 'No custom shared endpoints yet. Create one to fan out chats to a specific subset of members.'}
+      </Card>
+    );
+  }
+  return (
+    <div className='space-y-3'>
+      {sharedEndpoints.map((shared) => (
+        <SharedEndpointRow
+          key={shared.id}
+          collective={collective}
+          shared={shared}
+          onEdit={() => {
+            onEdit(shared);
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Static row representing the implicit ``collective/<slug>/all`` shortcut.
+ *
+ * This is NOT a database row — the backend short-circuits the ``all`` slug
+ * to "every approved member" and the SDK normalises it away — so the row is
+ * purely informational and has no edit/delete affordances.
+ */
+function DefaultAllRow({ collective, approvedMemberCount }: Readonly<DefaultAllRowProperties>) {
+  return (
+    <Card className='border-border/60 bg-muted/20 p-4'>
+      <div className='flex items-start gap-4'>
+        <div className='bg-primary/10 text-primary mt-0.5 rounded-md p-2'>
+          <Database className='h-5 w-5' />
+        </div>
+        <div className='min-w-0 flex-1'>
+          <div className='flex flex-wrap items-center gap-2'>
+            <p className='font-inter text-foreground font-medium'>All members</p>
+            <Badge variant='secondary'>default</Badge>
+          </div>
+          <p className='text-muted-foreground mt-0.5 text-xs'>
+            Fans out to every approved endpoint in the collective.
+          </p>
+          <CopyPath path={`${collective.shared_endpoint_path}/all`} className='mt-2' />
+        </div>
+        <div className='text-muted-foreground shrink-0 text-right text-xs'>
+          {approvedMemberCount} active
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+interface SharedEndpointRowProperties {
+  collective: Collective;
+  shared: CollectiveSharedEndpoint;
+  onEdit: () => void;
+}
+
+function SharedEndpointRow({ collective, shared, onEdit }: Readonly<SharedEndpointRowProperties>) {
+  const deleteMutation = useDeleteSharedEndpoint();
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const inactiveCount = shared.member_count - shared.active_member_count;
+
+  return (
+    <Card className='p-4'>
+      <div className='flex items-start gap-4'>
+        <div className='bg-primary/10 text-primary mt-0.5 rounded-md p-2'>
+          <Database className='h-5 w-5' />
+        </div>
+        <div className='min-w-0 flex-1'>
+          <div className='flex flex-wrap items-center gap-2'>
+            <p className='font-inter text-foreground font-medium'>{shared.name}</p>
+            {inactiveCount > 0 && (
+              <Badge
+                variant='outline'
+                className='border-amber-500/50 bg-amber-500/10 text-amber-700 dark:text-amber-300'
+              >
+                <AlertTriangle className='mr-1 h-3 w-3' />
+                {inactiveCount} inactive
+              </Badge>
+            )}
+          </div>
+          {shared.description && (
+            <p className='text-muted-foreground mt-0.5 text-xs'>{shared.description}</p>
+          )}
+          <CopyPath path={shared.shared_endpoint_path} className='mt-2' />
+        </div>
+        <div className='flex shrink-0 items-center gap-2 text-right'>
+          <div className='text-muted-foreground text-xs'>
+            <p>
+              <span className='text-foreground font-medium'>{shared.active_member_count}</span> /{' '}
+              {shared.member_count} active
+            </p>
+          </div>
+          <Button size='sm' variant='ghost' onClick={onEdit} title='Edit'>
+            <Pencil className='h-4 w-4' />
+          </Button>
+          <Button
+            size='sm'
+            variant='ghost'
+            onClick={() => {
+              setConfirmDelete(true);
+            }}
+            title='Delete'
+            className='text-muted-foreground hover:text-destructive'
+          >
+            <Trash2 className='h-4 w-4' />
+          </Button>
+        </div>
+      </div>
+
+      {confirmDelete && (
+        <Modal
+          isOpen
+          onClose={() => {
+            setConfirmDelete(false);
+          }}
+          title='Delete shared endpoint?'
+        >
+          <div className='space-y-3 text-sm'>
+            <p>
+              This removes <code>{shared.shared_endpoint_path}</code> as a routing alias. Member
+              endpoints themselves are NOT affected — they remain in the collective.
+            </p>
+            {deleteMutation.isError && (
+              <p className='text-destructive'>
+                {deleteMutation.error instanceof Error
+                  ? deleteMutation.error.message
+                  : 'Failed to delete'}
+              </p>
+            )}
+            <div className='flex justify-end gap-2 pt-2'>
+              <Button
+                variant='outline'
+                onClick={() => {
+                  setConfirmDelete(false);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant='destructive'
+                disabled={deleteMutation.isPending}
+                onClick={() => {
+                  deleteMutation.mutate(
+                    {
+                      collectiveId: collective.id,
+                      sharedSlug: shared.slug,
+                      collectiveSlug: collective.slug
+                    },
+                    {
+                      onSuccess: () => {
+                        setConfirmDelete(false);
+                      }
+                    }
+                  );
+                }}
+              >
+                {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
+              </Button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </Card>
+  );
+}
+
+interface SharedEndpointModalProperties {
+  collective: Collective;
+  approvedMembers: CollectiveMember[];
+  mode: 'create' | 'edit';
+  existing: CollectiveSharedEndpoint | null;
+  onClose: () => void;
+}
+
+/**
+ * Create/edit modal for a shared endpoint.
+ *
+ * Slug is editable on create (with a name-derived preview that locks when the
+ * user edits it) and immutable on edit — renaming the slug would silently
+ * break callers using the public path.
+ */
+function SharedEndpointModal({
+  collective,
+  approvedMembers,
+  mode,
+  existing,
+  onClose
+}: Readonly<SharedEndpointModalProperties>) {
+  const isEdit = mode === 'edit';
+  const [name, setName] = useState(existing?.name ?? '');
+  const [description, setDescription] = useState(existing?.description ?? '');
+  const [slug, setSlug] = useState(existing?.slug ?? '');
+  const [slugLocked, setSlugLocked] = useState(isEdit);
+  const initialIds = useMemo(
+    () =>
+      new Set(
+        (existing?.members ?? [])
+          .filter((member) => member.is_active)
+          .map((member) => member.endpoint_id)
+      ),
+    [existing]
+  );
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<number>>(initialIds);
+
+  const createMutation = useCreateSharedEndpoint();
+  const updateMutation = useUpdateSharedEndpoint();
+
+  // Live-derive the slug from the name until the user types into the slug
+  // field; mirrors the create-collective wizard's behaviour.
+  useEffect(() => {
+    if (isEdit) return;
+    if (slugLocked) return;
+    setSlug(slugify(name));
+  }, [name, isEdit, slugLocked]);
+
+  const inactiveExistingMembers: CollectiveSharedEndpointMember[] = useMemo(
+    () => (existing?.members ?? []).filter((member) => !member.is_active),
+    [existing]
+  );
+
+  const toggleEndpoint = (endpointId: number) => {
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (next.has(endpointId)) {
+        next.delete(endpointId);
+      } else {
+        next.add(endpointId);
+      }
+      return next;
+    });
+  };
+
+  const handleSubmit = () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+    const endpointIds = [...selectedIds];
+    if (isEdit && existing != null) {
+      updateMutation.mutate(
+        {
+          collectiveId: collective.id,
+          sharedSlug: existing.slug,
+          input: {
+            name: trimmedName,
+            description: description.trim(),
+            endpoint_ids: endpointIds
+          }
+        },
+        { onSuccess: onClose }
+      );
+    } else {
+      createMutation.mutate(
+        {
+          collectiveId: collective.id,
+          input: {
+            name: trimmedName,
+            description: description.trim(),
+            slug: slug.trim() || undefined,
+            endpoint_ids: endpointIds
+          }
+        },
+        { onSuccess: onClose }
+      );
+    }
+  };
+
+  const isSubmitting = createMutation.isPending || updateMutation.isPending;
+  const submitError = createMutation.error ?? updateMutation.error;
+  const canSubmit = name.trim().length > 0 && selectedIds.size > 0 && !isSubmitting;
+
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      title={isEdit ? `Edit ${existing?.name ?? 'shared endpoint'}` : 'New shared endpoint'}
+    >
+      <div className='space-y-4'>
+        <div>
+          <Label htmlFor='shared-endpoint-name'>Name</Label>
+          <Input
+            id='shared-endpoint-name'
+            value={name}
+            onChange={(event) => {
+              setName(event.target.value);
+            }}
+            placeholder='Health News'
+            className='mt-1'
+            maxLength={100}
+          />
+        </div>
+
+        <div>
+          <Label htmlFor='shared-endpoint-slug'>Slug</Label>
+          <Input
+            id='shared-endpoint-slug'
+            value={slug}
+            onChange={(event) => {
+              setSlug(event.target.value);
+              setSlugLocked(true);
+            }}
+            disabled={isEdit}
+            placeholder='health-news'
+            className='mt-1 font-mono text-sm'
+            maxLength={63}
+          />
+          <p className='text-muted-foreground mt-1 text-xs'>
+            Public path:{' '}
+            <code>
+              {collective.shared_endpoint_path}/{slug || '<slug>'}
+            </code>
+            {isEdit && ' · slug is immutable after creation'}
+          </p>
+        </div>
+
+        <div>
+          <Label htmlFor='shared-endpoint-description'>Description</Label>
+          <Textarea
+            id='shared-endpoint-description'
+            value={description}
+            onChange={(event) => {
+              setDescription(event.target.value);
+            }}
+            placeholder='One-line description of what this subset covers'
+            className='mt-1'
+            maxLength={500}
+            rows={2}
+          />
+        </div>
+
+        <div>
+          <Label>Endpoints</Label>
+          <p className='text-muted-foreground mt-1 mb-2 text-xs'>
+            Pick which approved member endpoints to include. The shared endpoint fans out only to
+            these at chat time.
+          </p>
+          <div className='border-border max-h-72 overflow-y-auto rounded-md border'>
+            {approvedMembers.length === 0 ? (
+              <p className='text-muted-foreground p-4 text-center text-sm'>
+                No approved members yet.
+              </p>
+            ) : (
+              approvedMembers.map((member) => {
+                const checked = selectedIds.has(member.endpoint_id);
+                return (
+                  <label
+                    key={member.endpoint_id}
+                    className='hover:bg-muted/30 flex cursor-pointer items-start gap-3 border-b px-3 py-2 last:border-b-0'
+                  >
+                    <Checkbox
+                      checked={checked}
+                      onCheckedChange={() => {
+                        toggleEndpoint(member.endpoint_id);
+                      }}
+                      className='mt-0.5'
+                    />
+                    <div className='min-w-0 flex-1'>
+                      <p className='text-sm font-medium'>
+                        {member.endpoint_name ?? `#${member.endpoint_id}`}
+                      </p>
+                      <p className='text-muted-foreground truncate text-xs'>
+                        {member.endpoint_owner_username
+                          ? `@${member.endpoint_owner_username}/`
+                          : ''}
+                        {member.endpoint_slug ?? ''}
+                        {member.endpoint_type ? ` · ${member.endpoint_type}` : ''}
+                      </p>
+                    </div>
+                  </label>
+                );
+              })
+            )}
+          </div>
+          <p className='text-muted-foreground mt-1 text-xs'>
+            {selectedIds.size} of {approvedMembers.length} selected
+          </p>
+        </div>
+
+        {inactiveExistingMembers.length > 0 && (
+          <InactiveMembersNotice members={inactiveExistingMembers} />
+        )}
+
+        {submitError != null && (
+          <p className='text-destructive text-sm'>
+            {submitError instanceof Error ? submitError.message : 'Failed to save'}
+          </p>
+        )}
+
+        <div className='flex justify-end gap-2 pt-2'>
+          <Button variant='outline' onClick={onClose} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button disabled={!canSubmit} onClick={handleSubmit}>
+            {submitLabel(isSubmitting, isEdit)}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+/**
+ * Surfaces configured endpoints that have since left the collective.
+ *
+ * These rows still exist in the shared endpoint but are silently dropped
+ * from chat fan-out. The owner needs to decide whether to re-invite them
+ * or remove them from the selection (saving the modal with them unselected
+ * persists the removal).
+ */
+function InactiveMembersNotice({
+  members
+}: Readonly<{ members: CollectiveSharedEndpointMember[] }>) {
+  return (
+    <Card className='border-amber-500/40 bg-amber-500/5 p-3'>
+      <div className='flex items-start gap-2 text-sm'>
+        <AlertTriangle className='mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400' />
+        <div className='min-w-0 flex-1'>
+          <p className='font-medium'>Some configured endpoints have left the collective.</p>
+          <p className='text-muted-foreground mt-1 text-xs'>
+            They're skipped at fan-out time. Re-invite them in the Members tab or save this modal to
+            remove them from the selection.
+          </p>
+          <ul className='text-muted-foreground mt-2 space-y-0.5 text-xs'>
+            {members.map((member) => (
+              <li key={member.endpoint_id}>
+                <code>
+                  {member.endpoint_owner_username ? `${member.endpoint_owner_username}/` : ''}
+                  {member.endpoint_slug ?? `#${member.endpoint_id}`}
+                </code>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+interface CopyPathProperties {
+  path: string;
+  className?: string;
+}
+
+function CopyPath({ path, className }: Readonly<CopyPathProperties>) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type='button'
+      onClick={() => {
+        void navigator.clipboard.writeText(path).then(() => {
+          setCopied(true);
+          setTimeout(() => {
+            setCopied(false);
+          }, 1500);
+        });
+      }}
+      className={`hover:bg-muted/50 inline-flex items-center gap-2 rounded-md border px-2 py-1 font-mono text-xs ${className ?? ''}`}
+    >
+      <code className='truncate'>{path}</code>
+      {copied ? (
+        <Check className='h-3 w-3 text-emerald-500' />
+      ) : (
+        <Copy className='h-3 w-3 opacity-60' />
+      )}
+    </button>
+  );
+}
+
+/** Submit-button label for the create/edit modal. */
+function submitLabel(isSubmitting: boolean, isEdit: boolean): string {
+  if (isSubmitting) return 'Saving...';
+  return isEdit ? 'Save changes' : 'Create';
+}
+
+/**
+ * Local slugifier for the live name -> slug preview. Mirrors the backend
+ * helper closely enough to be honest; the server is the source of truth and
+ * rejects malformed slugs at create time.
+ *
+ * Walks the string segment-by-segment rather than using a greedy `+`
+ * quantifier so sonarjs/slow-regex doesn't flag it as potentially super-linear.
+ */
+function slugify(value: string): string {
+  const lowered = value.toLowerCase();
+  const segments: string[] = [];
+  let current = '';
+  for (const char of lowered) {
+    if (/^[a-z0-9]$/.test(char)) {
+      current += char;
+    } else if (current) {
+      segments.push(current);
+      current = '';
+    }
+  }
+  if (current) segments.push(current);
+  let slug = segments.join('-');
+  if (slug.length > 63) slug = slug.slice(0, 63);
+  while (slug.endsWith('-')) slug = slug.slice(0, -1);
+  return slug;
+}

--- a/components/frontend/src/hooks/use-shared-endpoints.ts
+++ b/components/frontend/src/hooks/use-shared-endpoints.ts
@@ -1,0 +1,177 @@
+/**
+ * React Query hooks for collective shared endpoints — curated subsets of a
+ * collective's approved members. See `lib/collectives-api.ts` for the wire
+ * contracts and `components/backend/.../collective_service.py` for resolution
+ * semantics (intersection with currently approved members).
+ */
+import { useCallback } from 'react';
+
+import type {
+  Collective,
+  CollectiveSharedEndpoint,
+  CollectiveSharedEndpointCreateInput,
+  CollectiveSharedEndpointUpdateInput
+} from '@/lib/collectives-api';
+
+import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  createSharedEndpoint,
+  deleteSharedEndpoint,
+  getSharedEndpoint,
+  listSharedEndpoints,
+  listSharedEndpointsByCollectiveSlug,
+  updateSharedEndpoint
+} from '@/lib/collectives-api';
+import { collectiveKeys, sharedEndpointKeys } from '@/lib/query-keys';
+
+// =============================================================================
+// Queries
+// =============================================================================
+
+/** List a collective's shared endpoints by parent id. */
+export function useSharedEndpoints(collectiveId: number | undefined) {
+  return useQuery({
+    queryKey: sharedEndpointKeys.byCollective(collectiveId ?? 0),
+    queryFn: () => (collectiveId ? listSharedEndpoints(collectiveId) : []),
+    enabled: Boolean(collectiveId)
+  });
+}
+
+/**
+ * List a collective's shared endpoints by parent slug — useful on the public
+ * detail page where the numeric id isn't always in scope before the
+ * collective resolves.
+ */
+export function useSharedEndpointsByCollectiveSlug(collectiveSlug: string | undefined) {
+  return useQuery({
+    queryKey: sharedEndpointKeys.byCollectiveSlug(collectiveSlug ?? ''),
+    queryFn: () => (collectiveSlug ? listSharedEndpointsByCollectiveSlug(collectiveSlug) : []),
+    enabled: Boolean(collectiveSlug)
+  });
+}
+
+/**
+ * Bulk-load shared endpoints for an array of collectives.
+ *
+ * Fans out one cached query per collective so each result is cached + revalidated
+ * independently (`useSharedEndpoints` consumers also benefit from the cache).
+ * Combines the per-collective results into a flat list of
+ * `{ collective, shared }` pairs convenient for rendering in the chat
+ * add-sources modal.
+ */
+export function useSharedEndpointsForCollectives(collectives: Collective[]) {
+  return useQueries({
+    queries: collectives.map((collective) => ({
+      queryKey: sharedEndpointKeys.byCollective(collective.id),
+      queryFn: () => listSharedEndpoints(collective.id),
+      staleTime: 60_000
+    })),
+    combine: (results) => ({
+      data: results.flatMap((result, index) => {
+        const collective = collectives[index];
+        if (!collective) return [];
+        return (result.data ?? []).map((shared) => ({ collective, shared }));
+      }),
+      isLoading: results.some((result) => result.isLoading)
+    })
+  });
+}
+
+/** Get a single shared endpoint by parent id + own slug. */
+export function useSharedEndpoint(
+  collectiveId: number | undefined,
+  sharedSlug: string | undefined
+) {
+  return useQuery({
+    queryKey: sharedEndpointKeys.detail(collectiveId ?? 0, sharedSlug ?? ''),
+    queryFn: () =>
+      collectiveId && sharedSlug ? getSharedEndpoint(collectiveId, sharedSlug) : null,
+    enabled: Boolean(collectiveId && sharedSlug)
+  });
+}
+
+// =============================================================================
+// Mutations
+// =============================================================================
+
+/**
+ * Invalidator shared across mutations: every CUD operation invalidates the
+ * collective's list view AND the collective's detail (so the sidebar count
+ * stays consistent with the admin tab) AND the by-slug list (the public
+ * detail page reads via slug, not id).
+ */
+function useInvalidateForCollective() {
+  const queryClient = useQueryClient();
+  return useCallback(
+    (collectiveId: number, collectiveSlug?: string) => {
+      void queryClient.invalidateQueries({
+        queryKey: sharedEndpointKeys.byCollective(collectiveId)
+      });
+      if (collectiveSlug) {
+        void queryClient.invalidateQueries({
+          queryKey: sharedEndpointKeys.byCollectiveSlug(collectiveSlug)
+        });
+        void queryClient.invalidateQueries({
+          queryKey: collectiveKeys.detail(collectiveSlug)
+        });
+      }
+    },
+    [queryClient]
+  );
+}
+
+/** Create a shared endpoint. */
+export function useCreateSharedEndpoint() {
+  const invalidate = useInvalidateForCollective();
+  return useMutation({
+    mutationFn: ({
+      collectiveId,
+      input
+    }: {
+      collectiveId: number;
+      input: CollectiveSharedEndpointCreateInput;
+    }) => createSharedEndpoint(collectiveId, input),
+    onSuccess: (data: CollectiveSharedEndpoint) => {
+      invalidate(data.collective_id, data.collective_slug);
+    }
+  });
+}
+
+/** Update a shared endpoint. */
+export function useUpdateSharedEndpoint() {
+  const invalidate = useInvalidateForCollective();
+  return useMutation({
+    mutationFn: ({
+      collectiveId,
+      sharedSlug,
+      input
+    }: {
+      collectiveId: number;
+      sharedSlug: string;
+      input: CollectiveSharedEndpointUpdateInput;
+    }) => updateSharedEndpoint(collectiveId, sharedSlug, input),
+    onSuccess: (data: CollectiveSharedEndpoint) => {
+      invalidate(data.collective_id, data.collective_slug);
+    }
+  });
+}
+
+/** Delete a shared endpoint. */
+export function useDeleteSharedEndpoint() {
+  const invalidate = useInvalidateForCollective();
+  return useMutation({
+    mutationFn: ({
+      collectiveId,
+      sharedSlug
+    }: {
+      collectiveId: number;
+      sharedSlug: string;
+      /** Pass when known so the by-slug + detail caches also invalidate. */
+      collectiveSlug?: string;
+    }) => deleteSharedEndpoint(collectiveId, sharedSlug),
+    onSuccess: (_data, { collectiveId, collectiveSlug }) => {
+      invalidate(collectiveId, collectiveSlug);
+    }
+  });
+}

--- a/components/frontend/src/hooks/use-shared-endpoints.ts
+++ b/components/frontend/src/hooks/use-shared-endpoints.ts
@@ -13,13 +13,14 @@ import type {
   CollectiveSharedEndpointUpdateInput
 } from '@/lib/collectives-api';
 
-import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
   createSharedEndpoint,
   deleteSharedEndpoint,
   getSharedEndpoint,
   listSharedEndpoints,
+  listSharedEndpointsBulk,
   listSharedEndpointsByCollectiveSlug,
   updateSharedEndpoint
 } from '@/lib/collectives-api';
@@ -52,30 +53,31 @@ export function useSharedEndpointsByCollectiveSlug(collectiveSlug: string | unde
 }
 
 /**
- * Bulk-load shared endpoints for an array of collectives.
+ * Bulk-load shared endpoints for an array of collectives in a single request.
  *
- * Fans out one cached query per collective so each result is cached + revalidated
- * independently (`useSharedEndpoints` consumers also benefit from the cache).
- * Combines the per-collective results into a flat list of
- * `{ collective, shared }` pairs convenient for rendering in the chat
- * add-sources modal.
+ * Uses the `/shared-endpoints/bulk` endpoint so the chat-view modal can pay
+ * one round trip regardless of how many collectives the user can see (the
+ * older per-collective fan-out scaled linearly with collective count). The
+ * cache key is derived from the sorted collective ids — the list shape, not
+ * the array reference identity — so re-renders that pass a new array but the
+ * same ids don't refetch.
  */
 export function useSharedEndpointsForCollectives(collectives: Collective[]) {
-  return useQueries({
-    queries: collectives.map((collective) => ({
-      queryKey: sharedEndpointKeys.byCollective(collective.id),
-      queryFn: () => listSharedEndpoints(collective.id),
-      staleTime: 60_000
-    })),
-    combine: (results) => ({
-      data: results.flatMap((result, index) => {
-        const collective = collectives[index];
-        if (!collective) return [];
-        return (result.data ?? []).map((shared) => ({ collective, shared }));
-      }),
-      isLoading: results.some((result) => result.isLoading)
-    })
+  const collectivesBySlug = new Map(collectives.map((c) => [c.slug, c]));
+  const collectivesById = new Map(collectives.map((c) => [c.id, c]));
+  const collectiveIds = collectives.map((c) => c.id).toSorted((a, b) => a - b);
+  const query = useQuery({
+    queryKey: [...sharedEndpointKeys.all, 'bulk', collectiveIds],
+    queryFn: () => listSharedEndpointsBulk(collectiveIds),
+    enabled: collectiveIds.length > 0,
+    staleTime: 60_000
   });
+  const data = (query.data ?? []).flatMap((shared) => {
+    const parent =
+      collectivesById.get(shared.collective_id) ?? collectivesBySlug.get(shared.collective_slug);
+    return parent ? [{ collective: parent, shared }] : [];
+  });
+  return { data, isLoading: query.isLoading };
 }
 
 /** Get a single shared endpoint by parent id + own slug. */
@@ -96,22 +98,19 @@ export function useSharedEndpoint(
 // =============================================================================
 
 /**
- * Invalidator shared across mutations: every CUD operation invalidates the
- * collective's list view AND the collective's detail (so the sidebar count
- * stays consistent with the admin tab) AND the by-slug list (the public
- * detail page reads via slug, not id).
+ * Invalidator shared across mutations: every CUD operation invalidates every
+ * shared-endpoint cache (list-by-id, list-by-slug, AND single-detail) plus
+ * the collective's detail (so the sidebar count stays consistent with the
+ * admin tab). Invalidating ``sharedEndpointKeys.all`` covers the detail key
+ * too — its prefix doesn't share ``byCollective`` / ``byCollectiveSlug`` so
+ * a narrower invalidation would leave ``useSharedEndpoint`` stale.
  */
 function useInvalidateForCollective() {
   const queryClient = useQueryClient();
   return useCallback(
-    (collectiveId: number, collectiveSlug?: string) => {
-      void queryClient.invalidateQueries({
-        queryKey: sharedEndpointKeys.byCollective(collectiveId)
-      });
+    (_collectiveId: number, collectiveSlug?: string) => {
+      void queryClient.invalidateQueries({ queryKey: sharedEndpointKeys.all });
       if (collectiveSlug) {
-        void queryClient.invalidateQueries({
-          queryKey: sharedEndpointKeys.byCollectiveSlug(collectiveSlug)
-        });
         void queryClient.invalidateQueries({
           queryKey: collectiveKeys.detail(collectiveSlug)
         });

--- a/components/frontend/src/lib/collectives-api.ts
+++ b/components/frontend/src/lib/collectives-api.ts
@@ -384,3 +384,144 @@ export function respondToInvitation(
     auth: true
   });
 }
+
+// =============================================================================
+// Shared endpoints — named, curated subsets of a collective's members
+// =============================================================================
+
+/**
+ * One member endpoint inside a shared endpoint, enriched for UI rendering.
+ *
+ * `is_active` is `true` when the endpoint is currently an approved member of
+ * the parent collective; `false` means the endpoint was configured into the
+ * subset but has since left the collective and is silently skipped at
+ * chat-time fan-out. Surface inactive members in the admin UI so owners can
+ * either re-invite them or remove them from the selection.
+ */
+export interface CollectiveSharedEndpointMember {
+  endpoint_id: number;
+  endpoint_name: string | null;
+  endpoint_slug: string | null;
+  endpoint_owner_username: string | null;
+  endpoint_type: string | null;
+  is_active: boolean;
+}
+
+/**
+ * A shared endpoint — named, curated subset of a collective's approved
+ * member endpoints. Resolves at chat-time as `collective/<collective_slug>/<slug>`.
+ */
+export interface CollectiveSharedEndpoint {
+  id: number;
+  collective_id: number;
+  collective_slug: string;
+  name: string;
+  slug: string;
+  /** Derived: `collective/<collective_slug>/<slug>`. Read-only. */
+  shared_endpoint_path: string;
+  description: string;
+  members: CollectiveSharedEndpointMember[];
+  member_count: number;
+  /**
+   * Members that are currently approved in the parent collective and will
+   * participate in chat fan-out — `<= member_count`.
+   */
+  active_member_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Body for creating a shared endpoint. */
+export interface CollectiveSharedEndpointCreateInput {
+  name: string;
+  description?: string;
+  /** Optional — auto-derived from the name when omitted. */
+  slug?: string;
+  /**
+   * Endpoints to include. Must all be currently approved members of the
+   * parent collective; the backend rejects non-members with a 400.
+   */
+  endpoint_ids: number[];
+}
+
+/**
+ * Body for updating a shared endpoint — all fields optional.
+ *
+ * `endpoint_ids` is a *full replacement* when present; omit it to leave the
+ * member set untouched. Slug is immutable.
+ */
+export interface CollectiveSharedEndpointUpdateInput {
+  name?: string;
+  description?: string;
+  endpoint_ids?: number[];
+}
+
+/** List a collective's shared endpoints by parent id. Public-readable. */
+export function listSharedEndpoints(collectiveId: number): Promise<CollectiveSharedEndpoint[]> {
+  return request<CollectiveSharedEndpoint[]>(`/${collectiveId}/shared-endpoints`);
+}
+
+/** List a collective's shared endpoints by parent slug. Public-readable.
+ *
+ * Returns an empty array on 404 so callers can render "no card" identically
+ * whether the parent collective is missing or simply has no subsets.
+ */
+export async function listSharedEndpointsByCollectiveSlug(
+  collectiveSlug: string
+): Promise<CollectiveSharedEndpoint[]> {
+  const response = await fetch(
+    `${BASE}/by-slug/${encodeURIComponent(collectiveSlug)}/shared-endpoints`
+  );
+  if (response.status === 404) return [];
+  if (!response.ok) {
+    throw new Error(
+      await errorMessage(response, `Failed to load shared endpoints (${response.status})`)
+    );
+  }
+  return (await response.json()) as CollectiveSharedEndpoint[];
+}
+
+/** Get one shared endpoint by parent id + own slug. Public-readable. */
+export function getSharedEndpoint(
+  collectiveId: number,
+  sharedSlug: string
+): Promise<CollectiveSharedEndpoint> {
+  return request<CollectiveSharedEndpoint>(
+    `/${collectiveId}/shared-endpoints/${encodeURIComponent(sharedSlug)}`
+  );
+}
+
+/** Create a shared endpoint under a collective. Collective owner only. */
+export function createSharedEndpoint(
+  collectiveId: number,
+  input: CollectiveSharedEndpointCreateInput
+): Promise<CollectiveSharedEndpoint> {
+  return request<CollectiveSharedEndpoint>(`/${collectiveId}/shared-endpoints`, {
+    method: 'POST',
+    body: input,
+    auth: true
+  });
+}
+
+/** Update a shared endpoint. Collective owner only. */
+export function updateSharedEndpoint(
+  collectiveId: number,
+  sharedSlug: string,
+  input: CollectiveSharedEndpointUpdateInput
+): Promise<CollectiveSharedEndpoint> {
+  return request<CollectiveSharedEndpoint>(
+    `/${collectiveId}/shared-endpoints/${encodeURIComponent(sharedSlug)}`,
+    { method: 'PATCH', body: input, auth: true }
+  );
+}
+
+/** Delete a shared endpoint and its member rows. Collective owner only. */
+export async function deleteSharedEndpoint(
+  collectiveId: number,
+  sharedSlug: string
+): Promise<void> {
+  await request<null>(`/${collectiveId}/shared-endpoints/${encodeURIComponent(sharedSlug)}`, {
+    method: 'DELETE',
+    auth: true
+  });
+}

--- a/components/frontend/src/lib/collectives-api.ts
+++ b/components/frontend/src/lib/collectives-api.ts
@@ -461,6 +461,21 @@ export function listSharedEndpoints(collectiveId: number): Promise<CollectiveSha
   return request<CollectiveSharedEndpoint[]>(`/${collectiveId}/shared-endpoints`);
 }
 
+/**
+ * Bulk-list shared endpoints across multiple collectives in one request.
+ *
+ * Replaces the per-collective fan-out that the chat-view modal previously
+ * issued (N collectives → N GETs). Returns an empty list when ``collectiveIds``
+ * is empty so callers don't need to guard before invocation.
+ */
+export function listSharedEndpointsBulk(
+  collectiveIds: readonly number[]
+): Promise<CollectiveSharedEndpoint[]> {
+  if (collectiveIds.length === 0) return Promise.resolve([]);
+  const query = collectiveIds.map((id) => `collective_id=${id}`).join('&');
+  return request<CollectiveSharedEndpoint[]>(`/shared-endpoints/bulk?${query}`);
+}
+
 /** List a collective's shared endpoints by parent slug. Public-readable.
  *
  * Returns an empty array on 404 so callers can render "no card" identically

--- a/components/frontend/src/lib/query-keys.ts
+++ b/components/frontend/src/lib/query-keys.ts
@@ -64,3 +64,13 @@ export const collectiveKeys = {
   byEndpoint: (owner: string, slug: string) =>
     [...collectiveKeys.all, 'byEndpoint', owner, slug] as const
 };
+
+export const sharedEndpointKeys = {
+  all: ['shared-endpoints'] as const,
+  byCollective: (collectiveId: number) =>
+    [...sharedEndpointKeys.all, 'byCollective', collectiveId] as const,
+  byCollectiveSlug: (collectiveSlug: string) =>
+    [...sharedEndpointKeys.all, 'byCollectiveSlug', collectiveSlug] as const,
+  detail: (collectiveId: number, sharedSlug: string) =>
+    [...sharedEndpointKeys.all, 'detail', collectiveId, sharedSlug] as const
+};

--- a/components/frontend/src/pages/collective-admin.tsx
+++ b/components/frontend/src/pages/collective-admin.tsx
@@ -15,6 +15,7 @@ import Users from 'lucide-react/dist/esm/icons/users';
 import X from 'lucide-react/dist/esm/icons/x';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
+import { SharedEndpointsTab } from '@/components/collectives/shared-endpoints-tab';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -38,7 +39,7 @@ import { useEndpointByPath } from '@/hooks/use-endpoint-queries';
 import { isJoinableEndpointType, parseTags } from '@/lib/collectives-api';
 import { formatDate } from '@/lib/date-utils';
 
-type AdminTab = 'members' | 'requests' | 'invitations' | 'settings';
+type AdminTab = 'members' | 'requests' | 'invitations' | 'shared' | 'settings';
 
 /**
  * Collective administration (`/c/:slug/admin`). Owner only — the route is
@@ -106,6 +107,7 @@ function CollectiveAdminContent({ collective }: Readonly<{ collective: Collectiv
     { id: 'members', label: 'Members' },
     { id: 'requests', label: 'Requests', badge: requests.length },
     { id: 'invitations', label: 'Invitations', badge: invitations.length },
+    { id: 'shared', label: 'Shared Endpoints' },
     { id: 'settings', label: 'Settings' }
   ];
 
@@ -337,6 +339,10 @@ function CollectiveAdminContent({ collective }: Readonly<{ collective: Collectiv
             </Card>
           )}
         </div>
+      )}
+
+      {activeTab === 'shared' && (
+        <SharedEndpointsTab collective={collective} approvedMembers={members} />
       )}
 
       {activeTab === 'settings' && <CollectiveSettingsForm collective={collective} />}

--- a/components/frontend/src/pages/collective-detail.tsx
+++ b/components/frontend/src/pages/collective-detail.tsx
@@ -7,6 +7,7 @@ import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left';
 import Check from 'lucide-react/dist/esm/icons/check';
 import Copy from 'lucide-react/dist/esm/icons/copy';
 import Database from 'lucide-react/dist/esm/icons/database';
+import Layers from 'lucide-react/dist/esm/icons/layers';
 import Settings from 'lucide-react/dist/esm/icons/settings';
 import ShieldCheck from 'lucide-react/dist/esm/icons/shield-check';
 import UserPlus from 'lucide-react/dist/esm/icons/user-plus';
@@ -29,6 +30,7 @@ import {
   useRequestJoinMany
 } from '@/hooks/use-collectives';
 import { useMyEndpoints } from '@/hooks/use-endpoint-queries';
+import { useSharedEndpoints } from '@/hooks/use-shared-endpoints';
 import { isJoinableEndpointType } from '@/lib/collectives-api';
 import { getEndpointTypeLabel } from '@/lib/endpoint-utils';
 
@@ -73,9 +75,14 @@ export default function CollectiveDetailPage() {
 
   const { data: collective, isLoading, isError } = useCollectiveBySlug(slug);
   const { data: members } = useCollectiveMembers(collective?.id, 'approved');
+  const { data: sharedEndpoints } = useSharedEndpoints(collective?.id);
 
   const [showJoinModal, setShowJoinModal] = useState(false);
-  const [cardTab, setCardTab] = useState<'endpoints' | 'members'>('endpoints');
+  // The "shared" tab only appears when the collective has at least one custom
+  // subset; the default-all path lives in the sidebar SharedEndpointCard.
+  const sharedEndpointsList = sharedEndpoints ?? [];
+  const showSharedTab = sharedEndpointsList.length > 0;
+  const [cardTab, setCardTab] = useState<'endpoints' | 'members' | 'shared'>('endpoints');
 
   // The collective's "members" are the distinct owners of its endpoints —
   // derived from each approved membership's endpoint_owner_username.
@@ -191,7 +198,9 @@ export default function CollectiveDetailPage() {
             {/* Endpoints & Members */}
             <Card className='p-6'>
               <div className='mb-4 flex gap-4 border-b'>
-                {(['endpoints', 'members'] as const).map((tab) => (
+                {(
+                  ['endpoints', 'members', ...(showSharedTab ? (['shared'] as const) : [])] as const
+                ).map((tab) => (
                   <button
                     key={tab}
                     type='button'
@@ -204,14 +213,16 @@ export default function CollectiveDetailPage() {
                         : 'text-muted-foreground hover:text-foreground border-transparent'
                     }`}
                   >
-                    {tab === 'endpoints' ? (
-                      <Database className='h-4 w-4' />
-                    ) : (
-                      <Users className='h-4 w-4' />
-                    )}
-                    {tab}
+                    <TabIcon tab={tab} />
+                    {tab === 'shared' ? 'shared endpoints' : tab}
                     <span className='text-muted-foreground text-xs font-normal'>
-                      ({tab === 'endpoints' ? approvedMembers.length : owners.length})
+                      (
+                      {tabCount(tab, {
+                        endpoints: approvedMembers.length,
+                        members: owners.length,
+                        shared: sharedEndpointsList.length
+                      })}
+                      )
                     </span>
                   </button>
                 ))}
@@ -312,6 +323,34 @@ export default function CollectiveDetailPage() {
                       No members yet.
                     </p>
                   )}
+                </div>
+              )}
+
+              {/* Shared endpoints tab — curated subsets of approved members.
+                  Each row shows the public path so visitors can copy and use
+                  it in chat directly. */}
+              {cardTab === 'shared' && (
+                <div>
+                  <div className='max-h-[22rem] space-y-3 overflow-y-auto pr-1'>
+                    {sharedEndpointsList.map((shared) => (
+                      <Card key={shared.id} className='hover:border-primary/30 p-3 transition-all'>
+                        <div className='flex items-start justify-between gap-3'>
+                          <div className='min-w-0 flex-1'>
+                            <h4 className='truncate text-sm font-medium'>{shared.name}</h4>
+                            {shared.description && (
+                              <p className='text-muted-foreground mt-1 line-clamp-2 text-xs'>
+                                {shared.description}
+                              </p>
+                            )}
+                            <SharedPathChip path={shared.shared_endpoint_path} />
+                          </div>
+                          <div className='text-muted-foreground shrink-0 text-right text-xs'>
+                            {shared.active_member_count} active
+                          </div>
+                        </div>
+                      </Card>
+                    ))}
+                  </div>
                 </div>
               )}
             </Card>
@@ -636,5 +675,60 @@ function JoinCollectiveModal({
         </div>
       </div>
     </Modal>
+  );
+}
+
+type DetailCardTab = 'endpoints' | 'members' | 'shared';
+
+/** Icon for the main-column tab strip. Switch-keyed to avoid nested ternaries. */
+function TabIcon({ tab }: Readonly<{ tab: DetailCardTab }>) {
+  switch (tab) {
+    case 'endpoints': {
+      return <Database className='h-4 w-4' />;
+    }
+    case 'members': {
+      return <Users className='h-4 w-4' />;
+    }
+    case 'shared': {
+      return <Layers className='h-4 w-4' />;
+    }
+    default: {
+      return null;
+    }
+  }
+}
+
+/** Count badge for the main-column tab strip. */
+function tabCount(tab: DetailCardTab, counts: Record<DetailCardTab, number>): number {
+  return counts[tab];
+}
+
+/**
+ * Inline copy-to-clipboard chip for a shared-endpoint path.
+ *
+ * Smaller and less ceremonial than the sidebar `SharedEndpointCard`; meant
+ * for the per-row "Shared Endpoints" tab where multiple chips need to fit.
+ */
+function SharedPathChip({ path }: Readonly<{ path: string }>) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type='button'
+      onClick={() => {
+        void navigator.clipboard.writeText(path);
+        setCopied(true);
+        setTimeout(() => {
+          setCopied(false);
+        }, 1500);
+      }}
+      className='hover:bg-muted/50 mt-2 inline-flex max-w-full items-center gap-2 rounded-md border px-2 py-1 text-xs'
+    >
+      <code className='truncate font-mono'>{path}</code>
+      {copied ? (
+        <Check className='h-3 w-3 shrink-0 text-emerald-500' />
+      ) : (
+        <Copy className='h-3 w-3 shrink-0 opacity-60' />
+      )}
+    </button>
   );
 }

--- a/sdk/typescript/src/resources/chat.ts
+++ b/sdk/typescript/src/resources/chat.ts
@@ -244,8 +244,15 @@ export class ChatResource {
   private static readonly TUNNELING_PREFIX = 'tunneling:';
 
   /**
-   * Expand any `collective/<slug>` entries in the data-sources list into the
-   * individual `owner/slug` paths of the collective's approved members.
+   * Expand any `collective/<slug>` (or `collective/<slug>/<shared-slug>`)
+   * entries in the data-sources list into the individual `owner/slug` paths
+   * of the collective's approved members.
+   *
+   * Path forms recognised:
+   * - `collective/<slug>` → every approved member (backward-compatible)
+   * - `collective/<slug>/all` → equivalent alias of the above
+   * - `collective/<slug>/<shared-slug>` → the named subset, intersected with
+   *   the collective's currently approved members
    *
    * Non-collective entries pass through unchanged. String paths are
    * deduplicated so a regular endpoint that also belongs to a selected
@@ -259,13 +266,32 @@ export class ChatResource {
 
     for (const ds of dataSources) {
       if (typeof ds === 'string' && ds.startsWith(ChatResource.COLLECTIVE_PREFIX)) {
-        const slug = ds.slice(ChatResource.COLLECTIVE_PREFIX.length);
+        const rest = ds.slice(ChatResource.COLLECTIVE_PREFIX.length);
+        const slashAt = rest.indexOf('/');
+        const collectiveSlug = slashAt < 0 ? rest : rest.slice(0, slashAt);
+        // `all` is the implicit alias of "every approved member" and maps to
+        // the same hub route as the no-subset form, so the SDK normalises it
+        // away rather than round-tripping a degenerate identifier.
+        const rawShared = slashAt < 0 ? undefined : rest.slice(slashAt + 1);
+        const sharedSlug = rawShared && rawShared !== 'all' ? rawShared : undefined;
+
+        if (!collectiveSlug) {
+          throw new EndpointResolutionError(
+            `Malformed collective path: ${ds}`,
+            ds
+          );
+        }
+
         let memberPaths: string[];
         try {
-          memberPaths = await this.hub.getCollectiveEndpointPaths(slug);
+          memberPaths = await this.hub.getCollectiveEndpointPaths(
+            collectiveSlug,
+            sharedSlug
+          );
         } catch (error) {
+          const target = sharedSlug ? `${collectiveSlug}/${sharedSlug}` : collectiveSlug;
           throw new EndpointResolutionError(
-            `Failed to resolve collective '${slug}': ${error instanceof Error ? error.message : String(error)}`,
+            `Failed to resolve collective '${target}': ${error instanceof Error ? error.message : String(error)}`,
             ds
           );
         }

--- a/sdk/typescript/src/resources/hub.ts
+++ b/sdk/typescript/src/resources/hub.ts
@@ -326,22 +326,26 @@ export class HubResource {
   }
 
   /**
-   * Get the owner/slug paths of all approved member endpoints in a collective.
+   * Get the owner/slug paths of a collective's approved member endpoints,
+   * optionally narrowed to a single shared-endpoint subset.
    *
-   * Used by the chat resource to expand a `collective/<slug>` data-source
-   * reference into the individual endpoint paths before building the
-   * aggregator request.
+   * Used by the chat resource to expand both `collective/<slug>` and
+   * `collective/<slug>/<shared-slug>` data-source references into the
+   * individual endpoint paths before building the aggregator request.
    *
    * @param slug - The collective slug (e.g. "genomics-research")
-   * @returns Array of "owner/slug" path strings for approved members
-   * @throws {NotFoundError} If the collective does not exist
+   * @param sharedSlug - Optional curated-subset slug. When provided, only the
+   *   intersection of the subset's configured endpoints with the collective's
+   *   currently approved members is returned. Omit for "all approved members".
+   * @returns Array of "owner/slug" path strings
+   * @throws {NotFoundError} If the collective (or shared endpoint) does not exist
    */
-  async getCollectiveEndpointPaths(slug: string): Promise<string[]> {
-    return this.http.get<string[]>(
-      `/api/v1/collectives/by-slug/${encodeURIComponent(slug)}/endpoint-paths`,
-      {},
-      { includeAuth: false }
-    );
+  async getCollectiveEndpointPaths(slug: string, sharedSlug?: string): Promise<string[]> {
+    const base = `/api/v1/collectives/by-slug/${encodeURIComponent(slug)}`;
+    const path = sharedSlug
+      ? `${base}/shared-endpoints/${encodeURIComponent(sharedSlug)}/endpoint-paths`
+      : `${base}/endpoint-paths`;
+    return this.http.get<string[]>(path, {}, { includeAuth: false });
   }
 
   /**

--- a/sdk/typescript/tests/chat.test.ts
+++ b/sdk/typescript/tests/chat.test.ts
@@ -789,6 +789,116 @@ describe('ChatResource', () => {
       );
       expect(collectiveCalls).toHaveLength(1);
     });
+
+    it('should expand collective/<slug>/<shared> to the shared-endpoint route', async () => {
+      const mockAliceDocs = {
+        name: 'Alice Docs',
+        slug: 'docs',
+        type: 'data_source',
+        ownerUsername: 'alice',
+        description: 'Alice data source',
+        version: '1.0.0',
+        stars_count: 0,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        connect: [
+          {
+            type: 'syftai',
+            enabled: true,
+            description: 'Alice DS connection',
+            config: { url: 'http://alice-ds:8080' },
+          },
+        ],
+      };
+
+      mockFetch.mockImplementation(async (url: string) => {
+        if (
+          url.includes(
+            '/api/v1/collectives/by-slug/my-coll/shared-endpoints/health-news/endpoint-paths'
+          )
+        ) {
+          return new Response(JSON.stringify(['alice/docs']), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        if (url.includes('/api/v1/endpoints/public')) {
+          return new Response(JSON.stringify([mockAliceDocs]), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        if (url.includes('/chat') && !url.includes('/stream')) {
+          return new Response(JSON.stringify(mockChatResponse), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return new Response('Not found', { status: 404 });
+      });
+
+      await client.chat.complete({
+        prompt: 'Hello',
+        model: guestModel,
+        dataSources: ['collective/my-coll/health-news'],
+        ...guestOpts,
+      });
+
+      const sharedCall = mockFetch.mock.calls.find((call: unknown[]) =>
+        (call[0] as string).includes(
+          '/api/v1/collectives/by-slug/my-coll/shared-endpoints/health-news/endpoint-paths'
+        )
+      );
+      expect(sharedCall).toBeDefined();
+
+      // The non-shared endpoint-paths route must NOT have been called.
+      const defaultCall = mockFetch.mock.calls.find(
+        (call: unknown[]) =>
+          (call[0] as string).endsWith('/api/v1/collectives/by-slug/my-coll/endpoint-paths')
+      );
+      expect(defaultCall).toBeUndefined();
+    });
+
+    it('should treat collective/<slug>/all as an alias for the no-subset form', async () => {
+      mockFetch.mockImplementation(async (url: string) => {
+        if (
+          url.endsWith('/api/v1/collectives/by-slug/my-coll/endpoint-paths')
+        ) {
+          return new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        if (url.includes('/chat') && !url.includes('/stream')) {
+          return new Response(JSON.stringify(mockChatResponse), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return new Response('Not found', { status: 404 });
+      });
+
+      await client.chat.complete({
+        prompt: 'Hello',
+        model: guestModel,
+        dataSources: ['collective/my-coll/all'],
+        ...guestOpts,
+      });
+
+      // `/all` should NOT generate a shared-endpoints route — it falls back to
+      // the no-subset endpoint-paths route so the backend can short-circuit.
+      const sharedCall = mockFetch.mock.calls.find((call: unknown[]) =>
+        (call[0] as string).includes(
+          '/api/v1/collectives/by-slug/my-coll/shared-endpoints/all/endpoint-paths'
+        )
+      );
+      expect(sharedCall).toBeUndefined();
+
+      const defaultCall = mockFetch.mock.calls.find((call: unknown[]) =>
+        (call[0] as string).endsWith('/api/v1/collectives/by-slug/my-coll/endpoint-paths')
+      );
+      expect(defaultCall).toBeDefined();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Collective owners can define **named subsets** of their approved member endpoints, addressable at `collective/<collective-slug>/<shared-slug>`.
- The implicit `all` slug is hardcoded as an alias of the existing default; `collective/<slug>` continues to resolve to every approved member (backward compatible).
- Resolution intersects the configured set with the collective's currently-approved members at read time, so endpoints that leave silently drop from fan-out and the admin UI surfaces them as **inactive**.

## What's in here

### Backend
- Alembic `018_collective_shared_endpoints` — `collective_shared_endpoints` + `collective_shared_endpoint_members` tables (CASCADE on collective/endpoint deletion, unique slug per collective).
- Models / Pydantic schemas with reserved `all` slug + slugifier helper.
- Repositories with atomic create-with-members + bulk lookup.
- `CollectiveService` extended with full CRUD; the existing `get_collective_endpoint_paths` now delegates through a shared `_collective_approved_paths` helper.
- 6 new routes under `/api/v1/collectives` (3 public `/by-slug/.../shared-endpoints/...`, 3 management `/{collective_id}/shared-endpoints/...`), all declared before the catch-all `/{collective_id}`.
- 13 new tests; **58/58 collective tests pass** (no regressions).

### TypeScript SDK
- `HubResource.getCollectiveEndpointPaths(slug, sharedSlug?)` extended.
- `ChatResource.expandCollectivePaths` parses `collective/X`, `collective/X/all` (alias), and `collective/X/Y` (subset). 2 new tests; **7/7 collective-expansion tests pass**.

### Frontend
- `lib/collectives-api.ts` — `CollectiveSharedEndpoint` types + 6 CRUD wrappers.
- `hooks/use-shared-endpoints.ts` — single, by-slug, bulk (`useQueries`-based), plus create/update/delete mutations with proper cache invalidation.
- `lib/query-keys.ts` — `sharedEndpointKeys`.
- **Admin page** — new "Shared Endpoints" tab with create/edit modal: live slug preview, multi-select picker over approved members, inactive-member warning.
- **Detail page** — new "Shared Endpoints" tab (hidden when empty) with copy chips for the public path.
- **Chat add-sources modal** — collective rows now have indented child rows for each shared endpoint; selection stores the `collective/X/Y` path.

## Test plan
- [x] `pytest tests/test_collectives.py` — 58 passed
- [x] `vitest run tests/chat.test.ts -t "collective"` — 7 passed
- [x] `tsc --noEmit` clean on frontend + SDK
- [x] `ruff check` + `eslint` clean on changed files
- [ ] Manual UAT in the dev environment:
  - [ ] Create a collective, approve 3+ data-source members
  - [ ] Visit `/c/<slug>/admin` → "Shared Endpoints" tab → "New shared endpoint" → name + description + pick 2 of 3 → save
  - [ ] Copy the `collective/<slug>/<shared-slug>` chip from the public detail page
  - [ ] In the chat add-sources modal, expand the collective and pick the named subset
  - [ ] Submit a chat — only the configured 2 endpoints should fan out
  - [ ] Remove one member from the collective → that subset's "inactive" badge appears and chat fan-out drops them
  - [ ] Delete the shared endpoint from the admin tab → row gone, parent collective unaffected

## Notes for reviewers
- `all` is reserved at the schema layer; the slug pattern + the existing collective slug rules apply.
- Slugs are **immutable** post-creation — renaming them would silently break callers using the public path.
- The TS SDK's `collective/X/all` short-circuits to the no-subset route on the wire so the backend can use its existing code path; the `getCollectiveEndpointPaths` route is unchanged for the no-subset case.
- See the design proposal in conversation for the full rationale (intersection semantics, reserved-slug handling, phased rollout).