### PR TITLE
fix(backend): make uptime-sample tests rolling-window-relative

### DIFF
--- a/components/backend/tests/test_repositories/test_endpoint_uptime.py
+++ b/components/backend/tests/test_repositories/test_endpoint_uptime.py
@@ -35,7 +35,12 @@ def endpoint(test_session, user, sample_endpoint_data):
 class TestUpsertUptimeSample:
     def test_insert_new_row(self, test_session, endpoint):
         repo = EndpointRepository(test_session)
-        bucket = datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc)
+        # Relative to now (floored to the hour like a real bucket) so the sample
+        # always lands inside the rolling 30-day query window — a hardcoded date
+        # would silently fall out of the window as wall-clock time advances.
+        bucket = datetime.now(timezone.utc).replace(
+            minute=0, second=0, microsecond=0
+        ) - timedelta(days=1)
 
         repo.upsert_uptime_sample(
             endpoint_id=endpoint.id,
@@ -52,7 +57,9 @@ class TestUpsertUptimeSample:
 
     def test_accumulates_into_existing_bucket(self, test_session, endpoint):
         repo = EndpointRepository(test_session)
-        bucket = datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc)
+        bucket = datetime.now(timezone.utc).replace(
+            minute=0, second=0, microsecond=0
+        ) - timedelta(days=1)
 
         repo.upsert_uptime_sample(endpoint.id, bucket, True)
         repo.upsert_uptime_sample(endpoint.id, bucket, True)
@@ -67,7 +74,9 @@ class TestUpsertUptimeSample:
 
     def test_unhealthy_sample_only_increments_total(self, test_session, endpoint):
         repo = EndpointRepository(test_session)
-        bucket = datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc)
+        bucket = datetime.now(timezone.utc).replace(
+            minute=0, second=0, microsecond=0
+        ) - timedelta(days=1)
 
         repo.upsert_uptime_sample(endpoint.id, bucket, False)
         test_session.commit()


### PR DESCRIPTION
## Problem

The three `TestUpsertUptimeSample` tests in `test_endpoint_uptime.py` were a **time-bomb**. They hardcoded:

```python
bucket = datetime(2026, 5, 13, 12, 0, tzinfo=timezone.utc)
```

and read it back through a **rolling** 30-day window:

```python
repo.get_uptime_samples(endpoint_id, window_hours=24 * 30)
```

whose cutoff is computed as `datetime.now(timezone.utc) - timedelta(hours=window_hours)` (`repositories/endpoint.py:1278`). Once wall-clock time advanced past ~2026-06-12, the hardcoded bucket fell *outside* the window, so `get_uptime_samples` returned 0 rows and the assertions failed:

- `test_insert_new_row` → `assert 0 == 1`
- `test_accumulates_into_existing_bucket` → `assert 0 == 1`
- `test_unhealthy_sample_only_increments_total` → `IndexError: list index out of range`

`main` was green on 2026-06-09 (the bucket was still in-window then) and started failing on runs from ~2026-06-12 onward. A rerun does not help — every fresh run fails until this is fixed.

## Fix

Make each bucket relative to `now` (floored to the hour, like a real bucket boundary, one day ago) so it always lands inside the rolling window regardless of when CI runs. This matches the pattern the sibling `TestUptimeRetention` class already uses.

## Verification

All 9 tests in `tests/test_repositories/test_endpoint_uptime.py` pass locally; ruff/ruff-format/mypy pre-commit hooks pass.