### PR TITLE
release(sdk): bump Python and TypeScript SDKs to 0.2.0

### DIFF
--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-17
+
+### Added
+
+- `aggregators` resource for managing user aggregator configurations
+- `api_tokens` resource for creating and managing personal access tokens
+- Multi-turn message history support in the `chat` resource
+- Heartbeat integration tests
+
+### Changed
+
+- Migrated accounting to the Machine Payments Protocol (MPP) billing flow
+- Reworked authentication: satellite/transaction token handling and simplified
+  token management
+- Expanded chat streaming event handling and response models
+
+### Removed
+
+- **BREAKING:** Removed the Organization entity (organization accounts,
+  `OrganizationRole`, `organization_id`, and `owner_type`). Every endpoint is
+  now owned by a single user.
+
 ## [0.1.1] - 2026-01-27
 
 ### Added

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syfthub-sdk"
-version = "0.1.1"
+version = "0.2.0"
 description = "Python SDK for interacting with SyftHub API"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.10"

--- a/sdk/python/src/syfthub_sdk/__init__.py
+++ b/sdk/python/src/syfthub_sdk/__init__.py
@@ -100,7 +100,7 @@ from syfthub_sdk.models import (
 )
 from syfthub_sdk.syftai import SyftAIResource
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = [
     # Main client

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-17
+
+### Added
+
+- `aggregators` resource for managing user aggregator configurations
+- `apiTokens` resource for creating and managing personal access tokens
+- `agent` resource and agent models for the agent protocol
+- Multi-turn message history support in the `chat` resource
+
+### Changed
+
+- Replaced the legacy accounting service with the Machine Payments Protocol (MPP)
+  billing flow
+- Reworked authentication: satellite/transaction token handling and simplified
+  token management
+- Expanded chat streaming event handling and response models
+
+### Removed
+
+- **BREAKING:** Removed the Organization entity (organization accounts,
+  `OrganizationRole`, `organizationId`, and `ownerType`). Every endpoint is now
+  owned by a single user.
+
 ## [0.1.1] - 2026-01-27
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@syfthub/sdk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@syfthub/sdk",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.39.2",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syfthub/sdk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "TypeScript SDK for SyftHub API",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -75,11 +75,7 @@ export { PageIterator } from './pagination.js';
 export type { PageFetcher } from './pagination.js';
 
 // Models - Enums and constants
-export {
-  Visibility,
-  EndpointType,
-  UserRole,
-} from './models/index.js';
+export { Visibility, EndpointType, UserRole } from './models/index.js';
 
 // Models - Types
 export type {
@@ -143,9 +139,7 @@ export type {
 } from './models/index.js';
 
 // Model helpers
-export {
-  getEndpointPublicPath,
-} from './models/index.js';
+export { getEndpointPublicPath } from './models/index.js';
 
 // Accounting Resource (MPP wallet operations)
 export { AccountingResource, createAccountingResource } from './resources/accounting.js';

--- a/sdk/typescript/src/resources/agent.ts
+++ b/sdk/typescript/src/resources/agent.ts
@@ -22,11 +22,7 @@
  */
 
 import { SyftHubError } from '../errors.js';
-import type {
-  AgentEvent,
-  AgentSessionOptions,
-  AgentSessionState,
-} from '../models/agent.js';
+import type { AgentEvent, AgentSessionOptions, AgentSessionState } from '../models/agent.js';
 import type { AuthResource } from './auth.js';
 
 /**
@@ -82,8 +78,7 @@ export class AgentResource {
     const peerResponse = await this.auth.getPeerToken([owner]);
 
     // Build WebSocket URL
-    const wsUrl =
-      this.aggregatorUrl.replace(/^http/, 'ws') + '/agent/session';
+    const wsUrl = this.aggregatorUrl.replace(/^http/, 'ws') + '/agent/session';
 
     // Create WebSocket
     const ws = new WebSocket(wsUrl);
@@ -103,10 +98,14 @@ export class AgentResource {
 
       // Handle abort signal
       if (options.signal) {
-        options.signal.addEventListener('abort', () => {
-          ws.close();
-          reject(new AgentSessionError('Session start aborted'));
-        }, { once: true });
+        options.signal.addEventListener(
+          'abort',
+          () => {
+            ws.close();
+            reject(new AgentSessionError('Session start aborted'));
+          },
+          { once: true }
+        );
       }
     });
 
@@ -125,10 +124,12 @@ export class AgentResource {
       startPayload.messages = options.messages;
     }
 
-    ws.send(JSON.stringify({
-      type: 'session.start',
-      payload: startPayload,
-    }));
+    ws.send(
+      JSON.stringify({
+        type: 'session.start',
+        payload: startPayload,
+      })
+    );
 
     // Wait for session.created response
     const response = await new Promise<{ session_id: string }>((resolve, reject) => {
@@ -142,10 +143,12 @@ export class AgentResource {
             });
           } else if (data.type === 'agent.error') {
             ws.removeEventListener('message', onMessage);
-            reject(new AgentSessionError(
-              data.payload?.message || 'Session start failed',
-              data.payload?.code
-            ));
+            reject(
+              new AgentSessionError(
+                data.payload?.message || 'Session start failed',
+                data.payload?.code
+              )
+            );
           }
         } catch {
           reject(new AgentSessionError('Failed to parse session response'));

--- a/sdk/typescript/src/resources/api-tokens.ts
+++ b/sdk/typescript/src/resources/api-tokens.ts
@@ -73,11 +73,13 @@ export class APITokensResource {
    * // Include revoked tokens
    * const all = await client.apiTokens.list({ includeInactive: true });
    */
-  async list(options: {
-    includeInactive?: boolean;
-    skip?: number;
-    limit?: number;
-  } = {}): Promise<APITokenListResponse> {
+  async list(
+    options: {
+      includeInactive?: boolean;
+      skip?: number;
+      limit?: number;
+    } = {}
+  ): Promise<APITokenListResponse> {
     const params: Record<string, unknown> = {};
     if (options.includeInactive !== undefined) {
       params.include_inactive = options.includeInactive;

--- a/sdk/typescript/src/resources/auth.ts
+++ b/sdk/typescript/src/resources/auth.ts
@@ -243,11 +243,9 @@ export class AuthResource {
    * @throws {APIError} If the code is invalid or max attempts exceeded
    */
   async verifyOtp(input: VerifyOTPInput): Promise<User> {
-    const response = await this.http.post<AuthResponse>(
-      '/api/v1/auth/register/verify-otp',
-      input,
-      { includeAuth: false }
-    );
+    const response = await this.http.post<AuthResponse>('/api/v1/auth/register/verify-otp', input, {
+      includeAuth: false,
+    });
 
     this.http.setTokens(response.accessToken, response.refreshToken);
     return response.user;
@@ -261,9 +259,13 @@ export class AuthResource {
    * @param email - Email address to resend the OTP to
    */
   async resendOtp(email: string): Promise<void> {
-    await this.http.post<void>('/api/v1/auth/register/resend-otp', { email }, {
-      includeAuth: false,
-    });
+    await this.http.post<void>(
+      '/api/v1/auth/register/resend-otp',
+      { email },
+      {
+        includeAuth: false,
+      }
+    );
   }
 
   /**

--- a/sdk/typescript/src/resources/chat.ts
+++ b/sdk/typescript/src/resources/chat.ts
@@ -276,18 +276,12 @@ export class ChatResource {
         const sharedSlug = rawShared && rawShared !== 'all' ? rawShared : undefined;
 
         if (!collectiveSlug) {
-          throw new EndpointResolutionError(
-            `Malformed collective path: ${ds}`,
-            ds
-          );
+          throw new EndpointResolutionError(`Malformed collective path: ${ds}`, ds);
         }
 
         let memberPaths: string[];
         try {
-          memberPaths = await this.hub.getCollectiveEndpointPaths(
-            collectiveSlug,
-            sharedSlug
-          );
+          memberPaths = await this.hub.getCollectiveEndpointPaths(collectiveSlug, sharedSlug);
         } catch (error) {
           const target = sharedSlug ? `${collectiveSlug}/${sharedSlug}` : collectiveSlug;
           throw new EndpointResolutionError(

--- a/sdk/typescript/tests/chat.test.ts
+++ b/sdk/typescript/tests/chat.test.ts
@@ -336,8 +336,8 @@ describe('ChatResource', () => {
       expect(response.response).toContain('Machine learning');
 
       // Verify peer-token endpoint was called
-      const peerTokenCall = mockFetch.mock.calls.find(
-        (call: unknown[]) => (call[0] as string).includes('/api/v1/peer-token')
+      const peerTokenCall = mockFetch.mock.calls.find((call: unknown[]) =>
+        (call[0] as string).includes('/api/v1/peer-token')
       );
       expect(peerTokenCall).toBeDefined();
     });
@@ -370,8 +370,8 @@ describe('ChatResource', () => {
       });
 
       // Verify peer-token endpoint was NOT called
-      const peerTokenCall = mockFetch.mock.calls.find(
-        (call: unknown[]) => (call[0] as string).includes('/api/v1/peer-token')
+      const peerTokenCall = mockFetch.mock.calls.find((call: unknown[]) =>
+        (call[0] as string).includes('/api/v1/peer-token')
       );
       expect(peerTokenCall).toBeUndefined();
     });
@@ -409,8 +409,8 @@ describe('ChatResource', () => {
       });
 
       // Verify peer-token endpoint was NOT called (since token was provided)
-      const peerTokenCall = mockFetch.mock.calls.find(
-        (call: unknown[]) => (call[0] as string).includes('/api/v1/peer-token')
+      const peerTokenCall = mockFetch.mock.calls.find((call: unknown[]) =>
+        (call[0] as string).includes('/api/v1/peer-token')
       );
       expect(peerTokenCall).toBeUndefined();
     });
@@ -458,10 +458,7 @@ describe('ChatResource', () => {
         retrieval_info: [],
         metadata: { retrieval_time_ms: 0, generation_time_ms: 0, total_time_ms: 0 },
       };
-      const allEvents = [
-        ...events,
-        { event: 'done', data: donePayload },
-      ];
+      const allEvents = [...events, { event: 'done', data: donePayload }];
       const sseText = allEvents
         .map((e) => `event: ${e.event}\ndata: ${JSON.stringify(e.data)}\n\n`)
         .join('');
@@ -476,9 +473,7 @@ describe('ChatResource', () => {
     /**
      * Mock fetch to return a SSE stream and collect all yielded events.
      */
-    async function collectParseEvents(
-      events: { event: string; data: Record<string, unknown> }[]
-    ) {
+    async function collectParseEvents(events: { event: string; data: Record<string, unknown> }[]) {
       mockFetch.mockImplementation(async (url: string) => {
         if (url.includes('/chat/stream')) {
           return new Response(makeSseStream(events), {
@@ -852,18 +847,15 @@ describe('ChatResource', () => {
       expect(sharedCall).toBeDefined();
 
       // The non-shared endpoint-paths route must NOT have been called.
-      const defaultCall = mockFetch.mock.calls.find(
-        (call: unknown[]) =>
-          (call[0] as string).endsWith('/api/v1/collectives/by-slug/my-coll/endpoint-paths')
+      const defaultCall = mockFetch.mock.calls.find((call: unknown[]) =>
+        (call[0] as string).endsWith('/api/v1/collectives/by-slug/my-coll/endpoint-paths')
       );
       expect(defaultCall).toBeUndefined();
     });
 
     it('should treat collective/<slug>/all as an alias for the no-subset form', async () => {
       mockFetch.mockImplementation(async (url: string) => {
-        if (
-          url.endsWith('/api/v1/collectives/by-slug/my-coll/endpoint-paths')
-        ) {
+        if (url.endsWith('/api/v1/collectives/by-slug/my-coll/endpoint-paths')) {
           return new Response(JSON.stringify([]), {
             status: 200,
             headers: { 'content-type': 'application/json' },
@@ -941,10 +933,7 @@ describe('typeMatches', () => {
     ['data_source', 'model_data_source', false],
   ];
 
-  it.each(testVectors)(
-    'typeMatches(%s, %s) should return %s',
-    (actualType, expectedType, want) => {
-      expect(typeMatches(actualType, expectedType)).toBe(want);
-    }
-  );
+  it.each(testVectors)('typeMatches(%s, %s) should return %s', (actualType, expectedType, want) => {
+    expect(typeMatches(actualType, expectedType)).toBe(want);
+  });
 });


### PR DESCRIPTION
## Summary

Cuts a new **0.2.0** release for both the Python (`syfthub-sdk`) and TypeScript (`@syfthub/sdk`) SDKs. Minor bump from `0.1.1`.

Once merged, tag the merged commit on `main` to trigger publishing:

```
git tag python-sdk/v0.2.0 <merge-sha> && git push origin python-sdk/v0.2.0
git tag typescript-sdk/v0.2.0 <merge-sha> && git push origin typescript-sdk/v0.2.0
```

The release workflows validate the tag version against the manifest, run lint/typecheck/tests, then publish via OIDC trusted publishing to PyPI / npm and cut GitHub Releases.

## Changes

**Python SDK** (`sdk/python`)
- `pyproject.toml` → `0.2.0`
- `__init__.py` `__version__` → `0.2.0` (was stale at `0.1.0`)
- CHANGELOG `## [0.2.0]` entry

**TypeScript SDK** (`sdk/typescript`)
- `package.json` + `package-lock.json` → `0.2.0`
- CHANGELOG `## [0.2.0]` entry

## Why minor (not patch)

Both SDKs gained public surface since `0.1.1` — new `aggregators` and `api_tokens` resources (plus TS `agent` resource/models), MPP accounting migration, reworked auth and expanded chat streaming — and carry the **breaking** Organization-entity removal. Under 0.x semver that's a minor bump.