### PR TITLE
feat(desktop+sdk): close all desktop attachment send/receive gaps

### DIFF
--- a/cli/internal/cmd/agent_attachments.go
+++ b/cli/internal/cmd/agent_attachments.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/openmined/syfthub/sdk/golang/agenttypes"
+	"github.com/openmined/syfthub/sdk/golang/syfthubapi"
 	"github.com/openmined/syfthub/sdk/golang/syfthubapi/transport"
 )
 
@@ -38,14 +39,14 @@ func uploadAgentAttachment(ctx context.Context, session *transport.AgentClientSe
 		mimeType = "application/octet-stream"
 	}
 
-	fileID, err := session.SendAttachment(ctx, f, transport.AttachmentOpts{
+	info, err := session.SendAttachment(ctx, f, transport.AttachmentOpts{
 		Name: name,
 		MIME: mimeType,
 	})
 	if err != nil {
 		return err
 	}
-	fmt.Printf("📎 attached %s (%d bytes) → %s\n", name, st.Size(), fileID)
+	fmt.Printf("📎 attached %s (%d bytes) → %s\n", name, st.Size(), info.FileID)
 	return nil
 }
 
@@ -89,8 +90,9 @@ func saveAgentAttachment(session *transport.AgentClientSession, e *agenttypes.At
 	case "object_store":
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
+		info := syfthubapi.AttachmentInfoFromEvent(e)
 		var buf bytes.Buffer
-		if err := session.DownloadAttachment(ctx, e.FileID, &buf); err != nil {
+		if err := session.DownloadAttachment(ctx, info, &buf); err != nil {
 			return fmt.Errorf("download: %w", err)
 		}
 		body = buf.Bytes()

--- a/cli/internal/cmd/ls.go
+++ b/cli/internal/cmd/ls.go
@@ -27,6 +27,7 @@ var lsCmd = &cobra.Command{
 Usage modes:
 
 - syft ls           : List all active users with endpoint counts
+- syft ls agents    : List all public agent endpoints on the network
 - syft ls <user>    : List endpoints for a specific user
 - syft ls user/ep   : Show details/README for a specific endpoint`,
 	Args:              cobra.MaximumNArgs(1),
@@ -61,6 +62,9 @@ func runLs(cmd *cobra.Command, args []string) error {
 	if target == "" {
 		// Mode 1: List all users
 		return listUsers(ctx, client)
+	} else if target == "agents" {
+		// Mode 4: List all public agents on the network
+		return listNetworkAgents(ctx, client)
 	} else if strings.Contains(target, "/") {
 		// Mode 3: Show endpoint details
 		return showEndpoint(ctx, client, target)
@@ -68,6 +72,68 @@ func runLs(cmd *cobra.Command, args []string) error {
 		// Mode 2: List user's endpoints
 		return listUserEndpoints(ctx, client, target)
 	}
+}
+
+// listNetworkAgents browses the SyftHub network for all public agent
+// endpoints and renders them, mirroring the desktop ListNetworkAgents flow
+// (syfthub-desktop/app.go:1066-1097).
+func listNetworkAgents(ctx context.Context, client *syfthub.Client) error {
+	endpoints, err := client.Hub.Browse(ctx).All(ctx)
+	if err != nil {
+		return output.ReplyError(lsJSONOutput, "Failed to browse network: %v", err)
+	}
+
+	// Filter to agent endpoints, capped by --limit/-n.
+	agents := make([]output.EndpointInfo, 0)
+	for _, ep := range endpoints {
+		if ep.Type != syfthub.EndpointTypeAgent {
+			continue
+		}
+		// Prefix slug with owner so cross-network listings remain unambiguous
+		// in both the grid and table renderers (which don't include an owner
+		// column).
+		displaySlug := ep.Slug
+		if ep.OwnerUsername != "" {
+			displaySlug = ep.OwnerUsername + "/" + ep.Slug
+		}
+		agents = append(agents, output.EndpointInfo{
+			Name:        ep.Name,
+			Slug:        displaySlug,
+			Type:        string(ep.Type),
+			Version:     ep.Version,
+			Stars:       ep.StarsCount,
+			Description: ep.Description,
+			Owner:       ep.OwnerUsername,
+		})
+		if lsLimit > 0 && len(agents) >= lsLimit {
+			break
+		}
+	}
+
+	if lsJSONOutput {
+		result := make([]map[string]any, 0, len(agents))
+		for _, ep := range agents {
+			result = append(result, map[string]any{
+				"owner":       ep.Owner,
+				"slug":        ep.Slug,
+				"name":        ep.Name,
+				"type":        ep.Type,
+				"version":     ep.Version,
+				"stars":       ep.Stars,
+				"description": ep.Description,
+			})
+		}
+		output.JSON(map[string]any{
+			"status": output.StatusSuccess,
+			"agents": result,
+		})
+	} else if lsLongFormat {
+		output.PrintEndpointsTable(agents, "")
+	} else {
+		output.PrintEndpointsGrid(agents, "")
+	}
+
+	return nil
 }
 
 func listUsers(ctx context.Context, client *syfthub.Client) error {

--- a/cli/internal/cmd/node_endpoint.go
+++ b/cli/internal/cmd/node_endpoint.go
@@ -51,7 +51,7 @@ var nodeEndpointCreateCmd = &cobra.Command{
 }
 
 func init() {
-	nodeEndpointCreateCmd.Flags().StringVar(&nodeEPCreateType, "type", "", "Endpoint type: model or data_source (required)")
+	nodeEndpointCreateCmd.Flags().StringVar(&nodeEPCreateType, "type", "", "Endpoint type: model, data_source, or agent (required)")
 	nodeEndpointCreateCmd.Flags().StringVar(&nodeEPCreateDescription, "description", "", "Endpoint description")
 	nodeEndpointCreateCmd.Flags().StringVar(&nodeEPCreateVersion, "version", "", "Endpoint version (default: 1.0.0)")
 	nodeEndpointCreateCmd.Flags().BoolVar(&nodeEPCreateJSON, "json", false, "Output result as JSON")
@@ -261,8 +261,8 @@ func runNodeEndpointEdit(cmd *cobra.Command, args []string) error {
 		updates["description"] = nodeEPEditDescription
 	}
 	if cmd.Flags().Changed("type") {
-		if nodeEPEditType != "model" && nodeEPEditType != "data_source" {
-			output.ReplyErrorSoft(nodeEPEditJSON, "type must be 'model' or 'data_source'")
+		if nodeEPEditType != "model" && nodeEPEditType != "data_source" && nodeEPEditType != "agent" {
+			output.ReplyErrorSoft(nodeEPEditJSON, "type must be 'model', 'data_source', or 'agent'")
 			return nil
 		}
 		updates["type"] = nodeEPEditType

--- a/cli/internal/cmd/node_endpoint_log.go
+++ b/cli/internal/cmd/node_endpoint_log.go
@@ -21,6 +21,8 @@ var (
 	nodeEndpointLogFollow bool
 	nodeEndpointLogLimit  int
 	nodeEndpointLogJSON   bool
+	nodeEndpointLogStatus string
+	nodeEndpointLogOffset int
 )
 
 // jsonlBuf is a reusable 1 MiB scratch buffer for the tail-follow hot path in
@@ -60,7 +62,19 @@ var nodeEndpointLogCmd = &cobra.Command{
 Logs show incoming requests, responses, timing, and policy decisions —
 similar to the Logs tab in syfthub-desktop.
 
-Use -f to follow new log entries in real time.`,
+Use -f to follow new log entries in real time.
+
+Filtering:
+  --status ok|err|denied|all   Only show entries with the given outcome
+                                (default: all). Matches desktop GetLogs.
+  --offset N                   Skip the first N matching entries before
+                                applying --limit (for paging through
+                                results). Ignored in --follow mode.
+
+Examples:
+  syft node endpoint log my-endpoint --status err -n 20
+  syft node endpoint log my-endpoint --status denied --offset 50 -n 50
+  syft node endpoint log my-endpoint -f --status err`,
 	Args: cobra.ExactArgs(1),
 	RunE: runNodeEndpointLog,
 }
@@ -69,6 +83,40 @@ func init() {
 	nodeEndpointLogCmd.Flags().BoolVarP(&nodeEndpointLogFollow, "follow", "f", false, "Follow log output in real time")
 	nodeEndpointLogCmd.Flags().IntVarP(&nodeEndpointLogLimit, "limit", "n", 50, "Number of recent log entries to show")
 	nodeEndpointLogCmd.Flags().BoolVar(&nodeEndpointLogJSON, "json", false, "Output as raw JSON lines")
+	nodeEndpointLogCmd.Flags().StringVar(&nodeEndpointLogStatus, "status", "all", "Filter by outcome: ok, err, denied, all")
+	nodeEndpointLogCmd.Flags().IntVar(&nodeEndpointLogOffset, "offset", 0, "Skip the first N matching entries (ignored with --follow)")
+}
+
+// normalizedLogStatusFilter validates --status and returns the canonical
+// uppercase classification ("OK", "ERR", "DENIED") to match against, or
+// "" when no filter should be applied (all/empty).
+func normalizedLogStatusFilter(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "all":
+		return "", nil
+	case "ok":
+		return "OK", nil
+	case "err", "error":
+		return "ERR", nil
+	case "denied":
+		return "DENIED", nil
+	default:
+		return "", fmt.Errorf("invalid --status %q: must be one of ok, err, denied, all", raw)
+	}
+}
+
+// classifyLogStatus returns "OK", "ERR", or "DENIED" for a log entry, using
+// the same rules as printLogEntry's status banner. Keep these two in sync by
+// only changing the logic here.
+func classifyLogStatus(e *logEntry) string {
+	status := "OK"
+	if e.Response != nil && !e.Response.Success {
+		status = "ERR"
+	}
+	if e.Policy != nil && e.Policy.Evaluated && !e.Policy.Allowed {
+		status = "DENIED"
+	}
+	return status
 }
 
 // logEntry is a lightweight struct for reading request log JSONL files.
@@ -106,6 +154,13 @@ func runNodeEndpointLog(cmd *cobra.Command, args []string) error {
 	slug := args[0]
 	logDir := filepath.Join(nodeconfig.LogsDir, slug)
 
+	if _, err := normalizedLogStatusFilter(nodeEndpointLogStatus); err != nil {
+		return err
+	}
+	if nodeEndpointLogOffset < 0 {
+		return fmt.Errorf("invalid --offset %d: must be >= 0", nodeEndpointLogOffset)
+	}
+
 	if _, err := os.Stat(logDir); os.IsNotExist(err) {
 		if nodeEndpointLogJSON {
 			output.JSON(map[string]any{
@@ -127,6 +182,11 @@ func runNodeEndpointLog(cmd *cobra.Command, args []string) error {
 }
 
 func showRecentLogs(logDir, slug string) error {
+	statusFilter, err := normalizedLogStatusFilter(nodeEndpointLogStatus)
+	if err != nil {
+		return err
+	}
+
 	// Read all JSONL files, sorted by date descending
 	files, err := getLogFiles(logDir)
 	if err != nil {
@@ -146,7 +206,12 @@ func showRecentLogs(logDir, slug string) error {
 		return nil
 	}
 
-	// Collect entries from files (most recent first)
+	// Collect entries from files (most recent first). When filtering or
+	// paging, we cannot early-exit on len(entries) >= limit since the
+	// per-file batch may not yet contain enough matching entries — read
+	// across all files in that case.
+	needed := nodeEndpointLogOffset + nodeEndpointLogLimit
+	filtering := statusFilter != "" || nodeEndpointLogOffset > 0
 	var entries []logEntry
 	for _, file := range files {
 		fileEntries, err := readLogFile(filepath.Join(logDir, file))
@@ -154,9 +219,26 @@ func showRecentLogs(logDir, slug string) error {
 			continue
 		}
 		entries = append(entries, fileEntries...)
-		if len(entries) >= nodeEndpointLogLimit {
+		if !filtering && len(entries) >= nodeEndpointLogLimit {
 			break
 		}
+		if filtering && len(entries) >= needed*4 && needed > 0 {
+			// Heuristic stop: we've read 4x the needed window across
+			// files; further reads are unlikely to surface relevant
+			// older matches given timestamp-desc sort below.
+			break
+		}
+	}
+
+	// Apply status filter
+	if statusFilter != "" {
+		filtered := entries[:0]
+		for i := range entries {
+			if classifyLogStatus(&entries[i]) == statusFilter {
+				filtered = append(filtered, entries[i])
+			}
+		}
+		entries = filtered
 	}
 
 	// Sort by timestamp descending
@@ -164,7 +246,14 @@ func showRecentLogs(logDir, slug string) error {
 		return entries[i].Timestamp.After(entries[j].Timestamp)
 	})
 
-	// Trim to limit
+	// Apply --offset, then trim to --limit
+	if nodeEndpointLogOffset > 0 {
+		if nodeEndpointLogOffset >= len(entries) {
+			entries = nil
+		} else {
+			entries = entries[nodeEndpointLogOffset:]
+		}
+	}
 	if len(entries) > nodeEndpointLogLimit {
 		entries = entries[:nodeEndpointLogLimit]
 	}
@@ -193,9 +282,20 @@ func showRecentLogs(logDir, slug string) error {
 }
 
 func followEndpointLogs(logDir, slug string) error {
+	statusFilter, err := normalizedLogStatusFilter(nodeEndpointLogStatus)
+	if err != nil {
+		return err
+	}
+	if nodeEndpointLogOffset > 0 {
+		fmt.Fprintf(os.Stderr, "warning: --offset is ignored in --follow mode\n")
+	}
+
 	fmt.Printf("Following logs for '%s' (Ctrl+C to stop)...\n\n", slug)
 
 	emit := func(line []byte, entry *logEntry) {
+		if statusFilter != "" && classifyLogStatus(entry) != statusFilter {
+			return
+		}
 		if nodeEndpointLogJSON {
 			fmt.Println(string(line))
 		} else {
@@ -258,13 +358,7 @@ func followEndpointLogs(logDir, slug string) error {
 func printLogEntry(e *logEntry) {
 	ts := e.Timestamp.Local().Format("2006-01-02 15:04:05")
 
-	status := "OK"
-	if e.Response != nil && !e.Response.Success {
-		status = "ERR"
-	}
-	if e.Policy != nil && e.Policy.Evaluated && !e.Policy.Allowed {
-		status = "DENIED"
-	}
+	status := classifyLogStatus(e)
 
 	user := "-"
 	if e.User != nil && e.User.Username != "" {

--- a/cli/internal/cmd/query.go
+++ b/cli/internal/cmd/query.go
@@ -178,9 +178,24 @@ func queryStream(ctx context.Context, client *syfthub.Client, target, prompt, ag
 					fmt.Println()
 				}
 
+			case *syfthub.RerankingStartEvent:
+				if queryVerbose {
+					output.Dim.Printf("Reranking %d documents...\n", e.Documents)
+				}
+
+			case *syfthub.RerankingCompleteEvent:
+				if queryVerbose {
+					output.Dim.Printf("Reranked in %dms\n", e.TimeMs)
+				}
+
 			case *syfthub.GenerationStartEvent:
 				if queryVerbose {
 					output.Dim.Println("Generating response...")
+				}
+
+			case *syfthub.GenerationHeartbeatEvent:
+				if queryVerbose {
+					output.Dim.Printf("Still generating (%dms elapsed)\n", e.ElapsedMs)
 				}
 
 			case *syfthub.TokenEvent:

--- a/cli/internal/completion/completion.go
+++ b/cli/internal/completion/completion.go
@@ -156,6 +156,12 @@ func CompleteLsTarget(cmd *cobra.Command, args []string, toComplete string) ([]s
 			}
 		}
 	} else {
+		// Suggest the "agents" pseudo-target for browsing public agents on
+		// the network.
+		if strings.HasPrefix("agents", strings.ToLower(toComplete)) {
+			completions = append(completions, "agents\tList all public agents on the network")
+		}
+
 		// User is typing a username
 		seenUsers := make(map[string]int)
 		for _, ep := range endpoints {

--- a/sdk/golang/agenttypes/agenttypes.go
+++ b/sdk/golang/agenttypes/agenttypes.go
@@ -44,6 +44,13 @@ type ToolCall struct {
 
 	// Description is a human-readable description of what the tool will do.
 	Description string `json:"description,omitempty"`
+
+	// Display is an optional renderer hint. Consumers SHOULD route the tool
+	// call to a category-specific UI when set (e.g. "terminal" for shell-style
+	// output, "code" for file read/write, "diff" for edits, "web" for fetches).
+	// When omitted, the consumer falls back to a generic renderer; recognised
+	// tool names may still upgrade to a richer view via a name-based lookup.
+	Display string `json:"display,omitempty"`
 }
 
 // ToolResult represents the result of a tool execution.

--- a/sdk/golang/agenttypes/events.go
+++ b/sdk/golang/agenttypes/events.go
@@ -162,6 +162,17 @@ type AttachmentEvent struct {
 
 func (e *AttachmentEvent) EventType() string { return "agent.attachment" }
 
+// UserAttachmentEvent is emitted by the host after it has successfully
+// received and materialized a client-staged attachment. It is the
+// accept-ack for a prior agent_user_attachment message and lets the
+// client mark the staged chip as delivered.
+type UserAttachmentEvent struct {
+	FileID    string `json:"file_id"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
+func (e *UserAttachmentEvent) EventType() string { return "user.attachment" }
+
 // Bytes returns the decoded plaintext for an inline-tier attachment. For
 // object-store-tier attachments it returns an error.
 func (e *AttachmentEvent) Bytes() ([]byte, error) {
@@ -227,6 +238,10 @@ func ParseAgentEvent(eventType string, payload json.RawMessage) (AgentEvent, err
 		event = &e
 	case "agent.attachment":
 		var e AttachmentEvent
+		err = json.Unmarshal(payload, &e)
+		event = &e
+	case "user.attachment":
+		var e UserAttachmentEvent
 		err = json.Unmarshal(payload, &e)
 		event = &e
 	default:

--- a/sdk/golang/agenttypes/events.go
+++ b/sdk/golang/agenttypes/events.go
@@ -156,6 +156,7 @@ type AttachmentEvent struct {
 	ObjectBucket string         `json:"object_bucket,omitempty"`
 	ObjectKey    string         `json:"object_key,omitempty"`
 	ChunkSize    int            `json:"chunk_size,omitempty"`
+	BaseNonceB64 string         `json:"base_nonce,omitempty"`
 	WrappedKey   map[string]any `json:"wrapped_key,omitempty"`
 }
 

--- a/sdk/golang/syfthubapi/attachments.go
+++ b/sdk/golang/syfthubapi/attachments.go
@@ -39,6 +39,12 @@ const (
 // canonical definition in the dependency-free agenttypes package.
 const InlineMaxBytes = agenttypes.InlineAttachmentMaxBytes
 
+// MaxAttachmentBytes is the absolute hard cap on a single attachment's
+// plaintext size, regardless of transport. Beyond this, both client and
+// host SHOULD refuse the transfer before reading the file. 2 GiB is the
+// generous upper bound — most agents will reject far smaller payloads.
+const MaxAttachmentBytes int64 = 2 << 30
+
 // AttachmentCapability is the capabilities[] string clients/hosts declare in
 // session.start to opt into the attachments protocol. It re-exports the
 // canonical definition in the dependency-free agenttypes package.
@@ -123,6 +129,44 @@ func AttachmentInfoFromRaw(data json.RawMessage) (*AttachmentInfo, error) {
 		return nil, err
 	}
 	return &info, nil
+}
+
+// AttachmentInfoFromEvent converts an agenttypes.AttachmentEvent (the
+// dependency-free wire form delivered with agent.attachment events) into
+// the typed AttachmentInfo required by the downloader. The reverse direction
+// (AttachmentInfo → AttachmentEvent) is implicit: emitAttachmentEvent marshals
+// an AttachmentInfo to JSON which agenttypes decodes back into AttachmentEvent.
+func AttachmentInfoFromEvent(e *agenttypes.AttachmentEvent) AttachmentInfo {
+	info := AttachmentInfo{
+		FileID:          e.FileID,
+		Name:            e.Name,
+		MIME:            e.MIME,
+		SizeBytes:       e.SizeBytes,
+		PlaintextSHA256: e.PlaintextSHA256,
+		Transport:       AttachmentTransport(e.Transport),
+		InlineDataB64:   e.InlineDataB64,
+		ObjectBucket:    e.ObjectBucket,
+		ObjectKey:       e.ObjectKey,
+		ChunkSize:       e.ChunkSize,
+		BaseNonceB64:    e.BaseNonceB64,
+	}
+	if e.WrappedKey != nil {
+		wk := &WrappedKey{}
+		if s, ok := e.WrappedKey["algorithm"].(string); ok {
+			wk.Algorithm = s
+		}
+		if s, ok := e.WrappedKey["ciphertext"].(string); ok {
+			wk.Ciphertext = s
+		}
+		if s, ok := e.WrappedKey["nonce"].(string); ok {
+			wk.Nonce = s
+		}
+		if s, ok := e.WrappedKey["info"].(string); ok {
+			wk.Info = s
+		}
+		info.WrappedKey = wk
+	}
+	return info
 }
 
 // AgentUserAttachmentPayload is the decrypted payload of an agent_user_attachment

--- a/sdk/golang/syfthubapi/containermode/runner/session_loop.py
+++ b/sdk/golang/syfthubapi/containermode/runner/session_loop.py
@@ -81,17 +81,28 @@ class AgentSession:
     def send_tool_call(self, tool_name: str, arguments: dict,
                        tool_call_id: Optional[str] = None,
                        description: str = "",
-                       requires_confirmation: bool = False) -> str:
+                       requires_confirmation: bool = False,
+                       display: str = "") -> str:
+        """Emit an agent.tool_call event.
+
+        `display` is an optional renderer hint (e.g. "terminal", "code",
+        "diff", "web"). When set, the UI routes the call to a category-
+        specific component. Omitting it falls back to a name-based lookup
+        or the generic collapsible renderer. See agenttypes.ToolCall.Display.
+        """
         if tool_call_id is None:
             self._tc_counter += 1
             tool_call_id = f"tc-{self._tc_counter}"
-        self._emit("agent.tool_call", {
+        payload = {
             "tool_call_id": tool_call_id,
             "tool_name": tool_name,
             "arguments": arguments,
             "description": description,
             "requires_confirmation": requires_confirmation,
-        })
+        }
+        if display:
+            payload["display"] = display
+        self._emit("agent.tool_call", payload)
         return tool_call_id
 
     def send_tool_result(self, tool_call_id: str, status: str = "success",

--- a/sdk/golang/syfthubapi/filemode/agent_executor.go
+++ b/sdk/golang/syfthubapi/filemode/agent_executor.go
@@ -121,18 +121,28 @@ class AgentSession:
         self._emit("agent.status", {"status": status, "detail": detail})
 
     def send_tool_call(self, tool_name, arguments, tool_call_id=None,
-                       description="", requires_confirmation=False):
-        """Send a tool call event."""
+                       description="", requires_confirmation=False,
+                       display=""):
+        """Send a tool call event.
+
+        display is an optional renderer hint (e.g. "terminal", "code",
+        "diff", "web") for the chat UI. When omitted the consumer falls
+        back to a name-based lookup or the generic renderer. See
+        agenttypes.ToolCall.Display for the wire-level contract.
+        """
         if tool_call_id is None:
             self._tc_counter += 1
             tool_call_id = f"tc-{self._tc_counter}"
-        self._emit("agent.tool_call", {
+        payload = {
             "tool_call_id": tool_call_id,
             "tool_name": tool_name,
             "arguments": arguments,
             "description": description,
             "requires_confirmation": requires_confirmation,
-        })
+        }
+        if display:
+            payload["display"] = display
+        self._emit("agent.tool_call", payload)
 
     def send_tool_result(self, tool_call_id, status="success",
                          result=None, error=None, duration_ms=0):

--- a/sdk/golang/syfthubapi/session_manager.go
+++ b/sdk/golang/syfthubapi/session_manager.go
@@ -101,11 +101,13 @@ type AgentSessionStartPayload struct {
 	// AttachmentCapability AND the endpoint has accepts_attachments=true.
 	Capabilities []string `json:"capabilities,omitempty"`
 
-	// SessionAttachmentKey is the base64-encoded 32-byte AES key the
-	// aggregator generated for this session. HOST + aggregator both wrap
-	// per-file content keys with KEKs derived from this key (HKDF info =
-	// "syfthub-attachment-v1" || file_id). Only meaningful when the
-	// "attachments" capability is present.
+	// SessionAttachmentKey is the base64-encoded 32-byte AES key minted by
+	// the client and shared with the host in session_start. Both peers
+	// derive per-file KEKs from it (HKDF info = "syfthub-attachment-v1" ||
+	// file_id) to wrap each attachment's content key. Only meaningful when
+	// the "attachments" capability is present. On the direct P2P path the
+	// client (AgentDialer) is the issuer; on the legacy aggregator-relayed
+	// path the aggregator minted it.
 	SessionAttachmentKey string `json:"session_attachment_key,omitempty"`
 
 	// CallerPublicKeyB64 is the caller's X25519 identity public key in

--- a/sdk/golang/syfthubapi/transport/agent_attachments.go
+++ b/sdk/golang/syfthubapi/transport/agent_attachments.go
@@ -1,12 +1,19 @@
 // agent_attachments.go adds the client-side attachment surface to an
-// AgentClientSession. The direct peer-to-peer path supports the inline tier
-// (≤ 64 KiB): the bytes ride, encrypted, inside an agent_user_attachment
-// message. Object-store (large-file) attachments over the direct path are a
-// documented follow-up — see syfthub-desktop/docs/p2p-agent-direct-nats-design.md.
+// AgentClientSession. Both transports are supported on the direct P2P path:
+//   - inline (≤ InlineMaxBytes): bytes ride, encrypted, inside an
+//     agent_user_attachment NATS message (single round-trip).
+//   - object_store (> InlineMaxBytes): ciphertext stored in NATS JetStream
+//     Object Store under a per-session bucket; the user-attachment message
+//     carries only metadata + the wrapped per-file key.
+//
+// Object_store transfers require the dialer to have been built with
+// WithAttachmentStore(transport) AND the session opened with the
+// AttachmentCapability so the session AES key has been minted and shared.
 
 package transport
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
@@ -26,18 +33,27 @@ type AttachmentOpts struct {
 	MIME string
 }
 
-// SendAttachmentBytes sends data to the agent as an inline attachment and
-// returns the assigned file_id. Reference it in subsequent text with the URI
+// SendAttachmentBytes is a buffered convenience wrapper around SendAttachment.
+// Prefer SendAttachment with an io.Reader for large payloads to avoid the
+// in-memory copy.
+func (s *AgentClientSession) SendAttachmentBytes(ctx context.Context, data []byte, opts AttachmentOpts) (syfthubapi.AttachmentInfo, error) {
+	return s.SendAttachment(ctx, bytes.NewReader(data), opts)
+}
+
+// SendAttachment streams r to the agent as an attachment and returns the
+// AttachmentInfo describing the transmitted file (file_id, transport, size,
+// plaintext SHA-256). Reference the file in subsequent text with the URI
 // scheme attachment://{file_id}.
 //
-// Payloads larger than the inline limit return an error: object-store
-// attachments are not yet supported on the direct P2P path.
-func (s *AgentClientSession) SendAttachmentBytes(_ context.Context, data []byte, opts AttachmentOpts) (string, error) {
-	if len(data) > syfthubapi.InlineMaxBytes {
-		return "", fmt.Errorf(
-			"attachment is %d bytes; the direct peer-to-peer path supports only inline attachments up to %d bytes",
-			len(data), syfthubapi.InlineMaxBytes)
-	}
+// Behavior:
+//   - Payloads ≤ syfthubapi.InlineMaxBytes ride inline (base64) in the
+//     encrypted user-attachment message — single round-trip, low latency.
+//   - Larger payloads spill to JetStream Object Store via the dialer's
+//     transport. Requires the dialer to have been built with
+//     WithAttachmentStore(transport) AND the session opened with the
+//     AttachmentCapability; otherwise this returns an error and the file
+//     is NOT sent.
+func (s *AgentClientSession) SendAttachment(_ context.Context, r io.Reader, opts AttachmentOpts) (syfthubapi.AttachmentInfo, error) {
 	name := opts.Name
 	if name == "" {
 		name = "attachment.bin"
@@ -46,40 +62,123 @@ func (s *AgentClientSession) SendAttachmentBytes(_ context.Context, data []byte,
 	if mimeType == "" {
 		mimeType = "application/octet-stream"
 	}
-	fileID := "att-" + uuid.NewString()
-	sum := sha256.Sum256(data)
-	info := syfthubapi.AttachmentInfo{
-		FileID:          fileID,
-		Name:            name,
-		MIME:            mimeType,
-		SizeBytes:       int64(len(data)),
-		PlaintextSHA256: hex.EncodeToString(sum[:]),
-		Transport:       syfthubapi.AttachmentTransportInline,
-		InlineDataB64:   base64.StdEncoding.EncodeToString(data),
-	}
-	if err := s.publishRequest(syfthubapi.MsgTypeAgentUserAttachment,
-		syfthubapi.AgentUserAttachmentPayload{SessionID: s.SessionID, Attachment: info}); err != nil {
-		return "", err
-	}
-	return fileID, nil
-}
 
-// SendAttachment reads r (up to the inline limit) and sends it as an inline
-// attachment via SendAttachmentBytes.
-func (s *AgentClientSession) SendAttachment(ctx context.Context, r io.Reader, opts AttachmentOpts) (string, error) {
-	data, err := io.ReadAll(io.LimitReader(r, syfthubapi.InlineMaxBytes+1))
+	// Read up to InlineMaxBytes+1 so we can detect spill-over in a single
+	// pass without re-reading on the small-file path.
+	head, err := io.ReadAll(io.LimitReader(r, int64(syfthubapi.InlineMaxBytes)+1))
 	if err != nil {
-		return "", fmt.Errorf("read attachment: %w", err)
+		return syfthubapi.AttachmentInfo{}, fmt.Errorf("read attachment head: %w", err)
 	}
-	return s.SendAttachmentBytes(ctx, data, opts)
+
+	fileID := "att-" + uuid.NewString()
+
+	if len(head) <= syfthubapi.InlineMaxBytes {
+		sum := sha256.Sum256(head)
+		info := syfthubapi.AttachmentInfo{
+			FileID:          fileID,
+			Name:            name,
+			MIME:            mimeType,
+			SizeBytes:       int64(len(head)),
+			PlaintextSHA256: hex.EncodeToString(sum[:]),
+			Transport:       syfthubapi.AttachmentTransportInline,
+			InlineDataB64:   base64.StdEncoding.EncodeToString(head),
+		}
+		if err := s.publishUserAttachment(info); err != nil {
+			return syfthubapi.AttachmentInfo{}, err
+		}
+		return info, nil
+	}
+
+	// Spill-over: route through Object Store.
+	up, err := s.ensureUploader()
+	if err != nil {
+		return syfthubapi.AttachmentInfo{}, fmt.Errorf("attachment exceeds inline limit (%d bytes): %w",
+			syfthubapi.InlineMaxBytes, err)
+	}
+	combined := io.MultiReader(bytes.NewReader(head), r)
+	info, err := up.Upload(fileID, name, mimeType, -1, combined)
+	if err != nil {
+		return syfthubapi.AttachmentInfo{}, fmt.Errorf("object-store upload: %w", err)
+	}
+	if err := s.publishUserAttachment(info); err != nil {
+		return syfthubapi.AttachmentInfo{}, err
+	}
+	return info, nil
 }
 
-// DownloadAttachment streams an agent-emitted object-store attachment into w.
-// Inline-tier attachments arrive with the agent.attachment event itself and
-// need no download; object-store attachments are not yet supported on the
-// direct P2P path.
-func (s *AgentClientSession) DownloadAttachment(_ context.Context, fileID string, _ io.Writer) error {
-	return fmt.Errorf(
-		"attachment %s is object-store tier; object-store attachments are not yet supported on the direct peer-to-peer path",
-		fileID)
+func (s *AgentClientSession) publishUserAttachment(info syfthubapi.AttachmentInfo) error {
+	return s.publishRequest(syfthubapi.MsgTypeAgentUserAttachment,
+		syfthubapi.AgentUserAttachmentPayload{SessionID: s.SessionID, Attachment: info})
+}
+
+// DownloadAttachment streams the plaintext bytes of an agent-emitted
+// object_store-tier attachment to w. Inline-tier attachments arrive with the
+// agent.attachment event itself and need no download — read
+// AttachmentEvent.Bytes() instead. info is the AttachmentInfo form of the
+// inbound event; convert from agenttypes.AttachmentEvent via
+// syfthubapi.AttachmentInfoFromEvent.
+//
+// On verification failure w MAY have received partial data; the caller is
+// responsible for cleanup. Requires the dialer to have been built with
+// WithAttachmentStore(transport) AND the session opened with the
+// AttachmentCapability.
+func (s *AgentClientSession) DownloadAttachment(_ context.Context, info syfthubapi.AttachmentInfo, w io.Writer) error {
+	if info.Transport != syfthubapi.AttachmentTransportObjectStore {
+		return fmt.Errorf("attachment %s has transport=%q; DownloadAttachment is for object_store only",
+			info.FileID, info.Transport)
+	}
+	dl, err := s.ensureDownloader()
+	if err != nil {
+		return fmt.Errorf("object-store downloader unavailable: %w", err)
+	}
+	osDl, ok := dl.(*ObjectStoreDownloader)
+	if !ok {
+		return fmt.Errorf("downloader %T does not support streaming", dl)
+	}
+	return osDl.DownloadStream(&info, w)
+}
+
+// ensureUploader lazily builds the object-store uploader on first large-file
+// send. Returns an error if the dialer wasn't built with WithAttachmentStore
+// or the session lacks an attachment key.
+func (s *AgentClientSession) ensureUploader() (syfthubapi.AttachmentUploader, error) {
+	s.upOnce.Do(func() {
+		if s.attachmentStore == nil {
+			s.upErr = fmt.Errorf("dialer not configured for object-store attachments — call WithAttachmentStore(transport)")
+			return
+		}
+		if len(s.sessionAESKey) != 32 {
+			s.upErr = fmt.Errorf("session lacks session_attachment_key — open the session with AttachmentCapability")
+			return
+		}
+		up, err := NewObjectStoreUploader(context.Background(), s.sessionAESKey, s.attachmentStore, s.SessionID)
+		if err != nil {
+			s.upErr = err
+			return
+		}
+		s.uploader = up
+	})
+	return s.uploader, s.upErr
+}
+
+// ensureDownloader lazily builds the object-store downloader on first large-
+// file receive. Same prerequisites as ensureUploader.
+func (s *AgentClientSession) ensureDownloader() (syfthubapi.AttachmentDownloader, error) {
+	s.dlOnce.Do(func() {
+		if s.attachmentStore == nil {
+			s.dlErr = fmt.Errorf("dialer not configured for object-store attachments — call WithAttachmentStore(transport)")
+			return
+		}
+		if len(s.sessionAESKey) != 32 {
+			s.dlErr = fmt.Errorf("session lacks session_attachment_key — open the session with AttachmentCapability")
+			return
+		}
+		dl, err := NewObjectStoreDownloader(context.Background(), s.sessionAESKey, s.attachmentStore)
+		if err != nil {
+			s.dlErr = err
+			return
+		}
+		s.downloader = dl
+	})
+	return s.downloader, s.dlErr
 }

--- a/sdk/golang/syfthubapi/transport/agent_attachments.go
+++ b/sdk/golang/syfthubapi/transport/agent_attachments.go
@@ -122,7 +122,10 @@ func (s *AgentClientSession) publishUserAttachment(info syfthubapi.AttachmentInf
 // responsible for cleanup. Requires the dialer to have been built with
 // WithAttachmentStore(transport) AND the session opened with the
 // AttachmentCapability.
-func (s *AgentClientSession) DownloadAttachment(_ context.Context, info syfthubapi.AttachmentInfo, w io.Writer) error {
+//
+// Optional DownloadOption values (e.g. WithProgress) are forwarded to the
+// underlying ObjectStoreDownloader.
+func (s *AgentClientSession) DownloadAttachment(_ context.Context, info syfthubapi.AttachmentInfo, w io.Writer, opts ...DownloadOption) error {
 	if info.Transport != syfthubapi.AttachmentTransportObjectStore {
 		return fmt.Errorf("attachment %s has transport=%q; DownloadAttachment is for object_store only",
 			info.FileID, info.Transport)
@@ -135,7 +138,7 @@ func (s *AgentClientSession) DownloadAttachment(_ context.Context, info syfthuba
 	if !ok {
 		return fmt.Errorf("downloader %T does not support streaming", dl)
 	}
-	return osDl.DownloadStream(&info, w)
+	return osDl.DownloadStream(&info, w, opts...)
 }
 
 // ensureUploader lazily builds the object-store uploader on first large-file

--- a/sdk/golang/syfthubapi/transport/agent_dial.go
+++ b/sdk/golang/syfthubapi/transport/agent_dial.go
@@ -13,9 +13,12 @@ package transport
 import (
 	"context"
 	"crypto/ecdh"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync"
 
 	"github.com/google/uuid"
@@ -35,10 +38,19 @@ type AgentDialer struct {
 	identityKey *ecdh.PrivateKey
 	identityPub string
 	logger      *slog.Logger
+
+	// transport is an optional reference to the same-process NATSTransport,
+	// borrowed for its lazily-initialized JetStream Object Store handle.
+	// Required for object_store-tier attachments on the client side; when
+	// nil, attachment sends/receives larger than InlineMaxBytes fail.
+	// Wire via WithAttachmentStore.
+	transport *NATSTransport
 }
 
 // NewAgentDialer creates a dialer that signs sessions with the given X25519
-// identity key and routes traffic over conn.
+// identity key and routes traffic over conn. The resulting dialer supports
+// only inline-tier attachments. Call WithAttachmentStore to enable
+// object_store-tier (large-file) attachment sends and receives.
 func NewAgentDialer(conn *NATSConn, identityKey *ecdh.PrivateKey, logger *slog.Logger) (*AgentDialer, error) {
 	if conn == nil {
 		return nil, fmt.Errorf("nats connection is required")
@@ -55,6 +67,16 @@ func NewAgentDialer(conn *NATSConn, identityKey *ecdh.PrivateKey, logger *slog.L
 		identityPub: b64urlEncode(identityKey.PublicKey().Bytes()),
 		logger:      logger,
 	}, nil
+}
+
+// WithAttachmentStore attaches a NATSTransport whose lazily-initialized
+// JetStream Object Store handle is borrowed by sessions opened by this dialer
+// for object_store-tier (large-file) attachment transfers. Both peers in a
+// session must share the same Object Store (typically because they speak to
+// the same NATS cluster). Returns the dialer for chaining.
+func (d *AgentDialer) WithAttachmentStore(transport *NATSTransport) *AgentDialer {
+	d.transport = transport
+	return d
 }
 
 // DialParams describes the agent session to open. The caller resolves the
@@ -83,6 +105,15 @@ type DialParams struct {
 	Config *agenttypes.AgentConfig
 	// Capabilities lists optional protocol extensions (e.g. "attachments").
 	Capabilities []string
+
+	// SessionAttachmentKey is the 32-byte raw AES key shared between both
+	// peers for wrapping per-file content keys with HKDF-derived KEKs. When
+	// nil AND Capabilities contains AttachmentCapability, Dial mints a fresh
+	// 32-byte key. The encoded form is sent (base64) in the session_start
+	// payload so the host can construct the matching uploader/downloader.
+	// Provide a non-nil value only for deterministic tests; production
+	// callers should leave this nil.
+	SessionAttachmentKey []byte
 
 	// PaymentCredential is the wire-format mppx credential to ship in the
 	// agent_session_start payload, used when the caller is restarting a
@@ -123,18 +154,51 @@ func (d *AgentDialer) Dial(ctx context.Context, p DialParams) (*AgentClientSessi
 		return nil, fmt.Errorf("derive session cipher: %w", err)
 	}
 
+	// Mint the session attachment key when the caller requested the
+	// "attachments" capability but didn't supply one explicitly. The same
+	// 32-byte key is held client-side (for uploader/downloader construction)
+	// and shipped, base64-encoded, in the session_start payload so the host
+	// can build the matching encryptor.
+	var sessionAESKey []byte
+	if slices.Contains(p.Capabilities, syfthubapi.AttachmentCapability) {
+		sessionAESKey = p.SessionAttachmentKey
+		if sessionAESKey == nil {
+			sessionAESKey = make([]byte, 32)
+			if _, err := rand.Read(sessionAESKey); err != nil {
+				return nil, fmt.Errorf("mint session attachment key: %w", err)
+			}
+		} else if len(sessionAESKey) != 32 {
+			return nil, fmt.Errorf("SessionAttachmentKey must be 32 bytes (got %d)", len(sessionAESKey))
+		}
+	}
+
+	// Acquire the JetStream Object Store handle for object_store-tier
+	// attachments. Failure is non-fatal — the session still works for inline
+	// attachments; only large-file transfers will error at send/receive time.
+	var attachmentStore AttachmentObjectStore
+	if d.transport != nil && sessionAESKey != nil {
+		if store, storeErr := d.transport.getAttachmentObjectStore(); storeErr == nil {
+			attachmentStore = store
+		} else {
+			d.logger.Warn("[AGENT] failed to acquire attachment object store; large-file attachments will fail",
+				"session_id", sessionID, "error", storeErr)
+		}
+	}
+
 	s := &AgentClientSession{
-		SessionID:     sessionID,
-		cipher:        cipher,
-		senderPub:     d.identityPub,
-		conn:          d.conn.Conn(),
-		targetSubject: spaceSubjectPrefix + p.TargetUsername,
-		peerChannel:   p.PeerChannel,
-		logger:        d.logger,
-		inbox:         make(chan *nats.Msg, 256),
-		events:        make(chan agenttypes.AgentEvent, 64),
-		errs:          make(chan error, 8),
-		done:          make(chan struct{}),
+		SessionID:       sessionID,
+		cipher:          cipher,
+		senderPub:       d.identityPub,
+		conn:            d.conn.Conn(),
+		targetSubject:   spaceSubjectPrefix + p.TargetUsername,
+		peerChannel:     p.PeerChannel,
+		logger:          d.logger,
+		inbox:           make(chan *nats.Msg, 256),
+		events:          make(chan agenttypes.AgentEvent, 64),
+		errs:            make(chan error, 8),
+		done:            make(chan struct{}),
+		sessionAESKey:   sessionAESKey,
+		attachmentStore: attachmentStore,
 	}
 
 	// Subscribe to the reply channel before publishing so no early event is
@@ -152,6 +216,9 @@ func (d *AgentDialer) Dial(ctx context.Context, p DialParams) (*AgentClientSessi
 		Messages:          p.Messages,
 		Capabilities:      p.Capabilities,
 		PaymentCredential: p.PaymentCredential,
+	}
+	if sessionAESKey != nil {
+		startPayload.SessionAttachmentKey = base64.StdEncoding.EncodeToString(sessionAESKey)
 	}
 	if p.Config != nil {
 		startPayload.Config = *p.Config
@@ -195,6 +262,22 @@ type AgentClientSession struct {
 
 	closeOnce sync.Once
 	done      chan struct{}
+
+	// Attachment state. sessionAESKey is the per-session 32-byte AES key
+	// also shipped (base64) to the host in session_start; both peers derive
+	// per-file KEKs from it. attachmentStore is the JetStream Object Store
+	// handle borrowed from the dialer's transport (nil when the dialer was
+	// constructed without WithAttachmentStore — in which case object_store
+	// transfers fail). uploader/downloader are lazily built on first
+	// large-file send/receive respectively.
+	sessionAESKey   []byte
+	attachmentStore AttachmentObjectStore
+	upOnce          sync.Once
+	uploader        syfthubapi.AttachmentUploader
+	upErr           error
+	dlOnce          sync.Once
+	downloader      syfthubapi.AttachmentDownloader
+	dlErr           error
 }
 
 // Events returns the channel of typed host events. It is closed when the

--- a/sdk/golang/syfthubapi/transport/agent_dial_attachment_key_test.go
+++ b/sdk/golang/syfthubapi/transport/agent_dial_attachment_key_test.go
@@ -1,0 +1,201 @@
+package transport
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/openmined/syfthub/sdk/golang/syfthubapi"
+)
+
+// TestDialMintsSessionAttachmentKey asserts the client-side AgentDialer mints
+// a 32-byte session_attachment_key whenever AttachmentCapability is requested
+// without an explicit key, retains it on the AgentClientSession, and ships
+// the base64-encoded form inside the encrypted session_start payload that
+// reaches the host's space subject.
+func TestDialMintsSessionAttachmentKey(t *testing.T) {
+	srv := runEmbeddedNATS(t)
+	defer srv.Shutdown()
+	natsURL := srv.ClientURL()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	const hostUser = "hostbob"
+	hostCreds := &syfthubapi.NATSCredentials{URL: natsURL, Subject: spaceSubjectPrefix + hostUser}
+
+	hostConn, err := NewNATSConn(hostCreds, "key-test-host", logger)
+	if err != nil {
+		t.Fatalf("host NATSConn: %v", err)
+	}
+	defer hostConn.Close()
+
+	hostT, err := NewNATSTransport(hostConn, &Config{
+		SpaceURL:        "tunneling:" + hostUser,
+		NATSCredentials: hostCreds,
+		Logger:          logger,
+	})
+	if err != nil {
+		t.Fatalf("NewNATSTransport: %v", err)
+	}
+
+	// Passive observer on the host's space subject — captures the envelope
+	// without running the full bridge handler.
+	var (
+		mu       sync.Mutex
+		captured []byte
+		gotOnce  sync.Once
+		gotCh    = make(chan struct{})
+	)
+	if _, err := hostT.conn.Subscribe(spaceSubjectPrefix+hostUser, func(m *nats.Msg) {
+		mu.Lock()
+		captured = append([]byte(nil), m.Data...)
+		mu.Unlock()
+		gotOnce.Do(func() { close(gotCh) })
+	}); err != nil {
+		t.Fatalf("subscribe space: %v", err)
+	}
+	time.Sleep(150 * time.Millisecond)
+
+	clientKey, err := GenerateX25519Keypair()
+	if err != nil {
+		t.Fatalf("client keypair: %v", err)
+	}
+	clientConn, err := NewNATSConn(&syfthubapi.NATSCredentials{URL: natsURL}, "key-test-client", logger)
+	if err != nil {
+		t.Fatalf("client NATSConn: %v", err)
+	}
+	defer clientConn.Close()
+
+	dialer, err := NewAgentDialer(clientConn, clientKey, logger)
+	if err != nil {
+		t.Fatalf("NewAgentDialer: %v", err)
+	}
+
+	ctx := t.Context()
+	sess, err := dialer.Dial(ctx, DialParams{
+		TargetUsername:   hostUser,
+		HostPublicKeyB64: hostT.PublicKeyB64(),
+		PeerChannel:      "key-test-channel",
+		SatelliteToken:   "fake",
+		Prompt:           "hi",
+		EndpointSlug:     "agent1",
+		Capabilities:     []string{syfthubapi.AttachmentCapability},
+	})
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer sess.Close()
+
+	// 1) Client-side: the session retained a 32-byte key.
+	if got := len(sess.sessionAESKey); got != 32 {
+		t.Fatalf("sess.sessionAESKey length = %d, want 32", got)
+	}
+
+	// 2) Wire: the start envelope must carry the same 32-byte key (base64).
+	select {
+	case <-gotCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not capture session_start envelope on host space subject")
+	}
+	mu.Lock()
+	raw := captured
+	mu.Unlock()
+
+	var env syfthubapi.AgentEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	if env.Type != syfthubapi.MsgTypeAgentSessionStart {
+		t.Fatalf("unexpected envelope type %q", env.Type)
+	}
+
+	// Decrypt with host's identity key + the client's sender pub from the envelope.
+	cipher, err := NewSessionCipher(hostT.privateKey, env.SenderPublicKey, env.SessionID)
+	if err != nil {
+		t.Fatalf("NewSessionCipher (host side): %v", err)
+	}
+	pt, err := cipher.DecryptRequest(env.Nonce, env.EncryptedPayload, env.CorrelationID)
+	if err != nil {
+		t.Fatalf("decrypt session_start payload: %v", err)
+	}
+	var startPayload syfthubapi.AgentSessionStartPayload
+	if err := json.Unmarshal(pt, &startPayload); err != nil {
+		t.Fatalf("unmarshal session_start payload: %v", err)
+	}
+	if startPayload.SessionAttachmentKey == "" {
+		t.Fatalf("dialer did not set SessionAttachmentKey on wire; payload=%+v", startPayload)
+	}
+	wireKey, err := base64.StdEncoding.DecodeString(startPayload.SessionAttachmentKey)
+	if err != nil {
+		t.Fatalf("decode wire session_attachment_key: %v", err)
+	}
+	if len(wireKey) != 32 {
+		t.Fatalf("wire session_attachment_key length = %d, want 32", len(wireKey))
+	}
+	if string(wireKey) != string(sess.sessionAESKey) {
+		t.Fatalf("wire key does not match in-memory session key")
+	}
+}
+
+// TestDialDoesNotMintKeyWithoutAttachmentCapability — when the caller doesn't
+// request the capability, the dialer should NOT mint a key (keeps sessions
+// keyless when attachments aren't needed). Validated by inspecting the
+// AgentClientSession's internal state.
+func TestDialDoesNotMintKeyWithoutAttachmentCapability(t *testing.T) {
+	srv := runEmbeddedNATS(t)
+	defer srv.Shutdown()
+	natsURL := srv.ClientURL()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	const hostUser = "hostcarol"
+	hostCreds := &syfthubapi.NATSCredentials{URL: natsURL, Subject: spaceSubjectPrefix + hostUser}
+	hostConn, err := NewNATSConn(hostCreds, "key-test-host2", logger)
+	if err != nil {
+		t.Fatalf("host NATSConn: %v", err)
+	}
+	defer hostConn.Close()
+	hostT, err := NewNATSTransport(hostConn, &Config{
+		SpaceURL:        "tunneling:" + hostUser,
+		NATSCredentials: hostCreds,
+		Logger:          logger,
+	})
+	if err != nil {
+		t.Fatalf("NewNATSTransport: %v", err)
+	}
+
+	clientKey, err := GenerateX25519Keypair()
+	if err != nil {
+		t.Fatalf("client keypair: %v", err)
+	}
+	clientConn, err := NewNATSConn(&syfthubapi.NATSCredentials{URL: natsURL}, "key-test-client2", logger)
+	if err != nil {
+		t.Fatalf("client NATSConn: %v", err)
+	}
+	defer clientConn.Close()
+
+	dialer, err := NewAgentDialer(clientConn, clientKey, logger)
+	if err != nil {
+		t.Fatalf("NewAgentDialer: %v", err)
+	}
+	sess, err := dialer.Dial(t.Context(), DialParams{
+		TargetUsername:   hostUser,
+		HostPublicKeyB64: hostT.PublicKeyB64(),
+		PeerChannel:      "key-test-channel2",
+		SatelliteToken:   "fake",
+		Prompt:           "hi",
+		EndpointSlug:     "agent1",
+		// no Capabilities
+	})
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer sess.Close()
+
+	if sess.sessionAESKey != nil {
+		t.Fatalf("expected nil sessionAESKey when AttachmentCapability not requested, got %d bytes", len(sess.sessionAESKey))
+	}
+}

--- a/sdk/golang/syfthubapi/transport/attachment_downloader.go
+++ b/sdk/golang/syfthubapi/transport/attachment_downloader.go
@@ -41,6 +41,42 @@ func NewObjectStoreDownloader(
 	}, nil
 }
 
+// DownloadOption customizes a streaming download.
+type DownloadOption func(*downloadOptions)
+
+type downloadOptions struct {
+	progress func(downloaded int64, total int64)
+}
+
+// WithProgress installs a callback fired as plaintext is written to the
+// destination. downloaded is the running plaintext byte count; total is
+// info.SizeBytes (declared, may be 0 if the producer didn't set it).
+// Fires at most once per AttachmentChunkSize boundary so it's safe to use
+// for UI updates without throttling at the call site.
+func WithProgress(cb func(downloaded int64, total int64)) DownloadOption {
+	return func(o *downloadOptions) { o.progress = cb }
+}
+
+// progressWriter is a small wrapper that ticks a progress callback as bytes
+// flow through it.
+type progressWriter struct {
+	w        io.Writer
+	total    int64
+	written  int64
+	progress func(int64, int64)
+}
+
+func (pw *progressWriter) Write(p []byte) (int, error) {
+	n, err := pw.w.Write(p)
+	if n > 0 {
+		pw.written += int64(n)
+		if pw.progress != nil {
+			pw.progress(pw.written, pw.total)
+		}
+	}
+	return n, err
+}
+
 // DownloadStream fetches the object-store ciphertext for info, decrypts it,
 // verifies the declared size and SHA-256, and writes the plaintext to w.
 //
@@ -49,7 +85,9 @@ func NewObjectStoreDownloader(
 // Callers that need atomic on-disk semantics should use DownloadAndMaterialize
 // instead, which buffers in memory and only writes the file after the SHA
 // check passes.
-func (d *ObjectStoreDownloader) DownloadStream(info *syfthubapi.AttachmentInfo, w io.Writer) error {
+//
+// Pass WithProgress to receive per-chunk byte-count callbacks for UI updates.
+func (d *ObjectStoreDownloader) DownloadStream(info *syfthubapi.AttachmentInfo, w io.Writer, opts ...DownloadOption) error {
 	if info.Transport != syfthubapi.AttachmentTransportObjectStore {
 		return fmt.Errorf("downloader called for transport=%q", info.Transport)
 	}
@@ -85,7 +123,16 @@ func (d *ObjectStoreDownloader) DownloadStream(info *syfthubapi.AttachmentInfo, 
 		return fmt.Errorf("object-store get: %w", err)
 	}
 
-	gotSize, gotSHA, err := d.encryptor.DecryptStream(fileKey, baseNonce, info.FileID, info.SizeBytes, &ct, w)
+	var dlOpts downloadOptions
+	for _, o := range opts {
+		o(&dlOpts)
+	}
+	dst := w
+	if dlOpts.progress != nil {
+		dst = &progressWriter{w: w, total: info.SizeBytes, progress: dlOpts.progress}
+	}
+
+	gotSize, gotSHA, err := d.encryptor.DecryptStream(fileKey, baseNonce, info.FileID, info.SizeBytes, &ct, dst)
 	if err != nil {
 		return fmt.Errorf("decrypt stream: %w", err)
 	}

--- a/sdk/golang/syfthubapi/transport/attachment_downloader.go
+++ b/sdk/golang/syfthubapi/transport/attachment_downloader.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -40,14 +41,15 @@ func NewObjectStoreDownloader(
 	}, nil
 }
 
-// DownloadAndMaterialize fetches ciphertext from Object Store, unwraps the
-// per-file key under the session KEK, decrypts the chunked stream, verifies
-// the plaintext SHA, and writes plaintext to a 0600-mode file inside
-// dir. Sets info.LocalPath on success.
-func (d *ObjectStoreDownloader) DownloadAndMaterialize(
-	dir string,
-	info *syfthubapi.AttachmentInfo,
-) error {
+// DownloadStream fetches the object-store ciphertext for info, decrypts it,
+// verifies the declared size and SHA-256, and writes the plaintext to w.
+//
+// On verification failure w MAY have received partial data; the caller is
+// responsible for cleaning up (truncating / removing the file or buffer).
+// Callers that need atomic on-disk semantics should use DownloadAndMaterialize
+// instead, which buffers in memory and only writes the file after the SHA
+// check passes.
+func (d *ObjectStoreDownloader) DownloadStream(info *syfthubapi.AttachmentInfo, w io.Writer) error {
 	if info.Transport != syfthubapi.AttachmentTransportObjectStore {
 		return fmt.Errorf("downloader called for transport=%q", info.Transport)
 	}
@@ -83,8 +85,7 @@ func (d *ObjectStoreDownloader) DownloadAndMaterialize(
 		return fmt.Errorf("object-store get: %w", err)
 	}
 
-	var pt bytes.Buffer
-	gotSize, gotSHA, err := d.encryptor.DecryptStream(fileKey, baseNonce, info.FileID, info.SizeBytes, &ct, &pt)
+	gotSize, gotSHA, err := d.encryptor.DecryptStream(fileKey, baseNonce, info.FileID, info.SizeBytes, &ct, w)
 	if err != nil {
 		return fmt.Errorf("decrypt stream: %w", err)
 	}
@@ -93,6 +94,23 @@ func (d *ObjectStoreDownloader) DownloadAndMaterialize(
 	}
 	if gotSHA != info.PlaintextSHA256 {
 		return fmt.Errorf("sha256 mismatch")
+	}
+	return nil
+}
+
+// DownloadAndMaterialize is the atomic on-disk variant of DownloadStream: it
+// buffers the plaintext in memory, verifies its SHA, and only then writes a
+// 0600-mode file under dir. Sets info.LocalPath on success. Use this when a
+// failed download must leave no partial file behind (the host runner path).
+// For a streaming variant that writes incrementally to an arbitrary io.Writer,
+// use DownloadStream.
+func (d *ObjectStoreDownloader) DownloadAndMaterialize(
+	dir string,
+	info *syfthubapi.AttachmentInfo,
+) error {
+	var pt bytes.Buffer
+	if err := d.DownloadStream(info, &pt); err != nil {
+		return err
 	}
 
 	name := info.FileID

--- a/sdk/golang/syfthubapi/transport/attachment_handshake_test.go
+++ b/sdk/golang/syfthubapi/transport/attachment_handshake_test.go
@@ -5,8 +5,14 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/openmined/syfthub/sdk/golang/agenttypes"
 	syfthubapi "github.com/openmined/syfthub/sdk/golang/syfthubapi"
 )
 
@@ -74,5 +80,168 @@ func TestObjectStoreUploaderBindsToSessionAttachmentKey(t *testing.T) {
 
 	if _, err := aggrEnc.UnwrapFileKey(info.FileID, wrappedCT, wrappedNonce); err != nil {
 		t.Fatalf("aggregator failed to unwrap with the same session key: %v", err)
+	}
+}
+
+// attachmentAckHandler is an AgentSessionHandler that registers a real
+// AgentSession with attachments enabled so the host-side agentNATSBridge can
+// look it up via GetSession and route an inbound user attachment to it.
+type attachmentAckHandler struct {
+	mu       sync.Mutex
+	sessions map[string]*syfthubapi.AgentSession
+}
+
+func newAttachmentAckHandler() *attachmentAckHandler {
+	return &attachmentAckHandler{sessions: make(map[string]*syfthubapi.AgentSession)}
+}
+
+func (h *attachmentAckHandler) StartSession(payload syfthubapi.AgentSessionStartPayload, user *syfthubapi.UserContext) (*syfthubapi.AgentSession, error) {
+	dir, err := os.MkdirTemp("", "syft-attach-ack-*")
+	if err != nil {
+		return nil, err
+	}
+	sess := syfthubapi.NewAgentSession(context.Background(), syfthubapi.AgentSessionParams{
+		ID:            payload.SessionID,
+		Prompt:        payload.Prompt,
+		EndpointSlug:  payload.EndpointSlug,
+		User:          user,
+		Capabilities:  payload.Capabilities,
+		AttachmentDir: dir,
+	})
+	// The handler drains the attachment channel and otherwise blocks until
+	// the test cancels the session — this keeps the session alive long
+	// enough for the bridge to deliver an attachment and emit the ack.
+	sess.RunHandler(func(ctx context.Context, s *syfthubapi.AgentSession) error {
+		ch := s.AttachmentCh()
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-ch:
+				// drain — we only care that the host got far enough to deliver
+			}
+		}
+	})
+	h.mu.Lock()
+	h.sessions[sess.ID] = sess
+	h.mu.Unlock()
+	return sess, nil
+}
+
+func (h *attachmentAckHandler) RouteMessage(syfthubapi.AgentUserMessagePayload) error { return nil }
+func (h *attachmentAckHandler) CancelSession(string) error                            { return nil }
+func (h *attachmentAckHandler) GetSession(id string) (*syfthubapi.AgentSession, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s, ok := h.sessions[id]
+	return s, ok
+}
+
+// TestHandleUserAttachmentEmitsAck spins up the embedded NATS server + the
+// agentNATSBridge, dials a session with the attachments capability, publishes
+// an inline attachment from the client, and asserts that the host emits a
+// user.attachment accept-ack event carrying the original file_id and size.
+func TestHandleUserAttachmentEmitsAck(t *testing.T) {
+	srv := runEmbeddedNATS(t)
+	defer srv.Shutdown()
+	natsURL := srv.ClientURL()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	const hostUser = "hostack"
+	hostCreds := &syfthubapi.NATSCredentials{URL: natsURL, Subject: spaceSubjectPrefix + hostUser}
+
+	hostConn, err := NewNATSConn(hostCreds, "ack-host", logger)
+	if err != nil {
+		t.Fatalf("host NATSConn: %v", err)
+	}
+	defer hostConn.Close()
+
+	hostT, err := NewNATSTransport(hostConn, &Config{
+		SpaceURL:        "tunneling:" + hostUser,
+		NATSCredentials: hostCreds,
+		Logger:          logger,
+	})
+	if err != nil {
+		t.Fatalf("NewNATSTransport: %v", err)
+	}
+	handler := newAttachmentAckHandler()
+	hostT.SetAgentHandler(handler)
+	hostT.SetTokenVerifier(func(_ context.Context, _ string) (*syfthubapi.UserContext, error) {
+		return &syfthubapi.UserContext{Sub: "u1", Username: hostUser, Role: "user"}, nil
+	})
+
+	ctx := t.Context()
+	go func() { _ = hostT.Start(ctx) }()
+	defer func() { _ = hostT.Stop(context.Background()) }()
+
+	// Wait for the host subscription to register on the server before the
+	// client publishes anything.
+	time.Sleep(200 * time.Millisecond)
+
+	clientKey, err := GenerateX25519Keypair()
+	if err != nil {
+		t.Fatalf("client keypair: %v", err)
+	}
+	clientConn, err := NewNATSConn(&syfthubapi.NATSCredentials{URL: natsURL}, "ack-client", logger)
+	if err != nil {
+		t.Fatalf("client NATSConn: %v", err)
+	}
+	defer clientConn.Close()
+
+	dialer, err := NewAgentDialer(clientConn, clientKey, logger)
+	if err != nil {
+		t.Fatalf("NewAgentDialer: %v", err)
+	}
+
+	sess, err := dialer.Dial(ctx, DialParams{
+		TargetUsername:   hostUser,
+		HostPublicKeyB64: hostT.PublicKeyB64(),
+		PeerChannel:      "ack-channel",
+		SatelliteToken:   "fake-satellite-token",
+		Prompt:           "hello host",
+		EndpointSlug:     "agent-ack",
+		Capabilities:     []string{syfthubapi.AttachmentCapability},
+	})
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer sess.Close()
+
+	// Give the host a moment to process session_start and register the
+	// session in the handler map (needed before GetSession can resolve it).
+	time.Sleep(200 * time.Millisecond)
+
+	body := []byte("ack-me-please")
+	info, err := sess.SendAttachmentBytes(ctx, body, AttachmentOpts{Name: "note.txt", MIME: "text/plain"})
+	if err != nil {
+		t.Fatalf("SendAttachmentBytes: %v", err)
+	}
+
+	timeout := time.After(10 * time.Second)
+	var ack *agenttypes.UserAttachmentEvent
+collect:
+	for {
+		select {
+		case ev, ok := <-sess.Events():
+			if !ok {
+				break collect
+			}
+			if e, ok := ev.(*agenttypes.UserAttachmentEvent); ok {
+				ack = e
+				break collect
+			}
+		case <-timeout:
+			t.Fatalf("timed out waiting for user.attachment ack")
+		}
+	}
+
+	if ack == nil {
+		t.Fatal("did not receive user.attachment ack event")
+	}
+	if ack.FileID != info.FileID {
+		t.Errorf("ack file_id mismatch: got %q, want %q", ack.FileID, info.FileID)
+	}
+	if ack.SizeBytes != int64(len(body)) {
+		t.Errorf("ack size_bytes mismatch: got %d, want %d", ack.SizeBytes, len(body))
 	}
 }

--- a/sdk/golang/syfthubapi/transport/nats.go
+++ b/sdk/golang/syfthubapi/transport/nats.go
@@ -137,6 +137,13 @@ func (b *agentNATSBridge) handleUserAttachment(env *syfthubapi.AgentEnvelope, ci
 		b.logger.Warn("[AGENT] attachment channel full, dropping",
 			"session_id", sess.ID, "file_id", info.FileID)
 	}
+
+	// Emit the accept-ack regardless of DeliverAttachment's boolean return —
+	// the file is materialized on disk either way; the boolean only reports
+	// whether the runner-side receive channel had room. Clients use this
+	// event to mark the staged-attachment chip as delivered.
+	b.sendAgentEvent(env.ReplyTo, cipher, env.SessionID, syfthubapi.EventTypeUserAttachment,
+		agenttypes.UserAttachmentEvent{FileID: info.FileID, SizeBytes: info.SizeBytes})
 }
 
 // materializeInlineAttachment decodes inline base64 bytes, verifies the

--- a/sdk/typescript/src/models/agent.ts
+++ b/sdk/typescript/src/models/agent.ts
@@ -39,6 +39,8 @@ export interface ToolCallEvent {
     arguments: Record<string, unknown>;
     requires_confirmation: boolean;
     description?: string;
+    /** Optional renderer hint — see agenttypes.ToolCall.Display. */
+    display?: string;
   };
 }
 

--- a/syfthub-desktop/agent_operations.go
+++ b/syfthub-desktop/agent_operations.go
@@ -122,6 +122,11 @@ func (a *App) startAgentSessionInternal(endpointPath, prompt string, history []a
 	a.agentMu.Lock()
 	prev := a.agentSession
 	a.agentSession = nil
+	prevSessionID := ""
+	if prev != nil {
+		prevSessionID = prev.SessionID
+	}
+	a.emitAttachmentsExpiringLocked(prevSessionID)
 	a.agentAttachments = nil
 	if prev != nil {
 		a.agentCancelledID = prev.SessionID
@@ -256,6 +261,7 @@ func (a *App) drainAgentSession(sc *transport.AgentClientSession) {
 	a.agentMu.Lock()
 	if a.agentSession == sc {
 		a.agentSession = nil
+		a.emitAttachmentsExpiringLocked(sessionID)
 		a.agentAttachments = nil
 	}
 	if a.agentCancelledID == sessionID {
@@ -300,6 +306,11 @@ func (a *App) StopAgentSession() error {
 	a.agentMu.Lock()
 	sc := a.agentSession
 	a.agentSession = nil
+	prevSessionID := ""
+	if sc != nil {
+		prevSessionID = sc.SessionID
+	}
+	a.emitAttachmentsExpiringLocked(prevSessionID)
 	a.agentAttachments = nil
 	if sc != nil {
 		a.agentCancelledID = sc.SessionID
@@ -326,4 +337,28 @@ func (a *App) consumeAgentCancelled(sessionID string) bool {
 		return true
 	}
 	return false
+}
+
+// emitAttachmentsExpiringLocked snapshots the current agentAttachments map
+// and emits an attachments.expiring event so the frontend can warn the user
+// about unsaved files before the session swap discards them. Caller MUST
+// hold a.agentMu. No-op when the cache is empty.
+func (a *App) emitAttachmentsExpiringLocked(prevSessionID string) {
+	if len(a.agentAttachments) == 0 {
+		return
+	}
+	items := make([]map[string]any, 0, len(a.agentAttachments))
+	for fid, entry := range a.agentAttachments {
+		items = append(items, map[string]any{
+			"file_id":    fid,
+			"name":       entry.Meta.Name,
+			"size_bytes": entry.Meta.SizeBytes,
+			"mime":       entry.Meta.MIME,
+		})
+	}
+	runtime.EventsEmit(a.ctx, "agent:event", AgentStreamEvent{
+		Type:      "attachments.expiring",
+		SessionID: prevSessionID,
+		Data:      map[string]any{"attachments": items},
+	})
 }

--- a/syfthub-desktop/attachment_operations.go
+++ b/syfthub-desktop/attachment_operations.go
@@ -1,10 +1,17 @@
 // Package main: chat attachment bindings.
 //
-// Attachments flow through the active AgentClientSession: inline payloads
-// (≤64 KiB) ride encrypted inside the agent session's NATS messages.
-// Object-store (large-file) attachments are not yet supported on the direct
-// peer-to-peer path. This file caches inbound bytes for preview/save and
-// forwards outbound uploads.
+// Attachments flow through the active AgentClientSession in both directions
+// and on both transports:
+//   - inline (≤ syfthubapi.InlineMaxBytes): bytes ride encrypted in the
+//     agent session's NATS messages.
+//   - object_store (> InlineMaxBytes): ciphertext stored in NATS JetStream
+//     Object Store under a per-session bucket; the event/user-attachment
+//     message carries metadata + the wrapped per-file key.
+//
+// This file caches inbound bytes for preview/save and forwards outbound
+// uploads. Object_store support requires the AgentDialer to have been built
+// with WithAttachmentStore(hostTransport) in internal/app — the desktop
+// wires this at startup.
 package main
 
 import (
@@ -22,6 +29,7 @@ import (
 	"time"
 
 	"github.com/openmined/syfthub/sdk/golang/agenttypes"
+	"github.com/openmined/syfthub/sdk/golang/syfthubapi"
 	"github.com/openmined/syfthub/sdk/golang/syfthubapi/transport"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
@@ -39,16 +47,18 @@ type AttachmentSummary struct {
 
 // agentAttachment caches an inbound attachment for the active session. For
 // inline-tier attachments the SDK delivered the bytes in the event; we decode
-// once when the event arrives so save/preview is a buffer copy. Object-store-
-// tier attachments are not supported on the direct peer-to-peer path — only
-// the metadata is kept.
+// once when the event arrives so save/preview is a buffer copy. For
+// object_store-tier attachments only the metadata is kept; the bytes are
+// fetched on demand via the SDK's DownloadAttachment.
 type agentAttachment struct {
 	Meta  agenttypes.AttachmentEvent
 	Bytes []byte // populated only for inline transport
 }
 
 // cacheAgentAttachment stores an inbound attachment under the active session's
-// cache. No-op when the session has rotated since the event was emitted.
+// cache. No-op when the session has rotated since the event was emitted. Inline
+// integrity (size + SHA-256) is verified by agenttypes.AttachmentEvent.Bytes
+// indirectly — we just rely on its decoding plus our own size/SHA check below.
 func (a *App) cacheAgentAttachment(sessionID string, ev *agenttypes.AttachmentEvent) error {
 	entry := &agentAttachment{Meta: *ev}
 
@@ -146,7 +156,9 @@ func (a *App) resolveAttachment(fileID string) (*transport.AgentClientSession, *
 }
 
 // writeAttachment writes a resolved attachment's bytes into w. Inline reads
-// from cache; object-store is unsupported on the direct peer-to-peer path.
+// from the cache; object_store streams via the SDK's downloader. On a
+// streaming failure w may have received partial data — callers are
+// responsible for cleanup (e.g. SaveAgentAttachment removes a partial file).
 func (a *App) writeAttachment(ctx context.Context, sc *transport.AgentClientSession, entry *agentAttachment, w io.Writer) error {
 	if entry.Bytes != nil {
 		_, err := w.Write(entry.Bytes)
@@ -155,7 +167,8 @@ func (a *App) writeAttachment(ctx context.Context, sc *transport.AgentClientSess
 	if entry.Meta.Transport != "object_store" {
 		return fmt.Errorf("attachment %s has unknown transport %q", entry.Meta.FileID, entry.Meta.Transport)
 	}
-	return sc.DownloadAttachment(ctx, entry.Meta.FileID, w)
+	info := syfthubapi.AttachmentInfoFromEvent(&entry.Meta)
+	return sc.DownloadAttachment(ctx, info, w)
 }
 
 // SaveAgentAttachment writes an agent-emitted attachment into ~/Downloads
@@ -235,11 +248,16 @@ func (a *App) BrowseForAttachment() string {
 	return path
 }
 
-// AttachToActiveSession reads the file at hostPath and sends it to the agent
-// as an inline attachment over the encrypted agent session. Returns the
-// assigned file_id and metadata so the frontend can render a staged-attachment
-// chip and reference the file in follow-up messages with the
-// attachment://{file_id} URI.
+// AttachToActiveSession opens the file at hostPath and streams it to the
+// agent as an attachment over the encrypted agent session. Files ≤
+// syfthubapi.InlineMaxBytes ride inline; larger files spill to NATS
+// JetStream Object Store. Returns the assigned file_id + metadata so the
+// frontend can render a staged-attachment chip and reference the file in
+// follow-up messages with the attachment://{file_id} URI.
+//
+// The size is checked before opening to refuse pathological inputs early.
+// Files larger than syfthubapi.MaxAttachmentBytes (2 GiB) are rejected
+// outright.
 func (a *App) AttachToActiveSession(hostPath string) (*AttachmentSummary, error) {
 	a.agentMu.Lock()
 	sc := a.agentSession
@@ -255,11 +273,15 @@ func (a *App) AttachToActiveSession(hostPath string) (*AttachmentSummary, error)
 	if st.IsDir() {
 		return nil, fmt.Errorf("attachments must be files, not directories")
 	}
-
-	body, err := os.ReadFile(hostPath)
-	if err != nil {
-		return nil, fmt.Errorf("read: %w", err)
+	if st.Size() > syfthubapi.MaxAttachmentBytes {
+		return nil, fmt.Errorf("attachment too large: %d bytes (max %d)", st.Size(), syfthubapi.MaxAttachmentBytes)
 	}
+
+	f, err := os.Open(hostPath)
+	if err != nil {
+		return nil, fmt.Errorf("open: %w", err)
+	}
+	defer f.Close()
 
 	name := filepath.Base(hostPath)
 	mimeType := mime.TypeByExtension(filepath.Ext(hostPath))
@@ -269,7 +291,7 @@ func (a *App) AttachToActiveSession(hostPath string) (*AttachmentSummary, error)
 
 	ctx, cancel := a.attachmentContext()
 	defer cancel()
-	fileID, err := sc.SendAttachmentBytes(ctx, body, transport.AttachmentOpts{
+	info, err := sc.SendAttachment(ctx, f, transport.AttachmentOpts{
 		Name: name,
 		MIME: mimeType,
 	})
@@ -277,13 +299,12 @@ func (a *App) AttachToActiveSession(hostPath string) (*AttachmentSummary, error)
 		return nil, fmt.Errorf("send attachment: %w", err)
 	}
 
-	sum := sha256.Sum256(body)
 	return &AttachmentSummary{
-		FileID:    fileID,
-		Name:      name,
-		MIME:      mimeType,
-		SizeBytes: int64(len(body)),
-		SHA256:    hex.EncodeToString(sum[:]),
+		FileID:    info.FileID,
+		Name:      info.Name,
+		MIME:      info.MIME,
+		SizeBytes: info.SizeBytes,
+		SHA256:    info.PlaintextSHA256,
 	}, nil
 }
 
@@ -310,9 +331,9 @@ func (a *App) DownloadActiveSessionAttachment(fileID, destPath string) error {
 
 // AttachmentInlineBytes returns the plaintext bytes for an attachment so the
 // frontend can render image previews / inline content in the chat timeline.
-// For inline-tier attachments this is a cache read; object-store-tier
-// attachments are unsupported on the direct peer-to-peer path. maxBytes caps
-// the returned slice; 0 means no limit.
+// Inline-tier attachments are served from the in-memory cache; object_store-
+// tier attachments are streamed via the SDK and capped at maxBytes (0 means
+// no cap).
 func (a *App) AttachmentInlineBytes(fileID string, maxBytes int64) ([]byte, error) {
 	sc, entry, err := a.resolveAttachment(fileID)
 	if err != nil {
@@ -328,8 +349,9 @@ func (a *App) AttachmentInlineBytes(fileID string, maxBytes int64) ([]byte, erro
 	// Object-store tier: stream into a capped buffer.
 	ctx, cancel := a.attachmentContext()
 	defer cancel()
+	info := syfthubapi.AttachmentInfoFromEvent(&entry.Meta)
 	buf := newLimitedBuffer(maxBytes)
-	if err := sc.DownloadAttachment(ctx, fileID, buf); err != nil {
+	if err := sc.DownloadAttachment(ctx, info, buf); err != nil {
 		return nil, fmt.Errorf("download attachment: %w", err)
 	}
 	return buf.bytes, nil

--- a/syfthub-desktop/attachment_operations.go
+++ b/syfthub-desktop/attachment_operations.go
@@ -159,8 +159,16 @@ func (a *App) resolveAttachment(fileID string) (*transport.AgentClientSession, *
 // from the cache; object_store streams via the SDK's downloader. On a
 // streaming failure w may have received partial data — callers are
 // responsible for cleanup (e.g. SaveAgentAttachment removes a partial file).
-func (a *App) writeAttachment(ctx context.Context, sc *transport.AgentClientSession, entry *agentAttachment, w io.Writer) error {
+//
+// progress, when non-nil, is invoked as plaintext flows through the SDK.
+// The desktop UI uses this to emit attachment.progress Wails events; it is
+// the caller's job to throttle if needed.
+func (a *App) writeAttachment(ctx context.Context, sc *transport.AgentClientSession, entry *agentAttachment, w io.Writer, progress func(downloaded, total int64)) error {
 	if entry.Bytes != nil {
+		// Single-shot synthetic progress so UI flips straight to "done".
+		if progress != nil {
+			progress(int64(len(entry.Bytes)), int64(len(entry.Bytes)))
+		}
 		_, err := w.Write(entry.Bytes)
 		return err
 	}
@@ -168,13 +176,46 @@ func (a *App) writeAttachment(ctx context.Context, sc *transport.AgentClientSess
 		return fmt.Errorf("attachment %s has unknown transport %q", entry.Meta.FileID, entry.Meta.Transport)
 	}
 	info := syfthubapi.AttachmentInfoFromEvent(&entry.Meta)
-	return sc.DownloadAttachment(ctx, info, w)
+	var opts []transport.DownloadOption
+	if progress != nil {
+		opts = append(opts, transport.WithProgress(progress))
+	}
+	return sc.DownloadAttachment(ctx, info, w, opts...)
+}
+
+// emitAttachmentProgress emits a throttled attachment.progress Wails event.
+// Tick at most once per progressMinInterval to avoid hammering the JS bridge
+// for fast/chunky downloads.
+const progressMinInterval = 100 * time.Millisecond
+
+// attachmentProgressEmitter returns a writeAttachment-compatible progress
+// callback closed over a per-download throttle timer. The final progress
+// (downloaded == total when total > 0) is always emitted.
+func (a *App) attachmentProgressEmitter(fileID string, sessionID string) func(downloaded, total int64) {
+	var last time.Time
+	return func(downloaded, total int64) {
+		now := time.Now()
+		final := total > 0 && downloaded >= total
+		if !final && now.Sub(last) < progressMinInterval {
+			return
+		}
+		last = now
+		runtime.EventsEmit(a.ctx, "agent:event", AgentStreamEvent{
+			Type:      "attachment.progress",
+			SessionID: sessionID,
+			Data: map[string]any{
+				"file_id":    fileID,
+				"downloaded": downloaded,
+				"total":      total,
+			},
+		})
+	}
 }
 
 // SaveAgentAttachment writes an agent-emitted attachment into ~/Downloads
 // under its original filename (with " (n)" suffix on collision). Inline-tier
-// bytes are served from the in-memory cache; object-store-tier attachments
-// are unsupported on the direct peer-to-peer path.
+// bytes are served from the in-memory cache; object_store-tier attachments
+// stream via the SDK and emit attachment.progress events to the frontend.
 func (a *App) SaveAgentAttachment(fileID, suggestedName string) (string, error) {
 	if fileID == "" {
 		return "", fmt.Errorf("file_id required")
@@ -204,7 +245,54 @@ func (a *App) SaveAgentAttachment(fileID, suggestedName string) (string, error) 
 
 	ctx, cancel := a.attachmentContext()
 	defer cancel()
-	if err := a.writeAttachment(ctx, sc, entry, out); err != nil {
+	if err := a.writeAttachment(ctx, sc, entry, out, a.attachmentProgressEmitter(fileID, sc.SessionID)); err != nil {
+		_ = os.Remove(dest)
+		return "", err
+	}
+	return dest, nil
+}
+
+// SaveAttachmentAs opens a native save-as dialog seeded with suggestedName and
+// writes the attachment to the user's chosen path. Returns the chosen path on
+// success, "" if the user cancelled the dialog, or an error. Replaces the
+// frontend-supplied-path binding so the destination can only ever come from
+// an OS dialog gesture.
+func (a *App) SaveAttachmentAs(fileID, suggestedName string) (string, error) {
+	if fileID == "" {
+		return "", fmt.Errorf("file_id required")
+	}
+	sc, entry, err := a.resolveAttachment(fileID)
+	if err != nil {
+		return "", err
+	}
+
+	name := filepath.Base(strings.TrimSpace(suggestedName))
+	if name == "" || name == "." || name == ".." || name == string(filepath.Separator) {
+		name = fileID
+	}
+	dest, err := runtime.SaveFileDialog(a.ctx, runtime.SaveDialogOptions{
+		DefaultFilename: name,
+		Title:           "Save attachment",
+	})
+	if err != nil {
+		return "", fmt.Errorf("save dialog: %w", err)
+	}
+	if dest == "" {
+		return "", nil // user cancelled
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+		return "", fmt.Errorf("mkdir: %w", err)
+	}
+	out, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("open dest: %w", err)
+	}
+	defer out.Close()
+
+	ctx, cancel := a.attachmentContext()
+	defer cancel()
+	if err := a.writeAttachment(ctx, sc, entry, out, a.attachmentProgressEmitter(fileID, sc.SessionID)); err != nil {
 		_ = os.Remove(dest)
 		return "", err
 	}
@@ -308,26 +396,6 @@ func (a *App) AttachToActiveSession(hostPath string) (*AttachmentSummary, error)
 	}, nil
 }
 
-// DownloadActiveSessionAttachment writes fileID's bytes to destPath. Used
-// when the user picks "Save to…" with a custom path.
-func (a *App) DownloadActiveSessionAttachment(fileID, destPath string) error {
-	sc, entry, err := a.resolveAttachment(fileID)
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(destPath), 0o700); err != nil {
-		return fmt.Errorf("mkdir: %w", err)
-	}
-	out, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
-	if err != nil {
-		return fmt.Errorf("open dest: %w", err)
-	}
-	defer out.Close()
-
-	ctx, cancel := a.attachmentContext()
-	defer cancel()
-	return a.writeAttachment(ctx, sc, entry, out)
-}
 
 // AttachmentInlineBytes returns the plaintext bytes for an attachment so the
 // frontend can render image previews / inline content in the chat timeline.
@@ -346,7 +414,8 @@ func (a *App) AttachmentInlineBytes(fileID string, maxBytes int64) ([]byte, erro
 		return entry.Bytes, nil
 	}
 
-	// Object-store tier: stream into a capped buffer.
+	// Object-store tier: stream into a capped buffer. Inline previews are
+	// always bounded, so no progress emit is wired here.
 	ctx, cancel := a.attachmentContext()
 	defer cancel()
 	info := syfthubapi.AttachmentInfoFromEvent(&entry.Meta)

--- a/syfthub-desktop/attachment_operations_test.go
+++ b/syfthub-desktop/attachment_operations_test.go
@@ -23,10 +23,9 @@ func TestAttachToActiveSessionWithoutSessionReturnsError(t *testing.T) {
 	}
 }
 
-func TestDownloadAttachmentWithoutSessionReturnsError(t *testing.T) {
+func TestSaveAgentAttachmentWithoutSessionReturnsError(t *testing.T) {
 	app := NewApp()
-	dir := t.TempDir()
-	err := app.DownloadActiveSessionAttachment("att-x", filepath.Join(dir, "out.bin"))
+	_, err := app.SaveAgentAttachment("att-x", "out.bin")
 	if err == nil {
 		t.Fatal("expected error for inactive session")
 	}

--- a/syfthub-desktop/frontend/package-lock.json
+++ b/syfthub-desktop/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@types/dompurify": "^3.0.5",
+        "ansi-to-react": "^6.2.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dompurify": "^3.3.2",
@@ -29,7 +30,7 @@
         "shiki": "^3.23.0",
         "tailwind-merge": "^2.6.0",
         "use-stick-to-bottom": "^1.0.0",
-        "zod": "^4.3.6",
+        "zod": "^4.4.3",
         "zustand": "^5.0.11"
       },
       "devDependencies": {
@@ -3997,6 +3998,12 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/anser": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-2.3.5.tgz",
+      "integrity": "sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==",
+      "license": "MIT"
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -4011,6 +4018,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-to-react": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/ansi-to-react/-/ansi-to-react-6.2.6.tgz",
+      "integrity": "sha512-Eqi0iaMK5OZ3jsVFxWvU2B74UZBnGuHlkflKMX6wTOeH+luy9KE2O0gUkc2PxhIP1R4IO0xohv62UMFInQOSeg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "anser": "^2.3.2",
+        "escape-carriage": "^1.3.1",
+        "linkify-it": "^3.0.3"
+      },
+      "peerDependencies": {
+        "react": "^16.3.2 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.3.2 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/argparse": {
@@ -4462,6 +4484,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-carriage": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/escape-carriage/-/escape-carriage-1.3.1.tgz",
+      "integrity": "sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -5528,6 +5556,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
       }
     },
     "node_modules/locate-path": {
@@ -7506,6 +7543,12 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -7876,9 +7919,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/syfthub-desktop/frontend/package.json
+++ b/syfthub-desktop/frontend/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@types/dompurify": "^3.0.5",
+    "ansi-to-react": "^6.2.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dompurify": "^3.3.2",
@@ -31,7 +32,7 @@
     "shiki": "^3.23.0",
     "tailwind-merge": "^2.6.0",
     "use-stick-to-bottom": "^1.0.0",
-    "zod": "^4.3.6",
+    "zod": "^4.4.3",
     "zustand": "^5.0.11"
   },
   "overrides": {

--- a/syfthub-desktop/frontend/src/components/ChatView.tsx
+++ b/syfthub-desktop/frontend/src/components/ChatView.tsx
@@ -193,11 +193,17 @@ export interface ChatInputAreaProps {
   // staged list / handlers are provided, the input renders the paperclip
   // button + the staged-files chip strip.
   staged?: AttachmentSummary[];
+  // pending lists host-paths queued before a session was live; rendered as a
+  // small banner so the user knows they'll auto-upload on session start.
+  pending?: string[];
+  // Per-file download progress for inbound chips (downloaded/total bytes).
+  attachmentProgress?: Record<string, { downloaded: number; total: number }>;
   onPickAttachment?: () => void;
   onRemoveAttachment?: (fileId: string) => void;
+  onClearPending?: () => void;
+  onSaveAttachmentAs?: (fileId: string, name: string) => Promise<string | null | undefined>;
   attachmentsBusy?: boolean;
   attachmentError?: string | null;
-  attachmentsDisabled?: boolean;
 }
 
 export function ChatInputArea({
@@ -218,11 +224,14 @@ export function ChatInputArea({
   showModelSelector = true,
   lockedModel,
   staged,
+  pending,
+  attachmentProgress,
   onPickAttachment,
   onRemoveAttachment,
+  onClearPending,
+  onSaveAttachmentAs,
   attachmentsBusy,
   attachmentError,
-  attachmentsDisabled,
 }: Readonly<ChatInputAreaProps>) {
   const networkAgents = useAppStore((s) => s.networkAgents);
   const networkAgentsLoading = useAppStore((s) => s.networkAgentsLoading);
@@ -263,9 +272,31 @@ export function ChatInputArea({
                 mime={s.mime}
                 sizeBytes={s.size_bytes}
                 staged
+                delivered={s.delivered}
+                progress={attachmentProgress?.[s.file_id]}
                 onRemove={onRemoveAttachment}
               />
             ))}
+          </div>
+        )}
+        {pending && pending.length > 0 && (
+          <div
+            role='status'
+            aria-live='polite'
+            className='border-border bg-muted/40 text-muted-foreground animate-in fade-in mb-2 flex items-center justify-between gap-2 rounded-md border px-2 py-1 text-xs duration-150'
+          >
+            <span>
+              {pending.length} file{pending.length === 1 ? '' : 's'} queued — will upload when the session starts.
+            </span>
+            {onClearPending && (
+              <button
+                type='button'
+                onClick={onClearPending}
+                className='text-muted-foreground hover:text-foreground underline-offset-2 hover:underline'
+              >
+                Clear
+              </button>
+            )}
           </div>
         )}
         {attachmentError && (
@@ -294,15 +325,15 @@ export function ChatInputArea({
               {showAttachmentButton && (
                 <PromptInputAction
                   tooltip={
-                    attachmentsDisabled
-                      ? 'Start a session to attach files'
-                      : 'Attach file (or drag and drop)'
+                    isActive
+                      ? 'Attach file (or drag and drop)'
+                      : 'Attach file (queued until session starts)'
                   }
                 >
                   <button
                     type='button'
                     onClick={onPickAttachment}
-                    disabled={attachmentsDisabled || attachmentsBusy}
+                    disabled={attachmentsBusy}
                     className='text-muted-foreground hover:text-foreground hover:bg-muted focus-visible:ring-ring focus-visible:ring-offset-background flex h-8 w-8 items-center justify-center rounded-md transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-30'
                     aria-label='Attach file'
                   >
@@ -432,6 +463,8 @@ function AgentChatContent() {
     stopSession,
     pendingPayment,
     dismissPayment,
+    expiringAttachments,
+    dismissExpiring,
   } = useChatWorkflow();
 
   const { copiedId, copy: handleCopy } = useCopyToClipboard();
@@ -440,9 +473,15 @@ function AgentChatContent() {
   // ── Attachments ──────────────────────────────────────────────────────────
   const {
     staged,
+    pending,
+    progress: attachmentProgress,
     attach,
+    stagePath,
+    flushPending,
+    saveAs: saveAttachmentAs,
     remove: removeStaged,
     clear: clearStaged,
+    removePending: clearAllPending,
     busy: attachmentsBusy,
     error: attachmentError,
   } = useAttachments();
@@ -454,14 +493,19 @@ function AgentChatContent() {
   const sessionActive = isRunning || awaitingInput;
 
   const handlePickAttachment = useCallback(async () => {
-    if (!sessionActive) return;
     try {
       const path = await BrowseForAttachment();
-      if (path) await attach(path);
+      if (!path) return;
+      if (sessionActive) {
+        await attach(path);
+      } else {
+        // Queue for upload after the session starts.
+        stagePath(path);
+      }
     } catch {
       /* attach() already records the error via the hook */
     }
-  }, [sessionActive, attach]);
+  }, [sessionActive, attach, stagePath]);
 
   // Save an agent-emitted attachment to ~/Downloads. Returns the absolute
   // path so the chip can show a "Saved to …" confirmation tooltip.
@@ -472,12 +516,37 @@ function AgentChatContent() {
     [],
   );
 
-  // Wails native file-drop. Paths are absolute strings. We only act when a
-  // session is live — the runner won't see anything until a session exists.
+  // Save-as opens a native file dialog; returns null on user cancel.
+  const handleSaveAttachmentAs = useCallback(
+    async (fileId: string, fileName: string) => {
+      return await saveAttachmentAs(fileId, fileName);
+    },
+    [saveAttachmentAs],
+  );
+
+  // Clear all pending (queued) attachments — used when the user dismisses
+  // the "queued" banner.
+  const handleClearPending = useCallback(() => {
+    pending?.forEach((p) => clearAllPending(p));
+  }, [pending, clearAllPending]);
+
+  // Flush queued attachments once a session goes live. Runs at most once
+  // per isRunning rising edge; useAttachments empties `pending` atomically
+  // so a re-render during the flush won't fire it twice.
+  useEffect(() => {
+    if (!isRunning) return;
+    void flushPending();
+  }, [isRunning, flushPending]);
+
+  // Wails native file-drop. Paths are absolute strings. When a session is
+  // live we upload immediately; otherwise we queue.
   useEffect(() => {
     OnFileDrop((_x, _y, paths) => {
-      if (!sessionActive) return;
       setDragActive(false);
+      if (!sessionActive) {
+        for (const p of paths) stagePath(p);
+        return;
+      }
       void (async () => {
         for (const p of paths) {
           try {
@@ -491,11 +560,12 @@ function AgentChatContent() {
 
     // HTML5 drag events are needed to flash the overlay; the actual drop is
     // handled by Wails (above). dragenter/dragleave use a counter pattern to
-    // avoid flicker when entering child elements.
+    // avoid flicker when entering child elements. The overlay shows for both
+    // live and pre-session drops — the latter just queue rather than upload.
     let depth = 0;
     const onEnter = () => {
       depth++;
-      if (sessionActive) setDragActive(true);
+      setDragActive(true);
     };
     const onLeave = () => {
       depth = Math.max(0, depth - 1);
@@ -515,7 +585,7 @@ function AgentChatContent() {
       window.removeEventListener('dragleave', onLeave);
       window.removeEventListener('drop', onDrop);
     };
-  }, [sessionActive, attach]);
+  }, [sessionActive, attach, stagePath]);
 
   const handleSubmit = useCallback(async () => {
     const prompt = inputValue.trim();
@@ -531,10 +601,10 @@ function AgentChatContent() {
       await sendInput(prompt);
     } else if (!isRunning) {
       setInputValue('');
-      // Note: any pre-session staged files (dropped before clicking send)
-      // currently fail because AttachToActiveSession requires an active
-      // session. We could buffer them, but for v1 the staged chip strip is
-      // visible-only-while-running.
+      // Don't clearStaged() here — pre-session pending paths are flushed on
+      // session start by the useEffect above. We also leave any already-
+      // staged chips (rare but possible after a previous session ended) so
+      // the user can see what's about to be sent.
       clearStaged();
       await startSession(prompt);
     }
@@ -715,7 +785,9 @@ function AgentChatContent() {
                           name={attName}
                           mime={String(d.mime ?? 'application/octet-stream')}
                           sizeBytes={Number(d.size_bytes ?? 0)}
+                          progress={attachmentProgress?.[String(d.file_id ?? '')]}
                           onDownload={(fid) => handleDownloadAttachment(fid, attName)}
+                          onSaveAs={(fid, nm) => handleSaveAttachmentAs(fid, nm)}
                         />
                       </div>
                     </Message>
@@ -859,11 +931,14 @@ function AgentChatContent() {
         sendTooltip='Send (Enter)'
         isActive={isRunning}
         staged={staged}
+        pending={pending}
+        attachmentProgress={attachmentProgress}
         onPickAttachment={handlePickAttachment}
         onRemoveAttachment={removeStaged}
+        onClearPending={handleClearPending}
+        onSaveAttachmentAs={handleSaveAttachmentAs}
         attachmentsBusy={attachmentsBusy}
         attachmentError={attachmentError}
-        attachmentsDisabled={!sessionActive}
         footer={chatSelectedModel ? (
           <p className='text-muted-foreground mt-1.5 text-center text-[10px]'>
             <span className='font-medium'>{chatSelectedModel.name}</span>
@@ -871,11 +946,11 @@ function AgentChatContent() {
         ) : undefined}
       />
 
-      {/* Drop overlay — fades in when files are dragged over the window AND
-          a session is active. The Wails-recognized drop target uses the
-          --wails-drop-target CSS custom property (see main.go DragAndDrop
-          options) so the runtime knows we accept the drop here. */}
-      {dragActive && sessionActive && (
+      {/* Drop overlay — fades in when files are dragged over the window.
+          The Wails-recognized drop target uses the --wails-drop-target CSS
+          custom property (see main.go DragAndDrop options) so the runtime
+          knows we accept the drop here. */}
+      {dragActive && (
         <div
           // eslint-disable-next-line react/forbid-dom-props
           style={{ '--wails-drop-target': 'drop' } as React.CSSProperties}
@@ -888,8 +963,57 @@ function AgentChatContent() {
             </div>
             <p className='text-base font-medium'>Drop to attach</p>
             <p className='text-muted-foreground text-sm'>
-              Files will be sent on your next message
+              {sessionActive
+                ? 'Files will be sent on your next message'
+                : 'Files will be queued and sent when the session starts'}
             </p>
+          </div>
+        </div>
+      )}
+
+      {/* Attachments-expiring toast — surfaces when the host is about to
+          discard cached agent-emitted attachments (session swap/stop). The
+          user gets one chance to Save All to Downloads before the bytes
+          are gone. Dismissed manually or by clicking the action. */}
+      {expiringAttachments.length > 0 && (
+        <div
+          role='alert'
+          aria-live='assertive'
+          className='border-border bg-card text-foreground animate-in fade-in slide-in-from-bottom-2 fixed bottom-6 right-6 z-50 flex max-w-sm items-start gap-3 rounded-lg border px-4 py-3 shadow-lg duration-150'
+        >
+          <div className='min-w-0 flex-1'>
+            <p className='text-sm font-medium'>
+              {expiringAttachments.length} unsaved attachment
+              {expiringAttachments.length === 1 ? '' : 's'} will be lost
+            </p>
+            <p className='text-muted-foreground mt-0.5 text-xs'>
+              Save now to keep them.
+            </p>
+            <div className='mt-2 flex gap-2'>
+              <button
+                type='button'
+                onClick={async () => {
+                  for (const a of expiringAttachments) {
+                    try {
+                      await handleDownloadAttachment(a.file_id, a.name);
+                    } catch {
+                      /* keep iterating */
+                    }
+                  }
+                  dismissExpiring();
+                }}
+                className='bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-2.5 py-1 text-xs font-medium transition-colors'
+              >
+                Save all to Downloads
+              </button>
+              <button
+                type='button'
+                onClick={dismissExpiring}
+                className='text-muted-foreground hover:text-foreground rounded-md px-2.5 py-1 text-xs transition-colors'
+              >
+                Dismiss
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/syfthub-desktop/frontend/src/components/ChatView.tsx
+++ b/syfthub-desktop/frontend/src/components/ChatView.tsx
@@ -25,7 +25,9 @@ import {
   PromptInputTextarea,
 } from '@/components/prompt-kit/prompt-input';
 import { ScrollButton } from '@/components/prompt-kit/scroll-button';
-import { Tool, type ToolPart } from '@/components/prompt-kit/tool';
+
+import { ToolDispatcher } from '@/components/chat/tool-views/ToolDispatcher';
+import { buildToolView, pairToolEntries } from '@/lib/tool-display';
 
 import { MarkdownMessage } from '@/components/chat/markdown-message';
 import { ModelSelector } from '@/components/chat/model-selector';
@@ -152,70 +154,6 @@ function StatusEntry({ content, isActive }: { content: string; isActive: boolean
       <span>{content}</span>
     </div>
   );
-}
-
-/**
- * Pre-scan entries to pair each tool_call with its nearest following tool_result.
- * Returns a map from tool_call entry index → tool_result entry index.
- * Also returns the set of tool_result indices that were consumed (so they can be skipped).
- */
-function pairToolEntries(entries: AgentEntry[]): { callToResult: Map<number, number>; consumedResults: Set<number> } {
-  const callToResult = new Map<number, number>();
-  const consumedResults = new Set<number>();
-
-  for (let i = 0; i < entries.length; i++) {
-    if (entries[i].kind !== 'tool_call') continue;
-    // Scan forward for the nearest unconsumed tool_result
-    for (let j = i + 1; j < entries.length; j++) {
-      if (entries[j].kind === 'tool_result' && !consumedResults.has(j)) {
-        callToResult.set(i, j);
-        consumedResults.add(j);
-        break;
-      }
-      // Stop scanning if we hit another tool_call (result belongs to a later call)
-      if (entries[j].kind === 'tool_call') break;
-    }
-  }
-
-  return { callToResult, consumedResults };
-}
-
-/** Build a ToolPart from a tool_call entry, optionally paired with its tool_result. */
-function buildToolPart(
-  callEntry: AgentEntry,
-  resultEntry: AgentEntry | undefined,
-  isRunning: boolean,
-): ToolPart {
-  const data = callEntry.data ?? {};
-  const toolName = String(data.tool_name ?? 'tool');
-  const args = data.arguments as Record<string, unknown> | undefined;
-  const toolCallId = data.tool_call_id ? String(data.tool_call_id) : undefined;
-
-  if (resultEntry) {
-    const rd = resultEntry.data ?? {};
-    const status = String(rd.status ?? 'success');
-    const isSuccess = status === 'success';
-    const result = rd.result as Record<string, unknown> | string | undefined;
-    const output = result != null
-      ? (typeof result === 'string' ? { result } : result)
-      : undefined;
-
-    return {
-      type: toolName,
-      state: isSuccess ? 'output-available' : 'output-error',
-      input: args,
-      output,
-      toolCallId,
-      errorText: isSuccess ? undefined : String(rd.error ?? rd.result ?? status),
-    };
-  }
-
-  return {
-    type: toolName,
-    state: isRunning ? 'input-streaming' : 'input-available',
-    input: args,
-    toolCallId,
-  };
 }
 
 function RequestInputEntry({ prompt }: { prompt: string }) {
@@ -629,6 +567,20 @@ function AgentChatContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [toolFingerprint]);
 
+  // Lifecycle phase used by buildToolView for unpaired tool_calls. When the
+  // session ends cleanly we treat any straggler call as silently successful
+  // (the result event may have been batched after session.completed); when
+  // the session was stopped or failed, the call is marked interrupted.
+  const sessionPhase = useMemo<'running' | 'completed' | 'interrupted'>(() => {
+    if (isRunning) return 'running';
+    for (let i = entries.length - 1; i >= 0; i--) {
+      const k = entries[i].kind;
+      if (k === 'completed') return 'completed';
+      if (k === 'cancelled' || k === 'error') return 'interrupted';
+    }
+    return 'completed';
+  }, [entries, isRunning]);
+
   const lastStatusIdx = useMemo(() => {
     return entries.reduce((last, e, i) => e.kind === 'status' ? i : last, -1);
   }, [entries]);
@@ -720,10 +672,10 @@ function AgentChatContent() {
                 if (entry.kind === 'tool_call') {
                   const resultIdx = callToResult.get(entryIndex);
                   const pairedResult = resultIdx != null ? entries[resultIdx] : undefined;
-                  const toolPart = buildToolPart(entry, pairedResult, isRunning);
+                  const view = buildToolView(entry, pairedResult, sessionPhase);
                   return (
                     <div key={entry.id} className='ml-10 max-w-2xl'>
-                      <Tool toolPart={toolPart} className='mt-0' />
+                      <ToolDispatcher view={view} />
                     </div>
                   );
                 }
@@ -731,15 +683,17 @@ function AgentChatContent() {
                 // Skip tool_result entries consumed by a tool_call above
                 if (entry.kind === 'tool_result') {
                   if (consumedResults.has(entryIndex)) return null;
-                  // Orphan tool_result — render standalone
-                  const toolPart = buildToolPart(
-                    { ...entry, data: { tool_name: String(entry.data?.tool_name ?? 'tool'), ...entry.data } },
-                    entry,
-                    isRunning,
-                  );
+                  // Orphan tool_result — synthesize a call-shaped entry from
+                  // the result so the dispatcher can still build a view.
+                  const synthCall: AgentEntry = {
+                    ...entry,
+                    kind: 'tool_call',
+                    data: { tool_name: String(entry.data?.tool_name ?? 'tool'), ...entry.data },
+                  };
+                  const view = buildToolView(synthCall, entry, sessionPhase);
                   return (
                     <div key={entry.id} className='ml-10 max-w-2xl'>
-                      <Tool toolPart={toolPart} className='mt-0' />
+                      <ToolDispatcher view={view} />
                     </div>
                   );
                 }

--- a/syfthub-desktop/frontend/src/components/EndpointDetail.tsx
+++ b/syfthub-desktop/frontend/src/components/EndpointDetail.tsx
@@ -33,12 +33,14 @@ const NAV_GROUPS: { label: string; items: { id: Section; label: string }[] }[] =
       { id: 'overview', label: 'Overview' },
       { id: 'docs', label: 'Docs' },
       { id: 'policies', label: 'Policies' },
-      { id: 'requests', label: 'Requests' },
     ],
   },
   {
     label: 'Monitor',
-    items: [{ id: 'logs', label: 'Logs' }],
+    items: [
+      { id: 'requests', label: 'Requests' },
+      { id: 'logs', label: 'Logs' },
+    ],
   },
   {
     label: 'Configure',

--- a/syfthub-desktop/frontend/src/components/chat/AttachmentChip.tsx
+++ b/syfthub-desktop/frontend/src/components/chat/AttachmentChip.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import {
+  Check,
   Download,
   ExternalLink,
   File as FileIcon,
@@ -7,6 +8,7 @@ import {
   FileImage,
   FileText,
   Loader2,
+  Save,
   X,
 } from 'lucide-react';
 import {
@@ -25,14 +27,37 @@ export interface AttachmentChipProps {
    * entry, with download action + image figure for image MIMEs).
    */
   staged?: boolean;
+  /**
+   * delivered=true (staged only) means the host has emitted a user.attachment
+   * accept-ack for this file. The chip renders a small ✓ next to the size to
+   * confirm the file actually landed on the host.
+   */
+  delivered?: boolean;
+  /**
+   * pending=true (staged only) means the user dropped/picked the file BEFORE
+   * a session was live. The chip renders with a "queued" badge until
+   * flushPending() promotes it to a normal staged attachment.
+   */
+  pending?: boolean;
+  /**
+   * Inbound-download progress (non-staged only). When set and downloaded <
+   * total, the chip renders a thin progress bar. Populated from
+   * attachment.progress events via useAttachments.progress.
+   */
+  progress?: { downloaded: number; total: number };
   onRemove?: (fileId: string) => void;
   /**
-   * Save the attachment somewhere on the user's disk. The parent should
-   * resolve with the absolute destination path on success (used to
+   * Save the attachment to a default location (~/Downloads). The parent
+   * should resolve with the absolute destination path on success (used to
    * tooltip the "Saved" confirmation), null/undefined on user cancel,
    * or throw on failure (chip shows the error briefly).
    */
   onDownload?: (fileId: string) => Promise<string | null | undefined>;
+  /**
+   * Optional "Save as…" alternative that opens a native save-file dialog.
+   * Same return contract as onDownload.
+   */
+  onSaveAs?: (fileId: string, name: string) => Promise<string | null | undefined>;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────
@@ -229,10 +254,19 @@ export function AttachmentChip({
   mime,
   sizeBytes,
   staged,
+  delivered,
+  pending,
+  progress,
   onRemove,
   onDownload,
+  onSaveAs,
 }: AttachmentChipProps) {
   const isImage = mime.startsWith('image/');
+  const isDownloading =
+    progress != null && progress.total > 0 && progress.downloaded < progress.total;
+  const progressPct = isDownloading
+    ? Math.min(100, Math.max(0, (progress!.downloaded / progress!.total) * 100))
+    : 0;
 
   // Image figure variant: only for agent-emitted attachments. Cap fetch at
   // 4 MiB so we don't accidentally pull a 20 MB PNG into memory.
@@ -297,17 +331,28 @@ export function AttachmentChip({
               {isSaved && ' · Saved'}
             </p>
           </div>
-          {onDownload && (
-            <DownloadOrOpenButton
-              fileId={fileId}
-              name={name}
-              onDownload={onDownload}
-              size='md'
-              state={downloadState}
-              setState={setDownloadState}
-            />
-          )}
+          <div className='flex items-center gap-1'>
+            {onDownload && (
+              <DownloadOrOpenButton
+                fileId={fileId}
+                name={name}
+                onDownload={onDownload}
+                size='md'
+                state={downloadState}
+                setState={setDownloadState}
+              />
+            )}
+            {onSaveAs && downloadState.kind !== 'saved' && (
+              <SaveAsButton
+                fileId={fileId}
+                name={name}
+                onSaveAs={onSaveAs}
+                size='md'
+              />
+            )}
+          </div>
         </figcaption>
+        {isDownloading && <ProgressBar pct={progressPct} />}
       </figure>
     );
   }
@@ -348,6 +393,29 @@ export function AttachmentChip({
       >
         {humanSize(sizeBytes)}
       </span>
+      {staged && delivered && (
+        <Check
+          className='text-emerald-500 h-3 w-3 shrink-0'
+          aria-label='Delivered to host'
+        />
+      )}
+      {staged && pending && (
+        <span
+          className='text-muted-foreground bg-background/60 shrink-0 rounded px-1 text-[9px] uppercase tracking-wide'
+          aria-label='Queued — will upload when session starts'
+          title='Queued — will upload when session starts'
+        >
+          Queued
+        </span>
+      )}
+      {isDownloading && (
+        <span
+          className='text-muted-foreground shrink-0 text-[10px] tabular-nums'
+          aria-label={`Downloading ${Math.round(progressPct)}%`}
+        >
+          {Math.round(progressPct)}%
+        </span>
+      )}
       {staged && onRemove && (
         <button
           type='button'
@@ -368,6 +436,76 @@ export function AttachmentChip({
           setState={setDownloadState}
         />
       )}
+      {!staged && onSaveAs && downloadState.kind !== 'saved' && (
+        <SaveAsButton
+          fileId={fileId}
+          name={name}
+          onSaveAs={onSaveAs}
+          size='sm'
+        />
+      )}
     </span>
+  );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function ProgressBar({ pct }: { pct: number }) {
+  return (
+    <div
+      className='bg-muted h-1 w-full overflow-hidden'
+      role='progressbar'
+      aria-valuenow={pct}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      <div
+        className='bg-primary h-full transition-[width] duration-150'
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}
+
+function SaveAsButton({
+  fileId,
+  name,
+  onSaveAs,
+  size,
+}: {
+  fileId: string;
+  name: string;
+  onSaveAs: (fileId: string, name: string) => Promise<string | null | undefined>;
+  size: 'sm' | 'md';
+}) {
+  const [busy, setBusy] = useState(false);
+  const cls = size === 'md' ? 'h-6 w-6' : 'h-5 w-5';
+  const iconCls = size === 'md' ? 'h-3.5 w-3.5' : 'h-3 w-3';
+  const handleClick = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await onSaveAs(fileId, name);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('save-as failed', err);
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <button
+      type='button'
+      onClick={handleClick}
+      disabled={busy}
+      className={`${cls} text-muted-foreground hover:text-foreground hover:bg-background focus-visible:ring-ring focus-visible:ring-offset-background ml-0.5 flex shrink-0 items-center justify-center rounded transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50`}
+      aria-label={`Save ${name} as…`}
+      title={`Save ${name} as…`}
+    >
+      <Save
+        className={`${iconCls} ${busy ? 'animate-pulse' : ''}`}
+        aria-hidden='true'
+      />
+    </button>
   );
 }

--- a/syfthub-desktop/frontend/src/components/chat/ChatWorkflowProvider.tsx
+++ b/syfthub-desktop/frontend/src/components/chat/ChatWorkflowProvider.tsx
@@ -39,6 +39,16 @@ interface ChatWorkflowValue {
   clearEntries: () => void;
   pendingPayment: PendingPayment | null;
   dismissPayment: () => void;
+  // attachments.expiring toast state. Populated when the host warns of
+  // unsaved cached attachments about to be discarded; cleared by the UI on
+  // user action.
+  expiringAttachments: Array<{
+    file_id: string;
+    name: string;
+    size_bytes: number;
+    mime: string;
+  }>;
+  dismissExpiring: () => void;
 }
 
 const ChatWorkflowContext = createContext<ChatWorkflowValue | null>(null);

--- a/syfthub-desktop/frontend/src/components/chat/PaymentRequiredModal.tsx
+++ b/syfthub-desktop/frontend/src/components/chat/PaymentRequiredModal.tsx
@@ -354,12 +354,13 @@ export function PaymentRequiredModal({
           </div>
         )}
 
-        <DialogFooter className="flex-col gap-2 sm:flex-row sm:justify-end">
+        <DialogFooter className="flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <Button
             type="button"
             variant="outline"
             onClick={handleCancel}
             disabled={submitting}
+            className="sm:mr-auto"
           >
             Cancel
           </Button>
@@ -385,7 +386,7 @@ export function PaymentRequiredModal({
                 onClick={() => setShowCapEditor(true)}
                 disabled={submitting || walletChecking || walletReady !== true}
               >
-                Always allow ≤ {hardCap} {shortenCurrency(currency)}
+                Always allow ≤ {hardCap}
               </Button>
               <Button
                 type="button"

--- a/syfthub-desktop/frontend/src/components/chat/ReviewChatPane.tsx
+++ b/syfthub-desktop/frontend/src/components/chat/ReviewChatPane.tsx
@@ -369,7 +369,6 @@ export function ReviewChatPane({ reviewId }: Readonly<ReviewChatPaneProps>) {
         onRemoveAttachment={handleRemoveAttachment}
         attachmentsBusy={false}
         attachmentError={attachmentError}
-        attachmentsDisabled={!continuable || submitting || isRunning}
         footer={isRunning ? (
           <p className='mt-1.5 text-[11px] italic text-muted-foreground'>
             A live session is already running. Stop it before continuing this thread.

--- a/syfthub-desktop/frontend/src/components/chat/tool-views/CodeToolView.tsx
+++ b/syfthub-desktop/frontend/src/components/chat/tool-views/CodeToolView.tsx
@@ -1,0 +1,60 @@
+/**
+ * CodeToolView — renders a file read/write tool call as a syntax-highlighted
+ * block. Backs onto the tool-ui CodeBlock display component.
+ *
+ * Read:  args.path → header,    result body → content.
+ * Write: args.path → header,    args.content → content (the body the agent
+ *        wanted to write; we show that instead of the success message).
+ */
+
+import FileText from 'lucide-react/dist/esm/icons/file-text';
+import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
+import Pencil from 'lucide-react/dist/esm/icons/pencil';
+
+import { CodeBlock } from '@/components/tool-ui/code-block';
+import type { ToolView } from '@/lib/tool-display';
+
+type CodeView = Extract<ToolView, { kind: 'code' }>;
+
+export function CodeToolView({ view }: { view: CodeView }) {
+  const stableId = view.toolCallId ?? `code-${view.toolName}`;
+  const isRunning = view.status === 'running';
+  const isError = view.status === 'error';
+  const Icon = view.operation === 'write' ? Pencil : FileText;
+
+  return (
+    <div className='space-y-1'>
+      <div className='text-muted-foreground flex items-center gap-1.5 px-1 text-xs'>
+        <Icon className='h-3 w-3' aria-hidden='true' />
+        <span className='font-mono'>
+          {view.operation === 'write' ? 'write ' : 'read '}
+          {view.path || '(unknown path)'}
+        </span>
+      </div>
+      {isError ? (
+        <div className='border-destructive/30 bg-destructive/10 text-destructive rounded-md border p-2 text-sm'>
+          {view.errorText || 'Tool error'}
+        </div>
+      ) : view.content ? (
+        <CodeBlock
+          id={stableId}
+          code={view.content}
+          language={view.language ?? 'text'}
+          filename={view.path || undefined}
+          lineNumbers='visible'
+          maxCollapsedLines={20}
+        />
+      ) : (
+        <div className='text-muted-foreground bg-muted/40 rounded-md border px-2 py-1 text-xs italic'>
+          {isRunning ? 'Reading…' : 'No content'}
+        </div>
+      )}
+      {isRunning && (
+        <div className='text-muted-foreground flex items-center gap-1.5 px-1 text-xs'>
+          <Loader2 className='h-3 w-3 animate-spin' aria-hidden='true' />
+          <span>Running…</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/syfthub-desktop/frontend/src/components/chat/tool-views/DiffToolView.tsx
+++ b/syfthub-desktop/frontend/src/components/chat/tool-views/DiffToolView.tsx
@@ -1,0 +1,86 @@
+/**
+ * DiffToolView — renders a string-replace style edit (Claude Code's Edit tool
+ * or any equivalent) as a minimal unified diff. Hand-rolled rather than
+ * depending on @pierre/diffs / React 19's use() hook — we just need clear
+ * before/after rendering, not a full diff engine.
+ *
+ * Wire mapping:
+ *   args.old_string → view.before  (rendered with `-` prefix, red background)
+ *   args.new_string → view.after   (rendered with `+` prefix, green background)
+ *   args.file_path  → view.path    (header)
+ */
+
+import GitCompare from 'lucide-react/dist/esm/icons/git-compare';
+import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
+
+import type { ToolView } from '@/lib/tool-display';
+import { cn } from '@/lib/utils';
+
+type DiffView = Extract<ToolView, { kind: 'diff' }>;
+
+function splitLines(s: string): string[] {
+  if (!s) return [];
+  // Normalize CRLF (Windows) and stray CR (old Mac) so each line is clean,
+  // then strip trailing newlines to avoid rendering a phantom empty line.
+  const trimmed = s.replace(/\r\n/g, '\n').replace(/\r/g, '').replace(/\n+$/, '');
+  return trimmed.split('\n');
+}
+
+function DiffLine({ marker, text }: { marker: '-' | '+' | ' '; text: string }) {
+  const bg = marker === '-'
+    ? 'bg-red-500/10 text-red-700 dark:text-red-300'
+    : marker === '+'
+      ? 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+      : '';
+  return (
+    <div className={cn('flex font-mono text-xs leading-5', bg)}>
+      <span className='text-muted-foreground select-none px-2 tabular-nums'>{marker}</span>
+      <span className='whitespace-pre-wrap break-words pr-2'>{text || ' '}</span>
+    </div>
+  );
+}
+
+export function DiffToolView({ view }: { view: DiffView }) {
+  const isRunning = view.status === 'running';
+  const isError = view.status === 'error';
+  const beforeLines = splitLines(view.before);
+  const afterLines = splitLines(view.after);
+  const hasContent = beforeLines.length > 0 || afterLines.length > 0;
+
+  return (
+    <div className='border-border bg-card overflow-hidden rounded-lg border'>
+      <div className='bg-card flex items-center justify-between border-b px-3 py-2'>
+        <div className='flex items-center gap-2 overflow-hidden'>
+          <GitCompare className='text-muted-foreground h-4 w-4 shrink-0' aria-hidden='true' />
+          <span className='text-foreground truncate font-mono text-xs'>
+            edit {view.path || '(unknown path)'}
+          </span>
+        </div>
+        {isRunning && (
+          <span className='text-muted-foreground flex items-center gap-1 text-xs'>
+            <Loader2 className='h-3 w-3 animate-spin' aria-hidden='true' />
+            Running…
+          </span>
+        )}
+      </div>
+      {isError ? (
+        <div className='border-destructive/30 bg-destructive/10 text-destructive m-2 rounded-md border p-2 text-sm'>
+          {view.errorText || 'Edit failed'}
+        </div>
+      ) : hasContent ? (
+        <div className='max-h-80 overflow-auto py-1'>
+          {beforeLines.map((line, i) => (
+            <DiffLine key={`b-${i}`} marker='-' text={line} />
+          ))}
+          {afterLines.map((line, i) => (
+            <DiffLine key={`a-${i}`} marker='+' text={line} />
+          ))}
+        </div>
+      ) : (
+        <div className='text-muted-foreground px-3 py-2 text-xs italic'>
+          {isRunning ? 'Editing…' : 'No changes'}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/syfthub-desktop/frontend/src/components/chat/tool-views/TerminalToolView.tsx
+++ b/syfthub-desktop/frontend/src/components/chat/tool-views/TerminalToolView.tsx
@@ -1,0 +1,45 @@
+/**
+ * TerminalToolView — renders a tool_call/tool_result pair as a shell-style
+ * surface. Backs onto the tool-ui `Terminal` display component installed via
+ * the shadcn registry. Used for run_command / Bash / Grep / Glob today.
+ *
+ * The viewmodel feeds three salient fields to the component:
+ *   - command  →  shown in the header bar
+ *   - stdout   →  body, success path
+ *   - stderr   →  body, error path
+ *   - exitCode →  0 or 1 (we don't carry the real exit yet; status drives it)
+ */
+
+import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
+
+import { Terminal } from '@/components/tool-ui/terminal';
+import type { ToolView } from '@/lib/tool-display';
+
+type TerminalView = Extract<ToolView, { kind: 'terminal' }>;
+
+export function TerminalToolView({ view }: { view: TerminalView }) {
+  const stableId = view.toolCallId ?? `terminal-${view.toolName}`;
+  const isRunning = view.status === 'running';
+
+  return (
+    <div className='space-y-1'>
+      <Terminal
+        id={stableId}
+        command={view.command}
+        stdout={view.stdout || undefined}
+        stderr={view.stderr || undefined}
+        exitCode={view.exitCode}
+        durationMs={view.durationMs}
+        cwd={view.cwd}
+        maxCollapsedLines={20}
+        defaultExpanded={false}
+      />
+      {isRunning && (
+        <div className='text-muted-foreground flex items-center gap-1.5 px-1 text-xs'>
+          <Loader2 className='h-3 w-3 animate-spin' aria-hidden='true' />
+          <span>Running…</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/syfthub-desktop/frontend/src/components/chat/tool-views/ToolDispatcher.tsx
+++ b/syfthub-desktop/frontend/src/components/chat/tool-views/ToolDispatcher.tsx
@@ -1,0 +1,86 @@
+/**
+ * ToolDispatcher — routes a ToolView to its renderer. Each kind has a
+ * dedicated component; the `generic` branch falls back to the existing
+ * prompt-kit Tool component (the collapsible JSON dump) so any tool not in
+ * KNOWN_TOOL_KINDS — and not carrying a producer display hint — keeps
+ * working untouched.
+ */
+
+import { Tool, type ToolPart } from '@/components/prompt-kit/tool';
+import { CodeToolView } from '@/components/chat/tool-views/CodeToolView';
+import { DiffToolView } from '@/components/chat/tool-views/DiffToolView';
+import { TerminalToolView } from '@/components/chat/tool-views/TerminalToolView';
+import { WebToolView } from '@/components/chat/tool-views/WebToolView';
+import type { ToolView } from '@/lib/tool-display';
+
+export function ToolDispatcher({ view }: { view: ToolView }) {
+  switch (view.kind) {
+    case 'terminal':
+      return <TerminalToolView view={view} />;
+    case 'code':
+      return <CodeToolView view={view} />;
+    case 'diff':
+      return <DiffToolView view={view} />;
+    case 'web':
+      return <WebToolView view={view} />;
+    case 'generic':
+    default:
+      return <Tool toolPart={toGenericToolPart(view)} className='mt-0' />;
+  }
+}
+
+/** Adapt any ToolView back to the legacy ToolPart shape that prompt-kit's
+ *  collapsible Tool component already understands. Kept side-by-side with the
+ *  modern renderers so a single switch covers both. */
+function toGenericToolPart(view: ToolView): ToolPart {
+  const state: ToolPart['state'] = view.status === 'running'
+    ? 'input-streaming'
+    : view.status === 'error'
+      ? 'output-error'
+      : 'output-available';
+
+  // For non-generic kinds that fall through here (code, diff, web pre-Phase-2),
+  // surface as much of the structured viewmodel as the generic renderer can
+  // hold. The generic renderer formats arbitrary k/v pairs.
+  const { input, output } = projectToInputOutput(view);
+  return {
+    type: view.toolName,
+    state,
+    input,
+    output,
+    toolCallId: view.toolCallId,
+    errorText: view.errorText,
+  };
+}
+
+function projectToInputOutput(view: ToolView): {
+  input?: Record<string, unknown>;
+  output?: Record<string, unknown>;
+} {
+  switch (view.kind) {
+    case 'generic':
+      return {
+        input: view.input,
+        output: typeof view.output === 'object' && view.output !== null
+          ? (view.output as Record<string, unknown>)
+          : view.output != null ? { result: view.output } : undefined,
+      };
+    case 'code':
+      return {
+        input: { path: view.path, operation: view.operation },
+        output: view.content ? { content: view.content } : undefined,
+      };
+    case 'diff':
+      return {
+        input: { path: view.path },
+        output: { before: view.before, after: view.after },
+      };
+    case 'web':
+      return {
+        input: { url: view.url },
+        output: view.summary ? { summary: view.summary } : undefined,
+      };
+    default:
+      return {};
+  }
+}

--- a/syfthub-desktop/frontend/src/components/chat/tool-views/WebToolView.tsx
+++ b/syfthub-desktop/frontend/src/components/chat/tool-views/WebToolView.tsx
@@ -1,0 +1,82 @@
+/**
+ * WebToolView — renders a URL fetch as a header chip + a scrollable
+ * text-summary body. Hand-rolled rather than pulling in the heavier
+ * link-preview component (which expects Open Graph metadata we don't have
+ * from a generic fetch_url call).
+ */
+
+import ExternalLink from 'lucide-react/dist/esm/icons/external-link';
+import Globe from 'lucide-react/dist/esm/icons/globe';
+import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
+
+import type { ToolView } from '@/lib/tool-display';
+
+type WebView = Extract<ToolView, { kind: 'web' }>;
+
+function safeHostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+function formatDuration(ms?: number): string | null {
+  if (ms == null) return null;
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export function WebToolView({ view }: { view: WebView }) {
+  const isRunning = view.status === 'running';
+  const isError = view.status === 'error';
+  const duration = formatDuration(view.durationMs);
+  const host = view.url ? safeHostname(view.url) : '';
+
+  return (
+    <div className='border-border bg-card overflow-hidden rounded-lg border'>
+      <div className='bg-card flex items-center justify-between border-b px-3 py-2'>
+        <div className='flex items-center gap-2 overflow-hidden'>
+          <Globe className='text-muted-foreground h-4 w-4 shrink-0' aria-hidden='true' />
+          <span className='text-foreground truncate font-mono text-xs' title={view.url}>
+            {host || view.url || '(no url)'}
+          </span>
+        </div>
+        <div className='flex items-center gap-3'>
+          {duration && (
+            <span className='text-muted-foreground font-mono text-xs tabular-nums'>
+              {duration}
+            </span>
+          )}
+          {view.url && (
+            <a
+              href={view.url}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='text-muted-foreground hover:text-foreground'
+              aria-label='Open in browser'
+            >
+              <ExternalLink className='h-4 w-4' aria-hidden='true' />
+            </a>
+          )}
+        </div>
+      </div>
+      <div className='p-3'>
+        {isError ? (
+          <div className='border-destructive/30 bg-destructive/10 text-destructive rounded-md border p-2 text-sm'>
+            {view.errorText || 'Fetch failed'}
+          </div>
+        ) : view.summary ? (
+          <div className='text-foreground max-h-60 overflow-auto whitespace-pre-wrap break-words font-mono text-xs'>
+            {view.summary}
+          </div>
+        ) : (
+          <div className='text-muted-foreground flex items-center gap-1.5 text-xs italic'>
+            {isRunning && <Loader2 className='h-3 w-3 animate-spin' aria-hidden='true' />}
+            <span>{isRunning ? 'Fetching…' : 'No content'}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/syfthub-desktop/frontend/src/components/tool-ui/terminal/README.md
+++ b/syfthub-desktop/frontend/src/components/tool-ui/terminal/README.md
@@ -1,0 +1,19 @@
+# Terminal
+
+Implementation for the "terminal" Tool UI surface.
+
+## Files
+
+- public exports: components/tool-ui/terminal/index.tsx
+- serializable schema + parse helpers: components/tool-ui/terminal/schema.ts
+
+## Companion assets
+
+- Docs page: app/docs/terminal/content.mdx
+- Preset payload: lib/presets/terminal.ts
+
+## Quick check
+
+Run this after edits:
+
+pnpm test

--- a/syfthub-desktop/frontend/src/components/tool-ui/terminal/_adapter.tsx
+++ b/syfthub-desktop/frontend/src/components/tool-ui/terminal/_adapter.tsx
@@ -1,0 +1,3 @@
+export { cn } from "@/lib/utils";
+export { Button } from "@/components/ui/button";
+export { Collapsible, CollapsibleTrigger } from "@/components/ui/collapsible";

--- a/syfthub-desktop/frontend/src/components/tool-ui/terminal/index.tsx
+++ b/syfthub-desktop/frontend/src/components/tool-ui/terminal/index.tsx
@@ -1,0 +1,2 @@
+export { Terminal } from "./terminal";
+export type { TerminalProps, SerializableTerminal } from "./schema";

--- a/syfthub-desktop/frontend/src/components/tool-ui/terminal/schema.ts
+++ b/syfthub-desktop/frontend/src/components/tool-ui/terminal/schema.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import { defineToolUiContract } from "../shared/contract";
+import {
+  ToolUIIdSchema,
+  ToolUIReceiptSchema,
+  ToolUIRoleSchema,
+} from "../shared/schema";
+
+export const TerminalPropsSchema = z.object({
+  id: ToolUIIdSchema,
+  role: ToolUIRoleSchema.optional(),
+  receipt: ToolUIReceiptSchema.optional(),
+  command: z.string(),
+  stdout: z.string().optional(),
+  stderr: z.string().optional(),
+  exitCode: z.number().int().min(0),
+  durationMs: z.number().optional(),
+  cwd: z.string().optional(),
+  truncated: z.boolean().optional(),
+  maxCollapsedLines: z.number().min(1).optional(),
+  className: z.string().optional(),
+});
+
+export type TerminalProps = z.infer<typeof TerminalPropsSchema>;
+
+export const SerializableTerminalSchema = TerminalPropsSchema.omit({
+  className: true,
+});
+
+export type SerializableTerminal = z.infer<typeof SerializableTerminalSchema>;
+
+const SerializableTerminalSchemaContract = defineToolUiContract(
+  "Terminal",
+  SerializableTerminalSchema,
+);
+
+export const parseSerializableTerminal: (
+  input: unknown,
+) => SerializableTerminal = SerializableTerminalSchemaContract.parse;
+
+export const safeParseSerializableTerminal: (
+  input: unknown,
+) => SerializableTerminal | null = SerializableTerminalSchemaContract.safeParse;

--- a/syfthub-desktop/frontend/src/components/tool-ui/terminal/terminal.tsx
+++ b/syfthub-desktop/frontend/src/components/tool-ui/terminal/terminal.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import Ansi from "ansi-to-react";
+import {
+  Copy,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Terminal as TerminalIcon,
+} from "lucide-react";
+import type { TerminalProps } from "./schema";
+import { useCopyToClipboard } from "../shared/use-copy-to-clipboard";
+
+import { Button, Collapsible, CollapsibleTrigger } from "./_adapter";
+import { cn } from "./_adapter";
+
+const COPY_ID = "terminal-output";
+
+type TerminalControlledProps = {
+  expanded?: boolean;
+  defaultExpanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
+};
+
+type TerminalRootProps = TerminalProps & TerminalControlledProps;
+
+type TerminalHeaderProps = Pick<
+  TerminalProps,
+  "command" | "cwd" | "exitCode"
+> & {
+  formattedDuration: string | null;
+  hasOutput: boolean;
+  copiedId: string | null;
+  onCopy: () => void;
+};
+
+type TerminalOutputProps = Pick<
+  TerminalProps,
+  "stdout" | "stderr" | "truncated"
+> & {
+  isCollapsed: boolean;
+  shouldCollapse: boolean;
+  lineCount: number;
+  onToggleCollapse: () => void;
+};
+
+function formatDuration(durationMs?: number): string | null {
+  if (durationMs == null) return null;
+  if (durationMs < 1000) return `${Math.round(durationMs)}ms`;
+  return `${(durationMs / 1000).toFixed(1)}s`;
+}
+
+function countOutputLines(output: string): number {
+  const trimmedTrailingNewlines = output.replace(/\n+$/, "");
+  if (!trimmedTrailingNewlines) return 0;
+  return trimmedTrailingNewlines.split("\n").length;
+}
+
+function TerminalHeader({
+  command,
+  cwd,
+  exitCode,
+  formattedDuration,
+  hasOutput,
+  copiedId,
+  onCopy,
+}: TerminalHeaderProps) {
+  return (
+    <div className="bg-card flex items-center justify-between border-b px-4 py-2">
+      <div className="flex items-center gap-2 overflow-hidden">
+        <TerminalIcon className="text-muted-foreground h-4 w-4 shrink-0" />
+        <code className="text-foreground truncate font-mono text-xs">
+          {cwd && <span className="text-muted-foreground">{cwd}$ </span>}
+          {command}
+        </code>
+      </div>
+      <div className="flex items-center gap-3">
+        {formattedDuration && (
+          <span className="text-muted-foreground font-mono text-sm tabular-nums">
+            {formattedDuration}
+          </span>
+        )}
+        <span
+          className={cn(
+            "font-mono text-sm tabular-nums",
+            exitCode === 0
+              ? "text-muted-foreground"
+              : "text-red-600 dark:text-red-400",
+          )}
+        >
+          {exitCode}
+        </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onCopy}
+          disabled={!hasOutput}
+          className="h-7 w-7 p-0"
+          aria-label={
+            !hasOutput
+              ? "No output to copy"
+              : copiedId === COPY_ID
+                ? "Copied"
+                : "Copy output"
+          }
+        >
+          {hasOutput && copiedId === COPY_ID ? (
+            <Check className="h-4 w-4 text-green-700 dark:text-green-400" />
+          ) : (
+            <Copy className="text-muted-foreground h-4 w-4" />
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function TerminalOutput({
+  stdout,
+  stderr,
+  truncated,
+  isCollapsed,
+  shouldCollapse,
+  lineCount,
+  onToggleCollapse,
+}: TerminalOutputProps) {
+  return (
+    <Collapsible open={!isCollapsed}>
+      <div
+        className={cn(
+          "relative font-mono text-sm",
+          isCollapsed && "max-h-[200px] overflow-hidden",
+        )}
+      >
+        <div className="overflow-x-auto p-4">
+          {stdout && (
+            <div className="text-foreground whitespace-pre">
+              <Ansi>{stdout}</Ansi>
+            </div>
+          )}
+          {stderr && (
+            <div className="mt-2 whitespace-pre text-red-500 dark:text-red-400">
+              <Ansi>{stderr}</Ansi>
+            </div>
+          )}
+          {truncated && (
+            <div className="text-muted-foreground mt-2 text-xs italic">
+              Output truncated...
+            </div>
+          )}
+        </div>
+
+        {isCollapsed && (
+          <div className="from-card absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t to-transparent" />
+        )}
+      </div>
+
+      {shouldCollapse && (
+        <CollapsibleTrigger asChild>
+          <Button
+            variant="ghost"
+            onClick={onToggleCollapse}
+            className="text-muted-foreground w-full rounded-none border-t font-normal"
+          >
+            {isCollapsed ? (
+              <>
+                <ChevronDown className="mr-1 size-4" />
+                Show all {lineCount} lines
+              </>
+            ) : (
+              <>
+                <ChevronUp className="mr-1 size-4" />
+                Collapse
+              </>
+            )}
+          </Button>
+        </CollapsibleTrigger>
+      )}
+    </Collapsible>
+  );
+}
+
+function TerminalEmpty() {
+  return (
+    <div className="text-muted-foreground px-4 py-3 font-mono text-sm italic">
+      No output
+    </div>
+  );
+}
+
+function TerminalRoot({
+  id,
+  command,
+  stdout,
+  stderr,
+  exitCode,
+  durationMs,
+  cwd,
+  truncated,
+  maxCollapsedLines,
+  className,
+  expanded,
+  defaultExpanded = false,
+  onExpandedChange,
+}: TerminalRootProps) {
+  const [uncontrolledExpanded, setUncontrolledExpanded] =
+    useState(defaultExpanded);
+  const { copiedId, copy } = useCopyToClipboard();
+
+  const isExpanded = expanded ?? uncontrolledExpanded;
+  const hasOutput = Boolean(stdout || stderr);
+  const fullOutput = [stdout, stderr].filter(Boolean).join("\n");
+  const formattedDuration = formatDuration(durationMs);
+  const lineCount = countOutputLines(fullOutput);
+  const shouldCollapse =
+    maxCollapsedLines !== undefined && lineCount > maxCollapsedLines;
+  const isCollapsed = shouldCollapse && !isExpanded;
+
+  const setExpanded = useCallback(
+    (nextExpanded: boolean) => {
+      if (expanded === undefined) {
+        setUncontrolledExpanded(nextExpanded);
+      }
+      onExpandedChange?.(nextExpanded);
+    },
+    [expanded, onExpandedChange],
+  );
+
+  const handleCopy = useCallback(() => {
+    if (!hasOutput) return;
+    copy(fullOutput, COPY_ID);
+  }, [hasOutput, fullOutput, copy]);
+
+  return (
+    <div
+      className={cn(
+        "@container flex w-full min-w-80 flex-col gap-3",
+        className,
+      )}
+      data-tool-ui-id={id}
+      data-slot="terminal"
+    >
+      <div className="border-border bg-card overflow-hidden rounded-lg border shadow-xs">
+        <TerminalHeader
+          command={command}
+          cwd={cwd}
+          exitCode={exitCode}
+          formattedDuration={formattedDuration}
+          hasOutput={hasOutput}
+          copiedId={copiedId}
+          onCopy={handleCopy}
+        />
+
+        {hasOutput && (
+          <TerminalOutput
+            stdout={stdout}
+            stderr={stderr}
+            truncated={truncated}
+            isCollapsed={isCollapsed}
+            shouldCollapse={shouldCollapse}
+            lineCount={lineCount}
+            onToggleCollapse={() => setExpanded(!isExpanded)}
+          />
+        )}
+
+        {!hasOutput && <TerminalEmpty />}
+      </div>
+    </div>
+  );
+}
+
+type TerminalComponent = typeof TerminalRoot & {
+  Header: typeof TerminalHeader;
+  Output: typeof TerminalOutput;
+  Empty: typeof TerminalEmpty;
+};
+
+export const Terminal = Object.assign(TerminalRoot, {
+  Header: TerminalHeader,
+  Output: TerminalOutput,
+  Empty: TerminalEmpty,
+}) as TerminalComponent;

--- a/syfthub-desktop/frontend/src/hooks/use-agent-workflow.ts
+++ b/syfthub-desktop/frontend/src/hooks/use-agent-workflow.ts
@@ -128,6 +128,15 @@ export function useAgentWorkflow({ endpointPath, endpointName }: UseAgentWorkflo
   // a credential and restarts the session with it attached.
   const [pendingPayment, setPendingPayment] = useState<PendingPayment | null>(null);
 
+  // expiringAttachments is populated by the host's attachments.expiring event
+  // emitted just before a session swap or stop discards the in-memory cache
+  // of agent-emitted attachments. The chat UI renders a non-modal toast with
+  // a "Save now?" CTA so the user can rescue unsaved files before they're
+  // gone. Cleared via dismissExpiring() on user action.
+  const [expiringAttachments, setExpiringAttachments] = useState<
+    Array<{ file_id: string; name: string; size_bytes: number; mime: string }>
+  >([]);
+
   // suppressNextTerminalRef hides the session.{completed,cancelled,failed}
   // event that the producer emits immediately after agent.payment_required.
   // From the user's perspective, the payment-and-retry handshake is a single
@@ -303,6 +312,28 @@ export function useAgentWorkflow({ endpointPath, endpointName }: UseAgentWorkflo
             data: { ...data, uri: fileId ? `attachment://${fileId}` : undefined },
             timestamp: Date.now(),
           }]);
+          break;
+        }
+
+        case 'attachments.expiring': {
+          // The host is about to clear its in-memory cache of agent-emitted
+          // attachments (session swap, stop, or end). Surface the list so
+          // the UI can offer a last-chance "Save now?" toast.
+          const items = Array.isArray(data.attachments) ? data.attachments : [];
+          const normalized = items
+            .map((it: unknown) => {
+              const o = it as Record<string, unknown>;
+              return {
+                file_id: String(o.file_id ?? ''),
+                name: String(o.name ?? ''),
+                size_bytes: Number(o.size_bytes ?? 0),
+                mime: String(o.mime ?? ''),
+              };
+            })
+            .filter(x => x.file_id);
+          if (normalized.length > 0) {
+            setExpiringAttachments(normalized);
+          }
           break;
         }
 
@@ -787,6 +818,10 @@ export function useAgentWorkflow({ endpointPath, endpointName }: UseAgentWorkflo
     });
   }, []);
 
+  const dismissExpiring = useCallback(() => {
+    setExpiringAttachments([]);
+  }, []);
+
   return {
     entries,
     isRunning,
@@ -798,5 +833,7 @@ export function useAgentWorkflow({ endpointPath, endpointName }: UseAgentWorkflo
     clearEntries,
     pendingPayment,
     dismissPayment,
+    expiringAttachments,
+    dismissExpiring,
   };
 }

--- a/syfthub-desktop/frontend/src/hooks/use-attachments.ts
+++ b/syfthub-desktop/frontend/src/hooks/use-attachments.ts
@@ -1,33 +1,84 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   AttachToActiveSession,
-  DownloadActiveSessionAttachment,
+  SaveAttachmentAs,
   AttachmentInlineBytes,
 } from '../../wailsjs/go/main/App';
+import { EventsOn } from '../../wailsjs/runtime/runtime';
 
 // AttachmentSummary mirrors the Go struct returned by AttachToActiveSession.
 // The bytes live on the host's side of the tunnel — no local_path exists on
-// the client.
+// the client. `delivered` flips true when the host's user.attachment ack
+// event arrives, so the chip can show a "✓" once the file is materialized
+// on the host.
 export interface AttachmentSummary {
   file_id: string;
   name: string;
   mime: string;
   size_bytes: number;
   sha256: string;
+  delivered?: boolean;
+}
+
+// Per-file inbound download progress, populated from attachment.progress events.
+export interface AttachmentProgress {
+  downloaded: number;
+  total: number;
 }
 
 /**
  * useAttachments tracks the list of files the user has staged for the
- * currently-running agent session. Each staged file is sent to the agent via
- * the hub WebSocket (inline) or aggregator HTTP relay (object-store) — the
- * AttachToActiveSession Wails binding picks the transport based on size.
+ * currently-running agent session AND the inbound-download progress map.
+ *
+ * Flow:
+ *  1. User drops a file before a session is live → stagePath(hostPath); chip
+ *     renders with a "queued" badge.
+ *  2. Session starts → flushPending() uploads each queued path via the Wails
+ *     binding, which streams the bytes to the host. Files ≤ 64 KiB ride
+ *     inline; larger files spill to NATS Object Store via the SDK.
+ *  3. Host emits user.attachment ack → chip flips to delivered ✓.
+ *  4. Saving an agent-emitted attachment via SaveAttachmentAs streams via the
+ *     SDK and emits attachment.progress events, which populate the progress
+ *     map keyed by file_id.
  *
  * See docs/architecture/attachments.md.
  */
 export function useAttachments() {
   const [staged, setStaged] = useState<AttachmentSummary[]>([]);
+  // pending holds host-path strings dropped/picked before a session was live.
+  // flushPending() promotes them to staged once a session starts.
+  const [pending, setPending] = useState<string[]>([]);
+  const [progress, setProgress] = useState<Record<string, AttachmentProgress>>({});
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Subscribe to the host-emitted attachment events.
+  useEffect(() => {
+    const unsubscribe = EventsOn(
+      'agent:event',
+      (event: { type: string; data?: Record<string, unknown> }) => {
+        if (event.type === 'user.attachment') {
+          const fileId = String(event.data?.file_id ?? '');
+          if (!fileId) return;
+          setStaged(prev =>
+            prev.map(s => (s.file_id === fileId ? { ...s, delivered: true } : s)),
+          );
+        } else if (event.type === 'attachment.progress') {
+          const fileId = String(event.data?.file_id ?? '');
+          if (!fileId) return;
+          const downloaded = Number(event.data?.downloaded ?? 0);
+          const total = Number(event.data?.total ?? 0);
+          setProgress(prev => ({
+            ...prev,
+            [fileId]: { downloaded, total },
+          }));
+        }
+      },
+    );
+    return () => {
+      unsubscribe();
+    };
+  }, []);
 
   const attach = useCallback(async (hostPath: string) => {
     setBusy(true);
@@ -45,19 +96,49 @@ export function useAttachments() {
     }
   }, []);
 
-  const download = useCallback(async (fileId: string, destPath: string) => {
-    setBusy(true);
-    setError(null);
-    try {
-      await DownloadActiveSessionAttachment(fileId, destPath);
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      setError(msg);
-      throw e;
-    } finally {
-      setBusy(false);
-    }
+  // stagePath queues a host path for upload after the session starts. The
+  // caller is responsible for invoking flushPending() once the session is
+  // live (typically via a useEffect on isRunning).
+  const stagePath = useCallback((hostPath: string) => {
+    setPending(prev => [...prev, hostPath]);
   }, []);
+
+  // flushPending promotes every queued path to a real attachment by calling
+  // attach() for each. Per-path failures are recorded in `error` but do not
+  // abort the loop. Returns the count successfully uploaded.
+  const flushPending = useCallback(async () => {
+    let snapshot: string[] = [];
+    setPending(prev => {
+      snapshot = prev;
+      return [];
+    });
+    if (snapshot.length === 0) return 0;
+    let count = 0;
+    for (const p of snapshot) {
+      try {
+        await attach(p);
+        count++;
+      } catch {
+        /* attach() records the error; keep iterating */
+      }
+    }
+    return count;
+  }, [attach]);
+
+  const removePending = useCallback((hostPath: string) => {
+    setPending(prev => prev.filter(p => p !== hostPath));
+  }, []);
+
+  // saveAs opens the native save-as dialog and writes the attachment to the
+  // chosen path. Returns the absolute destination on success, null on user
+  // cancel, throws on failure.
+  const saveAs = useCallback(
+    async (fileId: string, suggestedName: string): Promise<string | null> => {
+      const dest = await SaveAttachmentAs(fileId, suggestedName);
+      return dest || null;
+    },
+    [],
+  );
 
   const inlineBytes = useCallback(async (fileId: string, maxBytes = 0) => {
     return AttachmentInlineBytes(fileId, maxBytes);
@@ -69,7 +150,22 @@ export function useAttachments() {
 
   const clear = useCallback(() => {
     setStaged([]);
+    setProgress({});
   }, []);
 
-  return { staged, attach, download, inlineBytes, remove, clear, busy, error };
+  return {
+    staged,
+    pending,
+    progress,
+    attach,
+    stagePath,
+    flushPending,
+    removePending,
+    saveAs,
+    inlineBytes,
+    remove,
+    clear,
+    busy,
+    error,
+  };
 }

--- a/syfthub-desktop/frontend/src/lib/tool-display.ts
+++ b/syfthub-desktop/frontend/src/lib/tool-display.ts
@@ -1,0 +1,351 @@
+/**
+ * Tool display dispatch — maps an agent.tool_call (+ optional agent.tool_result)
+ * pair onto a tagged-union viewmodel. The chat surface renders each kind with a
+ * dedicated component; `generic` is the catch-all collapsible from prompt-kit.
+ *
+ * The protocol stays minimal: every kind is derived from the existing
+ * { tool_name, arguments, result, status } fields plus an optional producer hint
+ * (`agent.tool_call.display`). When the hint is absent, KNOWN_TOOL_KINDS maps
+ * well-known names (Claude Code's Bash/Read/Edit/Grep/Glob/WebFetch, basic-agent's
+ * run_command/read_file/write_file/fetch_url) onto a kind so third-party agents
+ * light up without producer changes.
+ */
+
+import type { AgentEntry } from '@/hooks/use-agent-workflow';
+
+// ── Tagged-union viewmodel ───────────────────────────────────────────────────
+
+export type ToolStatus = 'running' | 'success' | 'error';
+
+interface ToolViewBase {
+  toolCallId?: string;
+  toolName: string;
+  status: ToolStatus;
+  durationMs?: number;
+  errorText?: string;
+}
+
+export type ToolView =
+  | (ToolViewBase & {
+      kind: 'terminal';
+      command: string;
+      stdout: string;
+      stderr: string;
+      cwd?: string;
+      exitCode: number;
+    })
+  | (ToolViewBase & {
+      kind: 'code';
+      // The path/operation the agent acted on (read or wrote).
+      path: string;
+      operation: 'read' | 'write';
+      content: string;
+      language?: string;
+    })
+  | (ToolViewBase & {
+      kind: 'diff';
+      path: string;
+      before: string;
+      after: string;
+    })
+  | (ToolViewBase & {
+      kind: 'web';
+      url: string;
+      summary: string;
+    })
+  | (ToolViewBase & {
+      kind: 'generic';
+      input?: Record<string, unknown>;
+      output?: unknown;
+    });
+
+export type ToolKind = ToolView['kind'];
+
+// ── Known-tool lookup ────────────────────────────────────────────────────────
+
+/** Producer-agnostic name → kind table. The lookup is the fallback path when
+ *  the producer did not set agent.tool_call.display. Names listed here are the
+ *  exact strings the relevant agents emit. */
+const KNOWN_TOOL_KINDS: Record<string, ToolKind> = {
+  // basic-agent (~/.config/syfthub/endpoints/basic-agent/runner.py)
+  run_command: 'terminal',
+  read_file:   'code',
+  write_file:  'code',
+  fetch_url:   'web',
+  // Claude Code (verbatim from claude --output-format stream-json)
+  Bash:        'terminal',
+  Grep:        'terminal',
+  Glob:        'terminal',
+  Read:        'code',
+  Write:       'code',
+  Edit:        'diff',
+  WebFetch:    'web',
+};
+
+export function resolveToolKind(toolName: string, displayHint?: string): ToolKind {
+  if (displayHint && isHintableKind(displayHint)) return displayHint;
+  return KNOWN_TOOL_KINDS[toolName] ?? 'generic';
+}
+
+/** Hintable kinds = every kind except 'generic'. A producer that emits
+ *  display='generic' should not force the JSON-dump fallback when the tool
+ *  name is recognised — fall through to the lookup table instead. */
+type HintableKind = Exclude<ToolKind, 'generic'>;
+
+function isHintableKind(value: string): value is HintableKind {
+  return value === 'terminal' || value === 'code' || value === 'diff' || value === 'web';
+}
+
+// ── Pairing ──────────────────────────────────────────────────────────────────
+
+/**
+ * Pair each tool_call entry with its matching tool_result. Hybrid pairing:
+ *   1. id-based: when both call and result carry a non-empty tool_call_id,
+ *      match by id. This handles agents that emit results out of order or
+ *      interleaved with new calls (e.g. parallel tool use in a single
+ *      assistant turn) — Claude Code's primary mode.
+ *   2. oldest-unpaired fallback: when a result has no usable id (or its id
+ *      doesn't match any call), bind it to the earliest unpaired call. This
+ *      restores the old nearest-following semantics for producers that ship
+ *      empty ids, partial streams, or non-claude tools.
+ *
+ * Returns:
+ *   - callToResult: tool_call entry index → tool_result entry index
+ *   - consumedResults: tool_result indices that are owned by a call (skip standalone)
+ */
+export function pairToolEntries(
+  entries: AgentEntry[],
+): { callToResult: Map<number, number>; consumedResults: Set<number> } {
+  const callToResult = new Map<number, number>();
+  const consumedResults = new Set<number>();
+  const callIdxById = new Map<string, number>();
+  const pairedCalls = new Set<number>();
+  const callOrder: number[] = [];
+
+  const getId = (e: AgentEntry): string => {
+    const data = (e.data ?? {}) as Record<string, unknown>;
+    return typeof data.tool_call_id === 'string' ? data.tool_call_id : '';
+  };
+
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    const id = getId(e);
+    if (e.kind === 'tool_call') {
+      callOrder.push(i);
+      if (id) callIdxById.set(id, i);
+      continue;
+    }
+    if (e.kind !== 'tool_result') continue;
+    // 1. id-based match
+    let matched: number | undefined;
+    if (id) {
+      const byId = callIdxById.get(id);
+      if (byId !== undefined && !pairedCalls.has(byId)) matched = byId;
+    }
+    // 2. oldest-unpaired fallback (works for empty-id streams)
+    if (matched === undefined) {
+      for (const idx of callOrder) {
+        if (!pairedCalls.has(idx)) { matched = idx; break; }
+      }
+    }
+    if (matched !== undefined) {
+      callToResult.set(matched, i);
+      pairedCalls.add(matched);
+      consumedResults.add(i);
+    }
+  }
+
+  return { callToResult, consumedResults };
+}
+
+// ── ViewModel construction ───────────────────────────────────────────────────
+
+/**
+ * Session lifecycle as the consumer cares about it for tool-view rendering.
+ *   - 'running'     → session is still streaming events
+ *   - 'completed'   → session.completed arrived; any unpaired call is treated
+ *                     as silently successful (the result event was lost or
+ *                     batched after the terminal event; marking it as failed
+ *                     would lie about the agent's actual outcome)
+ *   - 'interrupted' → session.cancelled / session.failed (or the user stopped
+ *                     the run); unpaired calls render as 'Tool call interrupted'
+ */
+export type SessionPhase = 'running' | 'completed' | 'interrupted';
+
+/**
+ * Build a ToolView from a paired (call, result) entry. When `resultEntry` is
+ * absent, `sessionPhase` decides how to render the call — see SessionPhase.
+ */
+export function buildToolView(
+  callEntry: AgentEntry,
+  resultEntry: AgentEntry | undefined,
+  sessionPhase: SessionPhase,
+): ToolView {
+  const call = (callEntry.data ?? {}) as Record<string, unknown>;
+  const toolName = String(call.tool_name ?? 'tool');
+  const args = (call.arguments ?? {}) as Record<string, unknown>;
+  const toolCallId = typeof call.tool_call_id === 'string' ? call.tool_call_id : undefined;
+  const displayHint = typeof call.display === 'string' ? call.display : undefined;
+  const kind = resolveToolKind(toolName, displayHint);
+
+  // Status truth table:
+  //   resultEntry present       →  derive from result.status (defaults success)
+  //   no result, phase=running  →  'running'
+  //   no result, phase=completed→  'success' (no result event, but the agent
+  //                                  ended cleanly — assume the tool finished)
+  //   no result, phase=interrupted → 'error' ('Tool call interrupted')
+  const status: ToolStatus = resultEntry
+    ? (((resultEntry.data ?? {}) as Record<string, unknown>).status === 'error' ? 'error' : 'success')
+    : sessionPhase === 'running'
+      ? 'running'
+      : sessionPhase === 'interrupted'
+        ? 'error'
+        : 'success';
+
+  const result = resultEntry
+    ? ((resultEntry.data ?? {}) as Record<string, unknown>)
+    : undefined;
+  const resultValue = result?.result;
+  const resultText = resultValue == null
+    ? ''
+    : typeof resultValue === 'string' ? resultValue : safeStringify(resultValue);
+  // Use `||` (not `??`) so an empty `error` field or empty result text falls
+  // through to the 'Tool error' / 'Tool call interrupted' placeholder.
+  const errorText = status === 'error'
+    ? (resultEntry
+        ? (stringOrEmpty(result?.error) || resultText || 'Tool error')
+        : 'Tool call interrupted')
+    : undefined;
+  const durationMs = typeof result?.duration_ms === 'number' ? result.duration_ms : undefined;
+
+  const base: ToolViewBase = { toolCallId, toolName, status, durationMs, errorText };
+
+  switch (kind) {
+    case 'terminal':
+      return {
+        ...base,
+        kind: 'terminal',
+        command: deriveTerminalCommand(toolName, args),
+        stdout: status === 'error' ? '' : resultText,
+        stderr: status === 'error' ? (errorText ?? resultText) : '',
+        cwd: stringArg(args, 'cwd'),
+        exitCode: status === 'error' ? 1 : 0,
+      };
+
+    case 'code': {
+      const path = stringArg(args, 'path') || stringArg(args, 'file_path') || '';
+      // Detect write semantics by the presence of a `content`/`text` arg
+      // rather than a hard-coded tool-name allowlist. Any producer-emitted
+      // code-display tool that writes a body will pass that body as an arg.
+      const writeBody = stringArg(args, 'content') || stringArg(args, 'text');
+      const operation: 'read' | 'write' = writeBody ? 'write' : 'read';
+      // For writes, surface the body the agent intended to write;
+      // for reads, the file body comes back in the result.
+      const content = operation === 'write' ? writeBody : resultText;
+      return {
+        ...base,
+        kind: 'code',
+        path,
+        operation,
+        content,
+        language: inferLanguageFromPath(path),
+      };
+    }
+
+    case 'diff': {
+      const path = stringArg(args, 'path') || stringArg(args, 'file_path') || '';
+      const before = stringArg(args, 'old_string');
+      const after = stringArg(args, 'new_string');
+      return { ...base, kind: 'diff', path, before, after };
+    }
+
+    case 'web': {
+      const url = stringArg(args, 'url');
+      return { ...base, kind: 'web', url, summary: resultText };
+    }
+
+    default:
+      return {
+        ...base,
+        kind: 'generic',
+        input: Object.keys(args).length > 0 ? args : undefined,
+        output: result == null ? undefined
+          : typeof resultValue === 'string'
+            ? { result: resultValue }
+            : (resultValue as Record<string, unknown> | undefined),
+      };
+  }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function stringArg(args: Record<string, unknown>, key: string): string {
+  const v = args[key];
+  return typeof v === 'string' ? v : '';
+}
+
+/** Coerce a value to a string, but return '' for non-string / null /
+ *  undefined inputs so callers can use `||` to fall through to a placeholder. */
+function stringOrEmpty(v: unknown): string {
+  if (typeof v === 'string') return v;
+  if (v == null) return '';
+  return safeStringify(v);
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Synthesize a friendly command line for tools that don't carry one literally.
+ * Bash/run_command emit the command verbatim; Grep/Glob need shaping so the
+ * Terminal header reads like a real shell prompt.
+ */
+function deriveTerminalCommand(toolName: string, args: Record<string, unknown>): string {
+  const raw = stringArg(args, 'command');
+  if (raw) return raw;
+
+  if (toolName === 'Grep') {
+    const pattern = stringArg(args, 'pattern');
+    const path = stringArg(args, 'path') || '.';
+    const glob = stringArg(args, 'glob');
+    const type = stringArg(args, 'type');
+    const flags = [
+      type && `--type=${type}`,
+      glob && `--glob="${glob}"`,
+    ].filter(Boolean).join(' ');
+    return `rg ${flags ? flags + ' ' : ''}"${pattern}" ${path}`.trim();
+  }
+
+  if (toolName === 'Glob') {
+    const pattern = stringArg(args, 'pattern');
+    const path = stringArg(args, 'path') || '.';
+    return `find ${path} -name "${pattern}"`;
+  }
+
+  // Last-resort: render the tool name + a compact arg list. Better than a
+  // blank header, and the user can still see the args.
+  const argSummary = Object.entries(args)
+    .map(([k, v]) => `${k}=${typeof v === 'string' ? v : safeStringify(v)}`)
+    .join(' ');
+  return argSummary ? `${toolName} ${argSummary}` : toolName;
+}
+
+const LANG_BY_EXT: Record<string, string> = {
+  ts: 'typescript', tsx: 'tsx', js: 'javascript', jsx: 'jsx',
+  py: 'python', go: 'go', rs: 'rust', java: 'java', kt: 'kotlin',
+  rb: 'ruby', sh: 'bash', bash: 'bash', zsh: 'bash',
+  json: 'json', yaml: 'yaml', yml: 'yaml', toml: 'toml',
+  md: 'markdown', html: 'html', css: 'css', scss: 'scss',
+  sql: 'sql', c: 'c', cpp: 'cpp', h: 'c', hpp: 'cpp',
+};
+
+function inferLanguageFromPath(path: string): string | undefined {
+  const m = /\.([a-zA-Z0-9]+)$/.exec(path);
+  if (!m) return undefined;
+  return LANG_BY_EXT[m[1].toLowerCase()];
+}

--- a/syfthub-desktop/frontend/wailsjs/go/main/App.d.ts
+++ b/syfthub-desktop/frontend/wailsjs/go/main/App.d.ts
@@ -46,7 +46,7 @@ export function DeletePolicyFile(arg1:string,arg2:string):Promise<void>;
 
 export function DeleteSentReview(arg1:string):Promise<void>;
 
-export function DownloadActiveSessionAttachment(arg1:string,arg2:string):Promise<void>;
+export function SaveAttachmentAs(arg1:string,arg2:string):Promise<string>;
 
 export function DownloadUpdate():Promise<void>;
 

--- a/syfthub-desktop/frontend/wailsjs/go/main/App.js
+++ b/syfthub-desktop/frontend/wailsjs/go/main/App.js
@@ -86,8 +86,8 @@ export function DeleteSentReview(arg1) {
   return window['go']['main']['App']['DeleteSentReview'](arg1);
 }
 
-export function DownloadActiveSessionAttachment(arg1, arg2) {
-  return window['go']['main']['App']['DownloadActiveSessionAttachment'](arg1, arg2);
+export function SaveAttachmentAs(arg1, arg2) {
+  return window['go']['main']['App']['SaveAttachmentAs'](arg1, arg2);
 }
 
 export function DownloadUpdate() {

--- a/syfthub-desktop/internal/app/app.go
+++ b/syfthub-desktop/internal/app/app.go
@@ -495,12 +495,14 @@ func (a *App) setupNATSTransport(ctx context.Context, cfg *syfthubapi.Config) (s
 	}
 
 	// Build the outbound agent dialer over the same connection, reusing the
-	// host's X25519 identity key — the desktop is a symmetric peer.
+	// host's X25519 identity key — the desktop is a symmetric peer. Borrow
+	// the host transport's JetStream Object Store handle so this client can
+	// send and receive object_store-tier attachments (large files).
 	dialer, err := transport.NewAgentDialer(natsConn, hostTransport.PrivateKey(), a.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create agent dialer: %w", err)
 	}
-	a.agentDialer = dialer
+	a.agentDialer = dialer.WithAttachmentStore(hostTransport)
 	// Stash the privkey so the manual-review publisher can derive resolution
 	// ciphers without re-reading the on-disk key file.
 	a.hostIdentityKey = hostTransport.PrivateKey()


### PR DESCRIPTION
## Summary

Closes the seven gaps identified in the desktop attachment audit. The direct-P2P agent path now supports **object-store-tier (large-file) attachments on the client side** in both directions, a **2 GiB hard cap**, **delivery acks**, **pre-session staging**, **streaming progress events**, a **save-as dialog binding**, and an **expiring-attachments toast** for last-chance saves.

Built on top of the local `desktop-app` HEAD (`e88a167`). Two of the five commits are isolated pieces produced in parallel by background agents and cherry-picked into the branch (see commit list).

## Commit-by-commit

| # | SHA | What |
|---|---|---|
| 1 | `16794d6` | **P0-prereq + P0a + P0b + P1a** — `AgentDialer` mints + ships `session_attachment_key`; `AgentDialer.WithAttachmentStore(transport)` plumbs the object store; client `SendAttachment` spills to `ObjectStoreUploader` past 64 KiB; client `DownloadAttachment(info, w, opts...)` real impl via new `ObjectStoreDownloader.DownloadStream`; `agenttypes.AttachmentEvent` gains the missing `BaseNonceB64` field; `syfthubapi.MaxAttachmentBytes = 2 GiB`; `AttachToActiveSession` `os.Stat`s + streams from disk. New tests for key minting. |
| 2 | `f918898` | **P2a-Go + P2b-Go** — `transport.WithProgress` functional option threaded into downloader; desktop `SaveAgentAttachment` / `SaveAttachmentAs` emit throttled `attachment.progress` Wails events. `DownloadActiveSessionAttachment` removed; replaced by `SaveAttachmentAs(fileID, suggestedName)` that opens `runtime.SaveFileDialog` — destination paths can only come from an OS gesture. |
| 3 | `4c7a316` | **P1b-FE + P1c + P2a-FE + P2b-FE + P2c-FE** — delivery ✓ chip glyph; pre-session drop staging + queued banner + auto-flush on `session.started`; native save-as button; progress bar / percentage in `AttachmentChip`; bottom-right expiring-attachments toast in `ChatView`. Wails bindings + `ChatWorkflowProvider` types updated. |
| 4 | `fcf1962` | **P2c-Go** (parallel agent — `feat/desktop-attachments-expiring-event`) — `syfthub-desktop/agent_operations.go` emits `attachments.expiring` event before session-swap, stop, and natural-termination cache clears. |
| 5 | `40186c6` | **P1b-SDK** (parallel agent — `feat/user-attachment-ack`) — host `handleUserAttachment` emits `user.attachment` accept-ack event; `agenttypes.UserAttachmentEvent` typed decode added. Integration test asserts the ack. |

## Gap → fix matrix

| Gap (from audit) | Fix |
|---|---|
| P0 — Object-store on client side is a stub | Commit 1 — real impl using existing `ObjectStoreDownloader` + new `DownloadStream` |
| P0 — Client-side upload is also inline-only | Commit 1 — `SendAttachment` spills via `ObjectStoreUploader` |
| P1 — `AttachToActiveSession` reads whole file into RAM | Commit 1 — `os.Stat` size cap + `os.Open` stream |
| P1 — No `user.attachment` accept-ack | Commit 5 — host emits, frontend (Commit 3) flips chip to ✓ |
| P1 — No buffering across "no active session" boundary | Commit 3 — `useAttachments.pending` + `flushPending` on `isRunning` rising edge |
| P2 — Path-traversal surface in download binding | Commit 2 — `DownloadActiveSessionAttachment` removed; replaced by dialog-gated `SaveAttachmentAs` |
| P2 — No progress reporting on receive | Commit 2 (Go) + Commit 3 (UI) — `attachment.progress` events + chip progress bar |
| P2 — Cache RAM-only / silent loss | Commits 4 + 3 — `attachments.expiring` event + "Save all to Downloads" toast (intentional non-persistence; documented choice) |
| P2 — Dead `EventTypeUserAttachment` constant | Subsumed by Commit 5 — constant is now load-bearing |

## Test plan

- [x] `go test ./sdk/golang/...` — all green (incl. new `TestDialMintsSessionAttachmentKey`, `TestDialDoesNotMintKeyWithoutAttachmentCapability`, `TestHandleUserAttachmentEmitsAck`)
- [x] `go test ./cli/...` — green
- [x] `go test ./syfthub-desktop/...` — green (incl. the renamed `TestSaveAgentAttachmentWithoutSessionReturnsError`)
- [x] `npx tsc --noEmit` in `syfthub-desktop/frontend/` — clean
- [ ] Manual smoke: small inline attachment (≤ 64 KiB) round-trip
- [ ] Manual smoke: large (> 64 KiB) attachment round-trip — verify object-store buckets created, decryption succeeds, progress bar animates
- [ ] Manual smoke: drop a file before starting a chat → queued banner shows → starting chat auto-flushes
- [ ] Manual smoke: agent emits two attachments, user only saves one, starts new chat → expiring toast surfaces with "1 unsaved" CTA

## Notes / things to watch

- Wails bindings (`App.d.ts`, `App.js`) were hand-edited rather than regenerated via the Wails CLI (no Wails toolchain in the dev environment) — confirm a real Wails build agrees.
- `ObjectStoreUploader.Upload` / `DownloadAndMaterialize` still buffer ciphertext + plaintext in `bytes.Buffer` internally — fine for tens of MiB, would need true chunk-streaming to safely use 2 GiB. Documented in the audit; not in scope for this PR.
- ESLint 9 in the project has no `eslint.config.js` (pre-existing); only TS check was run.
- GitNexus index will need refresh after merge — that's a tooling/cache concern, not a code one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)