### PR TITLE
feat(frontend): remove verification badge from collective admin

### DIFF
--- a/components/frontend/src/pages/collective-admin.tsx
+++ b/components/frontend/src/pages/collective-admin.tsx
@@ -832,18 +832,6 @@ function CollectiveSettingsForm({ collective }: Readonly<{ collective: Collectiv
             </p>
           </div>
         </div>
-        <div className='text-muted-foreground mt-4 flex items-center gap-2 border-t pt-4 text-sm'>
-          <span>Verification:</span>
-          {collective.verified ? (
-            <Badge variant='secondary' className='gap-1'>
-              <ShieldCheck className='h-3 w-3 text-green-500' />
-              Verified
-            </Badge>
-          ) : (
-            <Badge variant='outline'>Not verified</Badge>
-          )}
-          <span className='text-xs'>— granted by the platform, not editable here.</span>
-        </div>
       </Card>
 
       {updateCollective.isError && (


### PR DESCRIPTION
## Summary

- Removes the read-only **Verification** status row from the Membership card in the collective admin settings page (`/c/:slug/admin`)
- The block showed "Not verified — granted by the platform, not editable here." (or a green Verified badge) with no way for admins to act on it
- Since it exposes platform-internal state with no actionable controls, it was confusing noise for collective admins

## Test plan

- [ ] Open `/c/:slug/admin` for any collective — confirm the verification row no longer appears in the Membership card
- [ ] Verify the Auto-approve toggle still works correctly
- [ ] Confirm no TypeScript / lint errors (`make check`)