### PR TITLE
fix(backend): fall back to unique username on registration collision

### DIFF
--- a/components/backend/src/syfthub/services/auth_service.py
+++ b/components/backend/src/syfthub/services/auth_service.py
@@ -119,12 +119,19 @@ class AuthService(BaseService):
                 detail="Password must be at least 8 characters long",
             )
 
-        # Check if user already exists in SyftHub
-        if self.user_repository.username_exists(register_data.username):
-            raise UserAlreadyExistsError("username", register_data.username)
-
+        # A duplicate email is a real "account already exists" error the user
+        # must see and act on.
         if self.user_repository.email_exists(register_data.email):
             raise UserAlreadyExistsError("email", register_data.email)
+
+        # The username is auto-derived from the email on the client, so the user
+        # never picked it. Collisions are expected — e.g. plus-addressing, where
+        # user+a@example.com and user+b@example.com both reduce to the base
+        # "user" — so fall back to a unique variant rather than failing
+        # registration with a confusing "username already exists" error.
+        username = register_data.username
+        if self.user_repository.username_exists(username):
+            username = self._generate_unique_username(register_data.email)
 
         # Generate password hash for SyftHub
         password_hash = hash_password(register_data.password)
@@ -134,7 +141,7 @@ class AuthService(BaseService):
 
         # Create user data
         user_data = UserCreate(
-            username=register_data.username,
+            username=username,
             email=register_data.email,
             full_name=register_data.full_name,
             is_active=True,

--- a/components/backend/tests/test_auth_endpoints.py
+++ b/components/backend/tests/test_auth_endpoints.py
@@ -63,29 +63,41 @@ def test_register_user(client: TestClient) -> None:
     assert user["is_active"] is True
 
 
-def test_register_duplicate_username(client: TestClient) -> None:
-    """Test registering with duplicate username."""
-    user_data = {
-        "username": "testuser",
-        "email": "test@example.com",
-        "full_name": "Test User",
-        "password": "testpass123",
-    }
+def test_register_duplicate_username_resolved(client: TestClient) -> None:
+    """A colliding username (auto-derived from email) does not block registration
+    for a distinct email — the server assigns a unique variant instead.
 
-    # Register first user
-    response1 = client.post("/api/v1/auth/register", json=user_data)
+    Mirrors the real client behaviour where the username is derived from the
+    email local part: "user+test@" and "usertest@" both reduce to "usertest".
+    """
+    # First account claims the derived username "usertest".
+    response1 = client.post(
+        "/api/v1/auth/register",
+        json={
+            "username": "usertest",
+            "email": "user+test@example.com",
+            "full_name": "Test User",
+            "password": "testpass123",
+        },
+    )
     assert response1.status_code == 201
+    assert response1.json()["user"]["username"] == "usertest"
 
-    # Try to register with same username
-    user_data2 = user_data.copy()
-    user_data2["email"] = "different@example.com"
-
-    response2 = client.post("/api/v1/auth/register", json=user_data2)
-    assert response2.status_code == 409
-    detail = response2.json()["detail"]
-    assert detail["code"] == "USER_ALREADY_EXISTS"
-    assert detail["field"] == "username"
-    assert "Username already exists" in detail["message"]
+    # A distinct email whose derived username collides still registers.
+    response2 = client.post(
+        "/api/v1/auth/register",
+        json={
+            "username": "usertest",
+            "email": "usertest@example.com",
+            "full_name": "Other User",
+            "password": "testpass123",
+        },
+    )
+    assert response2.status_code == 201
+    # Same email-derived base, but uniquified so both accounts can coexist.
+    assigned = response2.json()["user"]["username"]
+    assert assigned != "usertest"
+    assert assigned.startswith("usertest")
 
 
 def test_register_duplicate_email(client: TestClient) -> None:

--- a/components/backend/tests/test_services/test_auth_service.py
+++ b/components/backend/tests/test_services/test_auth_service.py
@@ -96,16 +96,57 @@ class TestAuthServiceRegistration:
             assert result.user["id"] == 1
             assert result.user["username"] == "testuser"
 
-    def test_register_user_duplicate_username(self, auth_service, sample_user_register):
-        """Test registration with existing username fails."""
-        with patch.object(
-            auth_service.user_repository, "username_exists", return_value=True
+    def test_register_user_duplicate_username_falls_back(
+        self, auth_service, sample_user_register
+    ):
+        """A taken username (auto-derived from email) is resolved to a unique
+        variant instead of failing registration."""
+        with (
+            patch.object(
+                auth_service.user_repository, "username_exists", return_value=True
+            ),
+            patch.object(
+                auth_service.user_repository, "email_exists", return_value=False
+            ),
+            patch.object(
+                auth_service,
+                "_generate_unique_username",
+                return_value="testuser123",
+            ) as mock_gen,
+            patch.object(auth_service.user_repository, "create_user") as mock_create,
+            patch(
+                "syfthub.services.auth_service.hash_password",
+                return_value="hashed_pass",
+            ),
+            patch(
+                "syfthub.services.auth_service.create_access_token",
+                return_value="access_token",
+            ),
+            patch(
+                "syfthub.services.auth_service.create_refresh_token",
+                return_value="refresh_token",
+            ),
         ):
-            with pytest.raises(UserAlreadyExistsError) as exc_info:
-                auth_service.register_user(sample_user_register)
+            mock_user = User(
+                id=1,
+                username="testuser123",
+                email="test@example.com",
+                full_name="Test User",
+                role="user",
+                is_active=True,
+                created_at=datetime.fromisoformat("2023-01-01T00:00:00"),
+                updated_at=datetime.fromisoformat("2023-01-01T00:00:00"),
+                age=25,
+                password_hash="hashed_pass",
+            )
+            mock_create.return_value = mock_user
 
-            assert exc_info.value.field == "username"
-            assert "Username already exists" in str(exc_info.value)
+            result = auth_service.register_user(sample_user_register)
+
+            # Fallback was used to derive a unique username from the email.
+            mock_gen.assert_called_once_with(sample_user_register.email)
+            assert mock_create.call_args.kwargs["user_data"].username == "testuser123"
+            assert result.user["username"] == "testuser123"
 
     def test_register_user_duplicate_email(self, auth_service, sample_user_register):
         """Test registration with existing email fails."""


### PR DESCRIPTION
## Problem

Emails with plus-addressing (e.g. `user+test@gmail.com`) are accepted everywhere — frontend regex (`lib/schemas.ts`) and backend `EmailStr` both allow `+`, and the email is stored verbatim with uniqueness on the full address. So plus-addressed registration already *works*.

The one rough edge: the **username is auto-derived from the email local part** on the client (`generateUsernameFromEmail`), stripping all non-alphanumerics. That makes `user+test@gmail.com` and `usertest@gmail.com` both reduce to the base `usertest`. The backend trusted the client-supplied username verbatim and raised `UserAlreadyExistsError("username")` on collision — so the second person to register got a confusing *"username already exists"* error even though their email was unique and they never chose a username.

## Fix

`auth_service.register_user` now resolves a unique username instead of raising:

- A **duplicate email** still raises `UserAlreadyExistsError` — a genuine "account already exists" condition the user must act on.
- A **duplicate username** falls back to `_generate_unique_username(email)` — the same helper the Google-login path already uses — which appends a random suffix until unique. The resolved username is persisted and returned in the registration response.

The fix lives entirely in the backend because it's the authoritative, race-safe place to resolve usernames; a frontend pre-check would be racy. No frontend change is needed — it already sends the email verbatim and picks up the real username from the response.

## Note

This makes the API's explicit `username` field best-effort on collision rather than authoritative. That's correct for SyftHub's flow (the signup form never lets users pick a username). If a username-picker UI is ever added, that path should branch so an explicitly-chosen-and-taken username returns 409 instead of being silently adjusted.

## Tests

- `test_services/test_auth_service.py`: replaced `test_register_user_duplicate_username` (asserted the old raise) with `test_register_user_duplicate_username_falls_back`, verifying the fallback runs and the unique username is persisted.
- `test_auth_endpoints.py`: replaced `test_register_duplicate_username` with `test_register_duplicate_username_resolved` — registers two distinct emails (`user+test@` and `usertest@`) that derive the same base and asserts the second succeeds (201) with a uniquified username.

All 68 auth tests pass locally.
