### PR TITLE
fix(backend): use real domain for collective invitation email links

### DIFF
--- a/.env.deploy.example
+++ b/.env.deploy.example
@@ -43,7 +43,7 @@ REDIS_PASSWORD=your-secure-redis-password
 # DOMAIN CONFIGURATION
 # =============================================================================
 
-# Production domain name (used for CORS and SSL configuration)
+# Production domain name (used for CORS, SSL, and links in outgoing emails)
 # Example: syfthub.example.com
 DOMAIN=localhost
 

--- a/deploy/docker-compose.deploy.yml
+++ b/deploy/docker-compose.deploy.yml
@@ -113,6 +113,9 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - LOG_FORMAT=${LOG_FORMAT:-json}
       - CORS_ORIGINS=https://${DOMAIN:-localhost}
+      # Public frontend base URL used to build links in outgoing emails
+      # (e.g. collective invitation accept/decline links)
+      - FRONTEND_URL=https://${DOMAIN:-localhost}
       - REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379/0
       # RSA keys for satellite token signing (required for multi-worker deployment)
       - RSA_PRIVATE_KEY_PEM=${RSA_PRIVATE_KEY_PEM}

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -57,6 +57,9 @@ services:
       - LOG_LEVEL=debug
       # Single origin since everything goes through proxy
       - CORS_ORIGINS=http://localhost:8080
+      # Public frontend base URL used to build links in outgoing emails
+      # (e.g. collective invitation accept/decline links)
+      - FRONTEND_URL=http://localhost:8080
       # MPP / Tempo configuration
       - TEMPO_TESTNET=true
       - MPP_SECRET_KEY=${MPP_SECRET_KEY:-}


### PR DESCRIPTION
## Problem

Collective invitation emails render the accept/decline link with a hardcoded `http://localhost:3000` instead of the deployment's actual domain (see screenshot of the broken email link).

## Root cause

The link is built in `components/backend/src/syfthub/services/email_service.py` from `settings.frontend_url`:

```python
invite_url = (
    f"{settings.frontend_url.rstrip('/')}"
    f"/collectives/{ctx.collective_slug}/invitations/{ctx.endpoint_id}"
)
```

`frontend_url` (`core/config.py`) defaults to `http://localhost:3000` and reads the `FRONTEND_URL` env var — but **`FRONTEND_URL` was never set in any compose file**, unlike its siblings `CORS_ORIGINS` and `NATS_WS_PUBLIC_URL` which are already wired to `${DOMAIN}`. So it always fell back to the localhost default.

The URL *path* is correct — it matches the frontend route `collectives/:slug/invitations/:endpointId`.

## Fix

Wire `FRONTEND_URL` through deployment, reusing the existing `DOMAIN` variable so operators don't get a new env var to forget:

- **`deploy/docker-compose.deploy.yml`** — `FRONTEND_URL=https://${DOMAIN:-localhost}`
- **`deploy/docker-compose.dev.yml`** — `FRONTEND_URL=http://localhost:8080` (nginx proxy origin, matching dev `CORS_ORIGINS`)
- **`.env.deploy.example`** — note that `DOMAIN` now also drives email links

Staging inherits this automatically (`docker-compose.staging.yml` is only a resource-limit override layered on deploy).

## Result

After redeploy, invitation emails render `https://<your-domain>/collectives/<slug>/invitations/<id>`.