### PR TITLE
fix(frontend): recognize bare "mpp" policy type as pay-as-you-go card

### DIFF
--- a/components/frontend/src/components/endpoint/policy-item.tsx
+++ b/components/frontend/src/components/endpoint/policy-item.tsx
@@ -39,7 +39,9 @@ function isPrepaidBalanceType(type: string): type is PrepaidProvider {
 // Pay-as-you-go (MPP) policy types. These share the premium balance-card
 // layout with the prepaid providers, but bill automatically per request out of
 // the user's MPP wallet — so there is no bundle picker or "Buy credits" CTA.
-const MPP_BALANCE_TYPES = new Set<string>(['mpp_accounting', 'accounting']);
+// `mpp`, `mpp_accounting`, and `accounting` are all emitted in the wild for the
+// same per-request strategy (same config shape: price/currency/unit_type).
+const MPP_BALANCE_TYPES = new Set<string>(['mpp', 'mpp_accounting', 'accounting']);
 function isMppBalanceType(type: string): boolean {
   return MPP_BALANCE_TYPES.has(type);
 }
@@ -52,6 +54,7 @@ const MPP_PROVIDER_LABEL = 'Tempo';
 const BALANCE_PROVIDER_LABELS: Record<string, string> = {
   xendit: 'Xendit',
   stripe: 'Stripe',
+  mpp: MPP_PROVIDER_LABEL,
   mpp_accounting: MPP_PROVIDER_LABEL,
   accounting: MPP_PROVIDER_LABEL
 };
@@ -81,8 +84,9 @@ const POLICY_TYPE_CONFIG: Record<
     description: string;
   }
 > = {
-  // Transaction/Pricing policies. mpp_accounting and accounting are aliases for
-  // the same pay-as-you-go strategy, so they share one config object.
+  // Transaction/Pricing policies. mpp, mpp_accounting, and accounting are
+  // aliases for the same pay-as-you-go strategy, so they share one config object.
+  mpp: MPP_POLICY_CONFIG,
   mpp_accounting: MPP_POLICY_CONFIG,
   accounting: MPP_POLICY_CONFIG,
   transaction: {


### PR DESCRIPTION
## Problem

After #449 merged, endpoints with an MPP pricing policy still rendered the **old flat policy card** instead of the new "Pay as you go" balance card — e.g. `openmined-data/about-abc-openmined`.

## Root cause

Verified directly against the prod DB. That endpoint's stored policy is:

```json
{"type": "mpp", "config": {"price": 0.1, "currency": "USD", "unit_type": "request", "applied_to": ["*"]}, ...}
```

The policy `type` is the **bare string `"mpp"`**, but #449 only matched `mpp_accounting` and `accounting`. A tally of prod policy types confirms `mpp` is in active use:

| type | count |
|------|-------|
| `xendit` | 8 |
| `accounting` | 5 |
| `mpp_accounting` | 3 |
| **`mpp`** | **3** |

Unmatched `mpp` policies fell through `getPolicyConfig` to the default flat card.

## Fix

`mpp` carries the same config shape (`price`/`currency`/`unit_type`) as the other MPP aliases, so it just needs to be recognized in the three places #449 handles the MPP types:

- `MPP_BALANCE_TYPES` (drives the balance-card branch)
- `BALANCE_PROVIDER_LABELS` (→ "via Tempo")
- `POLICY_TYPE_CONFIG` (→ shared `MPP_POLICY_CONFIG`, "Pay as you go")

No behavioral change for the already-handled `mpp_accounting`/`accounting`/prepaid types.

## Testing

- `eslint` + `tsc` (frontend) pass via pre-commit hooks.
