### PR TITLE
Streamline collective admin: unified Pending tab + searchable batch invite

### DIFF
--- a/components/frontend/src/components/collectives/invite-combobox.tsx
+++ b/components/frontend/src/components/collectives/invite-combobox.tsx
@@ -1,0 +1,419 @@
+/**
+ * InviteCombobox
+ *
+ * A two-phase typeahead for picking endpoints to invite into a collective,
+ * mirroring the chat `@owner/slug` mention flow: type a name, get suggestions
+ * you can Tab/Enter to complete.
+ *
+ * - Owner phase: type to filter owners; selecting one drills into their
+ *   endpoints (the input shows an `@owner /` token prefix).
+ * - Endpoint phase: a pinned "All data sources from @owner" row stages every
+ *   joinable endpoint at once (the `owner/*` action); below it, the owner's
+ *   individual data-source endpoints.
+ *
+ * Only `data_source` / `model_data_source` endpoints are ever surfaced, mirroring
+ * the backend `_require_joinable_endpoint` guard. Selection is delegated to the
+ * parent, which stages picks as removable chips.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import type { OwnerInfo } from '@/lib/mention-utils';
+import type { ChatSource } from '@/lib/types';
+
+import { useQuery } from '@tanstack/react-query';
+import Check from 'lucide-react/dist/esm/icons/check';
+import Database from 'lucide-react/dist/esm/icons/database';
+import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
+import Search from 'lucide-react/dist/esm/icons/search';
+import User from 'lucide-react/dist/esm/icons/user';
+import Users from 'lucide-react/dist/esm/icons/users';
+import X from 'lucide-react/dist/esm/icons/x';
+
+import { useEndpointsByOwner } from '@/hooks/use-endpoint-queries';
+import { isJoinableEndpointType } from '@/lib/collectives-api';
+import { getPublicEndpointOwners } from '@/lib/endpoint-utils';
+import { filterEndpoints, filterOwners } from '@/lib/mention-utils';
+import { cn } from '@/lib/utils';
+
+/** A single endpoint the user chose to invite. */
+export interface InviteEndpointOption {
+  owner: string;
+  slug: string;
+  name: string;
+}
+
+interface InviteComboboxProps {
+  /** Stage a single endpoint. */
+  onSelectEndpoint: (option: InviteEndpointOption) => void;
+  /** Stage every joinable endpoint of an owner (the `owner/*` action). */
+  onSelectAll: (owner: string, endpoints: { slug: string; name: string }[]) => void;
+  /** `owner/slug` keys already staged — rendered as added and not re-addable. */
+  stagedKeys: ReadonlySet<string>;
+  /** Owners already staged via an all-* chip — their rows are shown as covered. */
+  stagedAllOwners: ReadonlySet<string>;
+}
+
+type Row =
+  | { type: 'owner'; owner: OwnerInfo }
+  | { type: 'all'; owner: string; count: number; staged: boolean }
+  | { type: 'endpoint'; endpoint: ChatSource; itemKey: string; staged: boolean };
+
+export function InviteCombobox({
+  onSelectEndpoint,
+  onSelectAll,
+  stagedKeys,
+  stagedAllOwners
+}: Readonly<InviteComboboxProps>) {
+  const [selectedOwner, setSelectedOwner] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+
+  const containerReference = useRef<HTMLDivElement>(null);
+  const inputReference = useRef<HTMLInputElement>(null);
+  const listReference = useRef<HTMLUListElement>(null);
+  // True when the highlight last moved via keyboard, so we only auto-scroll for
+  // arrow-key navigation — not when the mouse hovers a row.
+  const keyboardNavReference = useRef(false);
+
+  const phase: 'owner' | 'endpoint' = selectedOwner ? 'endpoint' : 'owner';
+
+  const { data: owners = [], isLoading: ownersLoading } = useQuery({
+    queryKey: ['public-endpoint-owners'],
+    queryFn: getPublicEndpointOwners,
+    staleTime: 5 * 60 * 1000
+  });
+
+  const { data: ownerEndpoints = [], isFetching: endpointsLoading } = useEndpointsByOwner(
+    selectedOwner ?? undefined
+  );
+
+  const joinable = useMemo(
+    () => ownerEndpoints.filter((endpoint) => isJoinableEndpointType(endpoint.type)),
+    [ownerEndpoints]
+  );
+
+  const filteredOwners = useMemo(
+    () => (phase === 'owner' ? filterOwners(owners, query, 8) : []),
+    [phase, owners, query]
+  );
+  const filteredEndpoints = useMemo(
+    () => (phase === 'endpoint' ? filterEndpoints(joinable, query, 8) : []),
+    [phase, joinable, query]
+  );
+
+  const rows: Row[] = useMemo(() => {
+    if (phase === 'owner') {
+      return filteredOwners.map((owner) => ({ type: 'owner', owner }) as Row);
+    }
+    const owner = selectedOwner ?? '';
+    const list: Row[] = [];
+    if (joinable.length > 0) {
+      list.push({ type: 'all', owner, count: joinable.length, staged: stagedAllOwners.has(owner) });
+    }
+    for (const endpoint of filteredEndpoints) {
+      const itemKey = `${owner}/${endpoint.slug}`;
+      list.push({
+        type: 'endpoint',
+        endpoint,
+        itemKey,
+        staged: stagedAllOwners.has(owner) || stagedKeys.has(itemKey)
+      });
+    }
+    return list;
+  }, [
+    phase,
+    filteredOwners,
+    filteredEndpoints,
+    joinable,
+    selectedOwner,
+    stagedKeys,
+    stagedAllOwners
+  ]);
+
+  const loading = phase === 'owner' ? ownersLoading : endpointsLoading;
+
+  // Reset the highlight whenever the visible list changes.
+  useEffect(() => {
+    setHighlightedIndex(0);
+  }, [phase, query, rows.length]);
+
+  // Keep the keyboard-highlighted row scrolled into view (skip mouse hover, which
+  // would trigger a layout-reading scrollIntoView on every pointer move).
+  useEffect(() => {
+    if (!keyboardNavReference.current) return;
+    const node = listReference.current?.children[highlightedIndex] as HTMLElement | undefined;
+    node?.scrollIntoView({ block: 'nearest' });
+  }, [highlightedIndex]);
+
+  // Close the dropdown on an outside click.
+  useEffect(() => {
+    function onDocumentMouseDown(event: MouseEvent) {
+      if (
+        containerReference.current &&
+        !containerReference.current.contains(event.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', onDocumentMouseDown);
+    return () => {
+      document.removeEventListener('mousedown', onDocumentMouseDown);
+    };
+  }, []);
+
+  const focusInput = () => {
+    setTimeout(() => inputReference.current?.focus(), 0);
+  };
+
+  const clearOwner = () => {
+    setSelectedOwner(null);
+    setQuery('');
+    focusInput();
+  };
+
+  const chooseRow = (row: Row) => {
+    if (row.type === 'owner') {
+      setSelectedOwner(row.owner.username);
+      setQuery('');
+      setOpen(true);
+      focusInput();
+      return;
+    }
+    if (row.type === 'all') {
+      if (row.staged) return;
+      onSelectAll(
+        row.owner,
+        joinable.map((endpoint) => ({ slug: endpoint.slug, name: endpoint.name }))
+      );
+      // Everything from this owner is staged — drop back to owner phase so the
+      // user can move on to another owner.
+      clearOwner();
+      return;
+    }
+    if (row.staged) return;
+    onSelectEndpoint({
+      owner: selectedOwner ?? row.endpoint.owner_username ?? '',
+      slug: row.endpoint.slug,
+      name: row.endpoint.name
+    });
+    // Stay in endpoint phase so several picks from the same owner are quick.
+    setQuery('');
+    focusInput();
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    switch (event.key) {
+      case 'ArrowDown': {
+        event.preventDefault();
+        setOpen(true);
+        keyboardNavReference.current = true;
+        setHighlightedIndex((index) => Math.min(index + 1, rows.length - 1));
+
+        break;
+      }
+      case 'ArrowUp': {
+        event.preventDefault();
+        keyboardNavReference.current = true;
+        setHighlightedIndex((index) => Math.max(index - 1, 0));
+
+        break;
+      }
+      case 'Enter':
+      case 'Tab': {
+        const row = rows[highlightedIndex];
+        if (open && row) {
+          event.preventDefault();
+          chooseRow(row);
+        }
+
+        break;
+      }
+      default: {
+        if (event.key === 'Backspace' && query === '' && selectedOwner) {
+          event.preventDefault();
+          clearOwner();
+        } else if (event.key === 'Escape' && open) {
+          event.preventDefault();
+          setOpen(false);
+        }
+      }
+    }
+  };
+
+  return (
+    <div ref={containerReference} className='relative'>
+      <div className='border-input bg-background/50 focus-within:border-primary focus-within:ring-primary/20 flex h-11 items-center gap-2 rounded-lg border px-3 shadow-sm backdrop-blur-sm transition-all focus-within:ring-2'>
+        <Search className='text-muted-foreground h-4 w-4 shrink-0' aria-hidden />
+        {selectedOwner && (
+          <span className='bg-muted text-foreground inline-flex shrink-0 items-center gap-1 rounded-md py-0.5 pr-1 pl-1.5 text-sm'>
+            @{selectedOwner}
+            <span className='text-muted-foreground'>/</span>
+            <button
+              type='button'
+              aria-label={`Clear ${selectedOwner}`}
+              onClick={clearOwner}
+              className='text-muted-foreground hover:text-foreground'
+            >
+              <X className='h-3 w-3' />
+            </button>
+          </span>
+        )}
+        <input
+          ref={inputReference}
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => {
+            setOpen(true);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder={selectedOwner ? 'Filter endpoints…' : 'Search by owner or endpoint…'}
+          className='placeholder:text-muted-foreground/70 h-full flex-1 bg-transparent text-sm outline-none'
+          role='combobox'
+          aria-expanded={open}
+          aria-controls='invite-combobox-list'
+          aria-autocomplete='list'
+          aria-activedescendant={
+            open && rows[highlightedIndex] ? `invite-row-${highlightedIndex}` : undefined
+          }
+        />
+      </div>
+
+      {open && (
+        <div
+          id='invite-combobox-list'
+          role='listbox'
+          aria-label={selectedOwner ? 'Select endpoints' : 'Select an owner'}
+          className='bg-popover text-popover-foreground absolute top-full z-50 mt-2 w-full overflow-hidden rounded-lg border p-1 shadow-lg'
+        >
+          {loading && rows.length === 0 ? (
+            <div className='text-muted-foreground flex items-center justify-center gap-2 py-6 text-sm'>
+              <Loader2 className='h-4 w-4 animate-spin' />
+              {phase === 'owner' ? 'Loading owners…' : 'Loading endpoints…'}
+            </div>
+          ) : rows.length === 0 ? (
+            <p className='text-muted-foreground px-2 py-6 text-center text-sm'>
+              {emptyStateMessage(phase, joinable.length === 0, selectedOwner ?? '')}
+            </p>
+          ) : (
+            <ul ref={listReference} className='max-h-64 overflow-y-auto'>
+              {rows.map((row, index) => (
+                <RowItem
+                  key={rowKey(row)}
+                  id={`invite-row-${index}`}
+                  row={row}
+                  highlighted={index === highlightedIndex}
+                  onMouseEnter={() => {
+                    keyboardNavReference.current = false;
+                    setHighlightedIndex(index);
+                  }}
+                  onSelect={() => {
+                    chooseRow(row);
+                  }}
+                />
+              ))}
+            </ul>
+          )}
+          <div className='text-muted-foreground flex items-center gap-3 border-t px-2 py-1.5 text-xs'>
+            <span>
+              <kbd className='bg-muted rounded px-1 font-mono'>↑↓</kbd> navigate
+            </span>
+            <span>
+              <kbd className='bg-muted rounded px-1 font-mono'>Tab</kbd> select
+            </span>
+            <span>
+              <kbd className='bg-muted rounded px-1 font-mono'>Esc</kbd> close
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Message shown when the dropdown has no rows to offer. */
+function emptyStateMessage(
+  phase: 'owner' | 'endpoint',
+  ownerHasNoJoinable: boolean,
+  owner: string
+): string {
+  if (phase === 'owner') return 'No matching owners.';
+  if (ownerHasNoJoinable) return `@${owner} has no data-source endpoints to invite.`;
+  return 'No matching endpoints.';
+}
+
+function rowKey(row: Row): string {
+  if (row.type === 'owner') return `owner:${row.owner.username}`;
+  if (row.type === 'all') return `all:${row.owner}`;
+  return `ep:${row.itemKey}`;
+}
+
+interface RowItemProps {
+  id: string;
+  row: Row;
+  highlighted: boolean;
+  onMouseEnter: () => void;
+  onSelect: () => void;
+}
+
+function RowItem({ id, row, highlighted, onMouseEnter, onSelect }: Readonly<RowItemProps>) {
+  const isStaged = row.type !== 'owner' && row.staged;
+  return (
+    <li
+      id={id}
+      role='option'
+      aria-selected={highlighted}
+      aria-disabled={isStaged}
+      onMouseEnter={onMouseEnter}
+      onMouseDown={(event) => {
+        // Keep focus on the input so selection doesn't blur-close the dropdown.
+        event.preventDefault();
+      }}
+      onClick={onSelect}
+      className={cn(
+        'flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
+        isStaged && 'cursor-default opacity-60',
+        highlighted && !isStaged ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50'
+      )}
+    >
+      {row.type === 'owner' && (
+        <>
+          <span className='bg-muted flex h-6 w-6 shrink-0 items-center justify-center rounded-full'>
+            <User className='h-3.5 w-3.5' />
+          </span>
+          <span className='font-medium'>{row.owner.username}</span>
+          <span className='text-muted-foreground text-xs'>
+            {row.owner.endpointCount} endpoint{row.owner.endpointCount === 1 ? '' : 's'}
+          </span>
+        </>
+      )}
+
+      {row.type === 'all' && (
+        <>
+          <span className='bg-primary/10 text-primary flex h-6 w-6 shrink-0 items-center justify-center rounded-full'>
+            <Users className='h-3.5 w-3.5' />
+          </span>
+          <span className='text-foreground flex-1 font-medium'>
+            All data sources from @{row.owner}
+          </span>
+          <span className='text-muted-foreground text-xs'>({row.count})</span>
+          {row.staged && <Check className='text-primary h-4 w-4' aria-label='Added' />}
+        </>
+      )}
+
+      {row.type === 'endpoint' && (
+        <>
+          <span className='bg-muted flex h-6 w-6 shrink-0 items-center justify-center rounded-full'>
+            <Database className='h-3.5 w-3.5' />
+          </span>
+          <span className='min-w-0 flex-1 truncate font-medium'>{row.endpoint.name}</span>
+          <span className='text-muted-foreground shrink-0 text-xs'>{row.endpoint.type}</span>
+          {row.staged && <Check className='text-primary h-4 w-4 shrink-0' aria-label='Added' />}
+        </>
+      )}
+    </li>
+  );
+}

--- a/components/frontend/src/components/collectives/shared-endpoints-tab.tsx
+++ b/components/frontend/src/components/collectives/shared-endpoints-tab.tsx
@@ -145,11 +145,16 @@ function SharedEndpointsList({
     );
   }
   if (sharedEndpoints.length === 0) {
+    // No empty-state card when there are members but no custom subsets: every
+    // collective always exposes the implicit `/all` shared endpoint (rendered
+    // by DefaultAllRow above), so "no shared endpoints yet" would be wrong.
+    // Only surface guidance when there are no approved members to pick from.
+    if (!noMembers) {
+      return null;
+    }
     return (
       <Card className='text-muted-foreground p-12 text-center text-sm'>
-        {noMembers
-          ? 'Approve at least one data-source endpoint to start creating shared subsets.'
-          : 'No custom shared endpoints yet. Create one to fan out chats to a specific subset of members.'}
+        Approve at least one data-source endpoint to start creating shared subsets.
       </Card>
     );
   }

--- a/components/frontend/src/hooks/use-collectives.ts
+++ b/components/frontend/src/hooks/use-collectives.ts
@@ -174,6 +174,34 @@ export function useRequestJoin() {
   });
 }
 
+/**
+ * Run `fn` against every item in parallel and partition the outcomes. The
+ * backend exposes only single-item routes, so batch operations fan out here and
+ * report a partial result. Shared by {@link useRequestJoinMany} and
+ * {@link useInviteEndpointsByPath}.
+ */
+async function settleAll<T>(
+  items: T[],
+  fn: (item: T) => Promise<unknown>
+): Promise<{ succeeded: T[]; failed: { item: T; error: Error }[] }> {
+  const settled = await Promise.allSettled(items.map((item) => fn(item)));
+  const succeeded: T[] = [];
+  const failed: { item: T; error: Error }[] = [];
+  for (const [index, outcome] of settled.entries()) {
+    const item = items[index];
+    if (item === undefined) continue;
+    if (outcome.status === 'fulfilled') {
+      succeeded.push(item);
+    } else {
+      failed.push({
+        item,
+        error: outcome.reason instanceof Error ? outcome.reason : new Error(String(outcome.reason))
+      });
+    }
+  }
+  return { succeeded, failed };
+}
+
 /** Outcome of a {@link useRequestJoinMany} call. */
 export interface RequestJoinManyResult {
   /** Endpoints whose join request succeeded. */
@@ -194,25 +222,13 @@ export function useRequestJoinMany() {
   return useMutation<RequestJoinManyResult, Error, { collectiveId: number; endpointIds: number[] }>(
     {
       mutationFn: async ({ collectiveId, endpointIds }) => {
-        const settled = await Promise.allSettled(
-          endpointIds.map((endpointId) => requestJoin(collectiveId, endpointId))
+        const { succeeded, failed } = await settleAll(endpointIds, (endpointId) =>
+          requestJoin(collectiveId, endpointId)
         );
-        const succeeded: number[] = [];
-        const failed: { endpointId: number; error: Error }[] = [];
-        for (const [index, outcome] of settled.entries()) {
-          const endpointId = endpointIds[index];
-          if (endpointId === undefined) continue;
-          if (outcome.status === 'fulfilled') {
-            succeeded.push(endpointId);
-          } else {
-            failed.push({
-              endpointId,
-              error:
-                outcome.reason instanceof Error ? outcome.reason : new Error(String(outcome.reason))
-            });
-          }
-        }
-        return { succeeded, failed };
+        return {
+          succeeded,
+          failed: failed.map(({ item, error }) => ({ endpointId: item, error }))
+        };
       },
       onSuccess: (_data, { collectiveId }) => {
         invalidateMembers(collectiveId);
@@ -280,6 +296,45 @@ export function useInviteEndpointByPath() {
       ownerUsername: string;
       slug: string;
     }) => inviteEndpointByPath(collectiveId, ownerUsername, slug),
+    onSuccess: (_data, { collectiveId }) => {
+      invalidateMembers(collectiveId);
+    }
+  });
+}
+
+/** Outcome of a {@link useInviteEndpointsByPath} batch invite. */
+export interface InviteEndpointsByPathResult {
+  /** Endpoints that were successfully invited. */
+  succeeded: { owner: string; slug: string }[];
+  /** Per-endpoint failures (e.g. already a member), surfaced for a partial summary. */
+  failed: { owner: string; slug: string; error: Error }[];
+}
+
+/**
+ * Invite many endpoints into a collective by `owner/slug` path in parallel.
+ *
+ * The backend exposes only the single-endpoint invite route, so we fan out and
+ * gather with `Promise.allSettled` — each endpoint succeeds or fails on its own
+ * and the caller renders a partial-success summary. Backs the multi-select
+ * invite modal, including the "invite every endpoint of an owner" (`owner/*`)
+ * action.
+ */
+export function useInviteEndpointsByPath() {
+  const invalidateMembers = useInvalidateMembers();
+  return useMutation<
+    InviteEndpointsByPathResult,
+    Error,
+    { collectiveId: number; targets: { owner: string; slug: string }[] }
+  >({
+    mutationFn: async ({ collectiveId, targets }) => {
+      const { succeeded, failed } = await settleAll(targets, (target) =>
+        inviteEndpointByPath(collectiveId, target.owner, target.slug)
+      );
+      return {
+        succeeded,
+        failed: failed.map(({ item, error }) => ({ ...item, error }))
+      };
+    },
     onSuccess: (_data, { collectiveId }) => {
       invalidateMembers(collectiveId);
     }

--- a/components/frontend/src/pages/collective-admin.tsx
+++ b/components/frontend/src/pages/collective-admin.tsx
@@ -4,15 +4,18 @@ import type { Collective, CollectiveMember } from '@/lib/collectives-api';
 import type { ChatSource } from '@/lib/types';
 import type { ReactNode } from 'react';
 
+import ArrowDownLeft from 'lucide-react/dist/esm/icons/arrow-down-left';
 import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left';
+import ArrowUpRight from 'lucide-react/dist/esm/icons/arrow-up-right';
+import Check from 'lucide-react/dist/esm/icons/check';
+import Clock from 'lucide-react/dist/esm/icons/clock';
+import Inbox from 'lucide-react/dist/esm/icons/inbox';
 import Mail from 'lucide-react/dist/esm/icons/mail';
 import ShieldCheck from 'lucide-react/dist/esm/icons/shield-check';
 import Trash2 from 'lucide-react/dist/esm/icons/trash-2';
 import UserCheck from 'lucide-react/dist/esm/icons/user-check';
 import UserPlus from 'lucide-react/dist/esm/icons/user-plus';
-import UserX from 'lucide-react/dist/esm/icons/user-x';
 import Users from 'lucide-react/dist/esm/icons/users';
-import X from 'lucide-react/dist/esm/icons/x';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { SharedEndpointsTab } from '@/components/collectives/shared-endpoints-tab';
@@ -37,9 +40,9 @@ import {
 } from '@/hooks/use-collectives';
 import { useEndpointByPath } from '@/hooks/use-endpoint-queries';
 import { isJoinableEndpointType, parseTags } from '@/lib/collectives-api';
-import { formatDate } from '@/lib/date-utils';
+import { formatRelativeTime } from '@/lib/date-utils';
 
-type AdminTab = 'members' | 'requests' | 'invitations' | 'shared' | 'settings';
+type AdminTab = 'members' | 'pending' | 'shared' | 'settings';
 
 /**
  * Collective administration (`/c/:slug/admin`). Owner only — the route is
@@ -105,8 +108,10 @@ function CollectiveAdminContent({ collective }: Readonly<{ collective: Collectiv
 
   const tabs: { id: AdminTab; label: string; badge?: number }[] = [
     { id: 'members', label: 'Members' },
-    { id: 'requests', label: 'Requests', badge: requests.length },
-    { id: 'invitations', label: 'Invitations', badge: invitations.length },
+    // One unified "Pending" tab covers both inbound join requests and outbound
+    // invitations. The badge counts ONLY requests — the items awaiting *your*
+    // review — because invitations are waiting on the other party, not you.
+    { id: 'pending', label: 'Pending', badge: requests.length },
     { id: 'shared', label: 'Shared Endpoints' },
     { id: 'settings', label: 'Settings' }
   ];
@@ -185,7 +190,10 @@ function CollectiveAdminContent({ collective }: Readonly<{ collective: Collectiv
           >
             {tab.label}
             {tab.badge != null && tab.badge > 0 && (
-              <Badge variant='destructive' className='ml-2 text-xs'>
+              <Badge
+                variant='outline'
+                className='border-primary/20 bg-primary/10 text-primary ml-2 text-xs'
+              >
                 {tab.badge}
               </Badge>
             )}
@@ -235,110 +243,17 @@ function CollectiveAdminContent({ collective }: Readonly<{ collective: Collectiv
         </div>
       )}
 
-      {activeTab === 'requests' && (
-        <div className='space-y-3'>
-          {requests.length > 0 ? (
-            requests.map((request) => (
-              <MemberRow
-                key={request.id}
-                member={request}
-                subtitle={
-                  <>
-                    {request.endpoint_owner_username
-                      ? `@${request.endpoint_owner_username}`
-                      : 'owner unknown'}{' '}
-                    · requested {formatDate(request.requested_at)}
-                  </>
-                }
-                actions={
-                  <div className='flex shrink-0 gap-2'>
-                    <Button
-                      size='sm'
-                      disabled={reviewRequest.isPending}
-                      onClick={() => {
-                        reviewRequest.mutate({
-                          collectiveId: collective.id,
-                          endpointId: request.endpoint_id,
-                          decision: 'approve'
-                        });
-                      }}
-                    >
-                      <UserCheck className='mr-1 h-4 w-4' />
-                      Approve
-                    </Button>
-                    <Button
-                      size='sm'
-                      variant='outline'
-                      disabled={reviewRequest.isPending}
-                      onClick={() => {
-                        reviewRequest.mutate({
-                          collectiveId: collective.id,
-                          endpointId: request.endpoint_id,
-                          decision: 'reject'
-                        });
-                      }}
-                    >
-                      <UserX className='mr-1 h-4 w-4' />
-                      Reject
-                    </Button>
-                  </div>
-                }
-              />
-            ))
-          ) : (
-            <Card className='text-muted-foreground p-12 text-center text-sm'>
-              No pending join requests.
-            </Card>
-          )}
-        </div>
-      )}
-
-      {activeTab === 'invitations' && (
-        <div className='space-y-3'>
-          {invitations.length > 0 ? (
-            invitations.map((invitation) => (
-              <MemberRow
-                key={invitation.id}
-                member={invitation}
-                subtitle={
-                  <>
-                    {invitation.endpoint_owner_username
-                      ? `@${invitation.endpoint_owner_username}`
-                      : 'owner unknown'}{' '}
-                    · invited {formatDate(invitation.requested_at)}
-                  </>
-                }
-                actions={
-                  <Button
-                    size='sm'
-                    variant='outline'
-                    disabled={removeMember.isPending}
-                    onClick={() => {
-                      removeMember.mutate({
-                        collectiveId: collective.id,
-                        endpointId: invitation.endpoint_id
-                      });
-                    }}
-                    title='Cancel invitation'
-                  >
-                    <X className='mr-1 h-4 w-4' />
-                    Cancel
-                  </Button>
-                }
-              />
-            ))
-          ) : (
-            <Card className='text-muted-foreground p-12 text-center text-sm'>
-              <Mail className='mx-auto mb-3 h-8 w-8 opacity-50' />
-              <p>No pending invitations.</p>
-              <p className='mt-2 text-xs'>
-                Use the "Invite endpoint" button above to invite an endpoint by its
-                <code className='mx-1'>owner/slug</code>
-                path.
-              </p>
-            </Card>
-          )}
-        </div>
+      {activeTab === 'pending' && (
+        <PendingTab
+          collectiveId={collective.id}
+          requests={requests}
+          invitations={invitations}
+          reviewRequest={reviewRequest}
+          removeMember={removeMember}
+          onInvite={() => {
+            setInviteModalOpen(true);
+          }}
+        />
       )}
 
       {activeTab === 'shared' && (
@@ -355,7 +270,7 @@ function CollectiveAdminContent({ collective }: Readonly<{ collective: Collectiv
         }}
         onInvited={() => {
           setInviteModalOpen(false);
-          setActiveTab('invitations');
+          setActiveTab('pending');
         }}
       />
     </div>
@@ -383,6 +298,210 @@ function MemberRow({
         {actions}
       </div>
     </Card>
+  );
+}
+
+/**
+ * Unified "Pending" tab — merges what used to be the separate Requests and
+ * Invitations tabs into a single view organised by *whose action is needed*:
+ *
+ * - "Needs your review" (inbound join requests, status `pending`) — the owner
+ *   approves or rejects. Pinned first because it's blocking on the owner.
+ * - "Awaiting response" (outbound invitations, status `invited`) — waiting on
+ *   the invited endpoint's owner; the collective owner can only cancel.
+ *
+ * Empty sections are omitted; only when BOTH are empty is the all-caught-up
+ * state shown.
+ */
+function PendingTab({
+  collectiveId,
+  requests,
+  invitations,
+  reviewRequest,
+  removeMember,
+  onInvite
+}: Readonly<{
+  collectiveId: number;
+  requests: CollectiveMember[];
+  invitations: CollectiveMember[];
+  reviewRequest: ReturnType<typeof useReviewRequest>;
+  removeMember: ReturnType<typeof useRemoveMember>;
+  onInvite: () => void;
+}>) {
+  if (requests.length === 0 && invitations.length === 0) {
+    return (
+      <Card className='flex flex-col items-center gap-3 p-12 text-center'>
+        <div className='bg-muted text-muted-foreground rounded-xl p-3'>
+          <Inbox className='h-6 w-6' />
+        </div>
+        <div>
+          <p className='text-foreground text-sm font-medium'>You're all caught up</p>
+          <p className='text-muted-foreground mt-1 text-sm'>No pending requests or invitations.</p>
+        </div>
+        <Button variant='outline' size='sm' className='mt-2' onClick={onInvite}>
+          <UserPlus className='mr-2 h-4 w-4' />
+          Invite an endpoint
+        </Button>
+      </Card>
+    );
+  }
+
+  return (
+    <div className='space-y-8'>
+      {requests.length > 0 && (
+        <PendingSection
+          title='Needs your review'
+          hint='endpoint owners asking to join'
+          count={requests.length}
+        >
+          {requests.map((request) => (
+            <PendingRow
+              key={request.id}
+              member={request}
+              variant='inbound'
+              actions={
+                <div className='flex gap-2'>
+                  <Button
+                    size='sm'
+                    disabled={reviewRequest.isPending}
+                    onClick={() => {
+                      reviewRequest.mutate({
+                        collectiveId,
+                        endpointId: request.endpoint_id,
+                        decision: 'approve'
+                      });
+                    }}
+                  >
+                    <Check className='mr-1 h-4 w-4' />
+                    Approve
+                  </Button>
+                  <Button
+                    size='sm'
+                    variant='outline'
+                    disabled={reviewRequest.isPending}
+                    onClick={() => {
+                      reviewRequest.mutate({
+                        collectiveId,
+                        endpointId: request.endpoint_id,
+                        decision: 'reject'
+                      });
+                    }}
+                  >
+                    Reject
+                  </Button>
+                </div>
+              }
+            />
+          ))}
+        </PendingSection>
+      )}
+
+      {invitations.length > 0 && (
+        <PendingSection
+          title='Awaiting response'
+          hint='invitations you sent'
+          count={invitations.length}
+        >
+          {invitations.map((invitation) => (
+            <PendingRow
+              key={invitation.id}
+              member={invitation}
+              variant='outbound'
+              actions={
+                <div className='flex items-center gap-3'>
+                  <span className='flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-400'>
+                    <Clock className='h-3.5 w-3.5' />
+                    Pending their reply
+                  </span>
+                  <Button
+                    size='sm'
+                    variant='ghost'
+                    disabled={removeMember.isPending}
+                    className='text-muted-foreground hover:text-destructive'
+                    title='Cancel invitation'
+                    onClick={() => {
+                      removeMember.mutate({
+                        collectiveId,
+                        endpointId: invitation.endpoint_id
+                      });
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              }
+            />
+          ))}
+        </PendingSection>
+      )}
+    </div>
+  );
+}
+
+/**
+ * A labelled group inside the Pending tab. The uppercase header + count states
+ * whose move it is; member rows are collected into one bordered, divided card
+ * (rather than separate floating cards) so the group reads as a single queue.
+ */
+function PendingSection({
+  title,
+  hint,
+  count,
+  children
+}: Readonly<{ title: string; hint: string; count: number; children: ReactNode }>) {
+  return (
+    <section>
+      <div className='mb-3 flex items-baseline justify-between gap-3'>
+        <h2 className='text-muted-foreground flex items-center gap-2 text-xs font-semibold tracking-wider uppercase'>
+          {title}
+          <span className='bg-primary/10 text-primary rounded-full px-2 py-0.5 text-[11px] font-medium'>
+            {count}
+          </span>
+        </h2>
+        <span className='text-muted-foreground text-xs'>{hint}</span>
+      </div>
+      <Card className='divide-border gap-0 divide-y overflow-hidden p-0'>{children}</Card>
+    </section>
+  );
+}
+
+/**
+ * A single pending-membership row. The direction glyph (inbound ↘ / outbound ↗)
+ * reinforces the section grouping; on narrow screens the actions wrap below the
+ * endpoint info, indented past the glyph.
+ */
+function PendingRow({
+  member,
+  variant,
+  actions
+}: Readonly<{
+  member: CollectiveMember;
+  variant: 'inbound' | 'outbound';
+  actions: ReactNode;
+}>) {
+  const DirectionIcon = variant === 'inbound' ? ArrowDownLeft : ArrowUpRight;
+  const verb = variant === 'inbound' ? 'requested' : 'invited';
+  return (
+    <div className='flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center'>
+      <div className='flex min-w-0 flex-1 items-center gap-3'>
+        <div className='bg-muted text-muted-foreground shrink-0 rounded-md p-1.5' aria-hidden>
+          <DirectionIcon className='h-4 w-4' />
+        </div>
+        <div className='min-w-0'>
+          <p className='text-foreground truncate text-sm font-medium'>
+            {member.endpoint_name ?? `Endpoint #${member.endpoint_id}`}
+          </p>
+          <p className='text-muted-foreground truncate text-xs'>
+            {member.endpoint_owner_username
+              ? `@${member.endpoint_owner_username}`
+              : 'owner unknown'}
+            {member.endpoint_type ? ` · ${member.endpoint_type}` : ''} · {verb}{' '}
+            {formatRelativeTime(member.requested_at)}
+          </p>
+        </div>
+      </div>
+      <div className='shrink-0 pl-10 sm:pl-0'>{actions}</div>
+    </div>
   );
 }
 

--- a/components/frontend/src/pages/collective-admin.tsx
+++ b/components/frontend/src/pages/collective-admin.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
+import type { InviteEndpointOption } from '@/components/collectives/invite-combobox';
+import type { InviteEndpointsByPathResult } from '@/hooks/use-collectives';
 import type { Collective, CollectiveMember } from '@/lib/collectives-api';
-import type { ChatSource } from '@/lib/types';
 import type { ReactNode } from 'react';
 
 import ArrowDownLeft from 'lucide-react/dist/esm/icons/arrow-down-left';
@@ -16,8 +17,10 @@ import Trash2 from 'lucide-react/dist/esm/icons/trash-2';
 import UserCheck from 'lucide-react/dist/esm/icons/user-check';
 import UserPlus from 'lucide-react/dist/esm/icons/user-plus';
 import Users from 'lucide-react/dist/esm/icons/users';
+import X from 'lucide-react/dist/esm/icons/x';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
+import { InviteCombobox } from '@/components/collectives/invite-combobox';
 import { SharedEndpointsTab } from '@/components/collectives/shared-endpoints-tab';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -33,13 +36,12 @@ import {
   useCollectiveBySlug,
   useCollectiveMembers,
   useDeleteCollective,
-  useInviteEndpointByPath,
+  useInviteEndpointsByPath,
   useRemoveMember,
   useReviewRequest,
   useUpdateCollective
 } from '@/hooks/use-collectives';
-import { useEndpointByPath } from '@/hooks/use-endpoint-queries';
-import { isJoinableEndpointType, parseTags } from '@/lib/collectives-api';
+import { parseTags } from '@/lib/collectives-api';
 import { formatRelativeTime } from '@/lib/date-utils';
 
 type AdminTab = 'members' | 'pending' | 'shared' | 'settings';
@@ -506,12 +508,20 @@ function PendingRow({
 }
 
 /**
- * Modal for inviting an endpoint into the collective by `owner/slug` path.
+ * A pending pick in the invite modal: either one endpoint, or every joinable
+ * endpoint of an owner (the `owner/*` action, expanded to slugs at pick time).
+ */
+type StagedInvite =
+  | { kind: 'endpoint'; owner: string; slug: string; name: string }
+  | { kind: 'all'; owner: string; endpoints: { slug: string; name: string }[] };
+
+/**
+ * Modal for inviting endpoints into the collective.
  *
- * The collective owner enters a path (e.g. `alice/genome-data`), we preview
- * the resolved endpoint via the public-by-path API, and on confirm send an
- * invitation. Only data-source endpoints are joinable; the modal blocks
- * submission when the resolved endpoint isn't eligible.
+ * A chat-style combobox lets the owner search owners/endpoints and Tab to
+ * complete, or stage every endpoint of an owner at once (`owner/*`). Picks are
+ * collected as removable chips and sent as one batch; only data-source
+ * endpoints are ever surfaced (matching the backend join guard).
  */
 function InviteEndpointModal({
   isOpen,
@@ -524,182 +534,178 @@ function InviteEndpointModal({
   onClose: () => void;
   onInvited: () => void;
 }>) {
-  const [path, setPath] = useState('');
-  // Debounced path used for the actual lookup so we don't spam the API while
-  // the user is still typing.
-  const [debouncedPath, setDebouncedPath] = useState('');
-  const inviteMutation = useInviteEndpointByPath();
-  const resetInvite = inviteMutation.reset;
+  const [staged, setStaged] = useState<StagedInvite[]>([]);
+  const [result, setResult] = useState<InviteEndpointsByPathResult | null>(null);
+  const inviteMany = useInviteEndpointsByPath();
+  const resetInvite = inviteMany.reset;
 
-  useEffect(() => {
-    const trimmed = path.trim();
-    if (!trimmed) {
-      setDebouncedPath('');
-      return;
-    }
-    const timer = setTimeout(() => {
-      setDebouncedPath(trimmed);
-    }, 300);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [path]);
-
-  // Reset when the modal closes so reopening starts fresh. Depend on the
-  // stable `reset` method, not the mutation object — `useMutation` returns a
-  // fresh result object every render, which would re-fire this effect on
-  // every render.
+  // Reset when the modal closes so reopening starts fresh. Depend on the stable
+  // `reset` method, not the mutation object (which is a fresh ref each render).
   useEffect(() => {
     if (!isOpen) {
-      setPath('');
-      setDebouncedPath('');
+      setStaged([]);
+      setResult(null);
       resetInvite();
     }
   }, [isOpen, resetInvite]);
 
-  const parsed = parseOwnerSlug(debouncedPath);
-  const { data: endpoint, isFetching: isResolving } = useEndpointByPath(
-    parsed ? `${parsed.owner}/${parsed.slug}` : undefined
-  );
+  // Derive everything the modal/combobox needs from `staged` in one pass:
+  // the staged endpoint keys + owner-wide picks (for the combobox's "already
+  // staged" gating) and the deduplicated flat `{owner, slug}` targets to send.
+  const { stagedKeys, stagedAllOwners, targets } = useMemo(() => {
+    const keys = new Set<string>();
+    const allOwners = new Set<string>();
+    const targetMap = new Map<string, { owner: string; slug: string }>();
+    for (const item of staged) {
+      if (item.kind === 'endpoint') {
+        keys.add(`${item.owner}/${item.slug}`);
+        targetMap.set(`${item.owner}/${item.slug}`, { owner: item.owner, slug: item.slug });
+      } else {
+        allOwners.add(item.owner);
+        for (const endpoint of item.endpoints) {
+          targetMap.set(`${item.owner}/${endpoint.slug}`, {
+            owner: item.owner,
+            slug: endpoint.slug
+          });
+        }
+      }
+    }
+    return { stagedKeys: keys, stagedAllOwners: allOwners, targets: [...targetMap.values()] };
+  }, [staged]);
 
-  const ineligibleType = endpoint?.type != null && !isJoinableEndpointType(endpoint.type);
+  const addEndpoint = (option: InviteEndpointOption) => {
+    if (stagedAllOwners.has(option.owner)) return;
+    if (stagedKeys.has(`${option.owner}/${option.slug}`)) return;
+    setStaged((previous) => [...previous, { kind: 'endpoint', ...option }]);
+  };
 
-  const canSubmit =
-    parsed != null && endpoint != null && !ineligibleType && !inviteMutation.isPending;
+  const addAll = (owner: string, endpoints: { slug: string; name: string }[]) => {
+    // An owner-wide pick supersedes any individual picks for that owner.
+    setStaged((previous) => [
+      ...previous.filter((item) => item.owner !== owner),
+      { kind: 'all', owner, endpoints }
+    ]);
+  };
 
-  const handleSubmit = () => {
-    if (!parsed) return;
-    inviteMutation.mutate(
-      { collectiveId: collective.id, ownerUsername: parsed.owner, slug: parsed.slug },
-      { onSuccess: onInvited }
+  const removeAt = (index: number) => {
+    setStaged((previous) => previous.filter((_, index_) => index_ !== index));
+  };
+
+  const handleSend = () => {
+    if (targets.length === 0) return;
+    setResult(null);
+    inviteMany.mutate(
+      { collectiveId: collective.id, targets },
+      {
+        onSuccess: (response) => {
+          if (response.failed.length === 0) {
+            onInvited();
+            return;
+          }
+          // Partial result — keep the modal open with a summary; clear staging
+          // since the successes are sent and the failures are typically
+          // "already a member" (not retryable).
+          setResult(response);
+          setStaged([]);
+        }
+      }
     );
   };
 
+  const sendLabel = inviteMany.isPending
+    ? 'Sending…'
+    : `Send ${targets.length} invitation${targets.length === 1 ? '' : 's'}`;
+
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title='Invite an endpoint'>
+    <Modal isOpen={isOpen} onClose={onClose} title='Invite endpoints'>
       <div className='space-y-4'>
         <div>
-          <Label htmlFor='invite-path'>Endpoint path</Label>
-          <Input
-            id='invite-path'
-            placeholder='owner/endpoint-slug'
-            value={path}
-            onChange={(e) => {
-              setPath(e.target.value);
-            }}
-            className='mt-1 font-mono text-sm'
-          />
+          <Label htmlFor='invite-combobox-input'>Find endpoints</Label>
+          <div className='mt-1'>
+            <InviteCombobox
+              onSelectEndpoint={addEndpoint}
+              onSelectAll={addAll}
+              stagedKeys={stagedKeys}
+              stagedAllOwners={stagedAllOwners}
+            />
+          </div>
           <p className='text-muted-foreground mt-1 text-xs'>
-            Enter the public path of a data-source endpoint, e.g. <code>alice/genome-data</code>.
-            The endpoint owner receives an email and decides whether to accept.
+            Search by owner to invite all their data sources, or pick individual endpoints. Each
+            owner receives an email and decides whether to accept.
           </p>
         </div>
 
-        <InvitePreview
-          path={debouncedPath}
-          parsed={parsed}
-          endpoint={endpoint ?? null}
-          isResolving={isResolving}
-          ineligibleType={ineligibleType}
-        />
+        {staged.length > 0 && (
+          <div>
+            <p className='text-muted-foreground mb-2 text-xs font-medium'>
+              Staged invitations · {targets.length}
+            </p>
+            <div className='flex flex-wrap gap-2'>
+              {staged.map((item, index) => (
+                <span
+                  key={item.kind === 'all' ? `all:${item.owner}` : `${item.owner}/${item.slug}`}
+                  className='border-border bg-muted text-foreground inline-flex items-center gap-1.5 rounded-full border py-1 pr-1 pl-2.5 text-xs'
+                >
+                  {item.kind === 'all'
+                    ? `@${item.owner} · all (${item.endpoints.length})`
+                    : `@${item.owner}/${item.slug}`}
+                  <button
+                    type='button'
+                    aria-label='Remove'
+                    onClick={() => {
+                      removeAt(index);
+                    }}
+                    className='text-muted-foreground hover:text-destructive flex h-4 w-4 items-center justify-center rounded-full'
+                  >
+                    <X className='h-3 w-3' />
+                  </button>
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
 
-        {inviteMutation.isError && (
-          <p className='text-destructive text-sm'>
-            {inviteMutation.error instanceof Error
-              ? inviteMutation.error.message
-              : 'Failed to send invitation'}
-          </p>
+        {result && (
+          <div className='text-sm'>
+            {result.succeeded.length > 0 && (
+              <p className='flex items-center gap-1.5 text-emerald-600 dark:text-emerald-400'>
+                <Check className='h-4 w-4' />
+                {result.succeeded.length} invitation
+                {result.succeeded.length === 1 ? '' : 's'} sent.
+              </p>
+            )}
+            {result.failed.length > 0 && (
+              <div className='text-muted-foreground mt-2'>
+                <p>
+                  {result.failed.length} couldn't be invited (e.g. already a member or invited):
+                </p>
+                <ul className='mt-1 space-y-0.5'>
+                  {result.failed.map((failure) => (
+                    <li key={`${failure.owner}/${failure.slug}`}>
+                      <code>
+                        {failure.owner}/{failure.slug}
+                      </code>{' '}
+                      — {failure.error.message}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
         )}
 
         <div className='flex justify-end gap-2 pt-2'>
           <Button variant='outline' onClick={onClose}>
-            Cancel
+            {result ? 'Close' : 'Cancel'}
           </Button>
-          <Button disabled={!canSubmit} onClick={handleSubmit}>
+          <Button disabled={targets.length === 0 || inviteMany.isPending} onClick={handleSend}>
             <Mail className='mr-2 h-4 w-4' />
-            {inviteMutation.isPending ? 'Sending...' : 'Send invitation'}
+            {sendLabel}
           </Button>
         </div>
       </div>
     </Modal>
   );
-}
-
-/**
- * Render the resolved-endpoint preview block beneath the path input — empty
- * state, loading, error, mismatch, or a confirmed match.
- */
-function InvitePreview({
-  path,
-  parsed,
-  endpoint,
-  isResolving,
-  ineligibleType
-}: Readonly<{
-  path: string;
-  parsed: { owner: string; slug: string } | null;
-  endpoint: ChatSource | null;
-  isResolving: boolean;
-  ineligibleType: boolean;
-}>) {
-  if (!path) {
-    return null;
-  }
-  if (!parsed) {
-    return (
-      <p className='text-destructive text-sm'>
-        Path must look like <code>owner/endpoint-slug</code>.
-      </p>
-    );
-  }
-  if (isResolving) {
-    return <p className='text-muted-foreground text-sm'>Looking up endpoint...</p>;
-  }
-  if (!endpoint) {
-    return (
-      <p className='text-destructive text-sm'>
-        No public endpoint at{' '}
-        <code>
-          {parsed.owner}/{parsed.slug}
-        </code>
-        .
-      </p>
-    );
-  }
-  if (ineligibleType) {
-    return (
-      <Card className='border-destructive/30 bg-destructive/5 p-3 text-sm'>
-        <p className='font-medium'>{endpoint.name}</p>
-        <p className='text-muted-foreground text-xs'>
-          @{endpoint.owner_username} · {endpoint.type}
-        </p>
-        <p className='text-destructive mt-2 text-xs'>
-          Only data-source endpoints can join a collective.
-        </p>
-      </Card>
-    );
-  }
-  return (
-    <Card className='border-primary/30 bg-primary/5 p-3 text-sm'>
-      <p className='font-medium'>{endpoint.name}</p>
-      <p className='text-muted-foreground text-xs'>
-        @{endpoint.owner_username} · {endpoint.type}
-      </p>
-      {endpoint.description && (
-        <p className='text-muted-foreground mt-2 text-xs'>{endpoint.description}</p>
-      )}
-    </Card>
-  );
-}
-
-function parseOwnerSlug(path: string): { owner: string; slug: string } | null {
-  const trimmed = path.trim().replace(/^@/, '').replace(/^\//, '');
-  if (!trimmed) return null;
-  const parts = trimmed.split('/');
-  if (parts.length !== 2) return null;
-  const [owner, slug] = parts;
-  if (!owner || !slug) return null;
-  return { owner, slug };
 }
 
 /** General-settings form + danger zone for the collective. */


### PR DESCRIPTION
## Summary

Three focused improvements to the collective admin experience (`/c/:slug/admin`), each reviewed with impact analysis and `/simplify`:

### 1. Remove the misleading "no custom shared endpoints" empty state
Every collective always exposes the implicit `collective/<slug>/all` shared endpoint (rendered by `DefaultAllRow`), so the *"No custom shared endpoints yet"* card was wrong — the list is never truly empty. The card is dropped; only the genuinely distinct "approve a member first" guidance remains (shown when there are no approved members at all).

### 2. Unify the Requests + Invitations tabs into one "Pending" tab
The two tabs rendered near-identical lists differing only by direction. They're merged into a single **Pending** view organised by *whose action is needed*:
- **Needs your review** — inbound join requests (owner approves/rejects), pinned first.
- **Awaiting response** — outbound invitations (waiting on the invitee; owner can cancel).

The tab badge now counts **only** review-required requests and is primary-tinted instead of `destructive` red — invitations wait on the other party, so they no longer signal false urgency. Empty sections are omitted; an "all caught up" state shows only when both are empty.

### 3. Searchable, batch invite flow
Replaces the single blind `owner/slug` text field with a chat-style typeahead (`InviteCombobox`):
- Type to get **owner suggestions you Tab to complete**, then drill into that owner's data sources.
- A pinned **"All data sources from @owner"** row stages every endpoint of a user at once (the `username/*` ask).
- Picks collect as **removable chips** and send as **one batch** with a partial-result summary ("8 sent · 2 already members").

Only joinable (`data_source` / `model_data_source`) endpoints are ever surfaced, matching the backend join guard, so no post-hoc "not eligible" rejections. The combobox reuses the chat mention data/filter layer (`getPublicEndpointOwners`, `useEndpointsByOwner`, `filterOwners`/`filterEndpoints`). A new `useInviteEndpointsByPath` batch hook shares a `settleAll` helper with `useRequestJoinMany` so the fan-out/partition/error-coercion logic lives in one place.

## Scope
Frontend only — no API, schema, or backend changes. All work is in `components/frontend/`.

## Testing
- `tsc --noEmit`: clean
- ESLint: 0 errors · Prettier: clean
- Vitest: 297/297 pass

Not yet exercised in a browser.

## Follow-ups (out of scope)
- Backend bulk-invite route (`POST .../invitations:batch`) would replace the client-side fan-out and cut N round-trips/emails per `owner/*`.
- The typeahead keyboard/highlight engine is now similar across `InviteCombobox` and the chat mention popovers — could be extracted into a shared headless hook later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)