### PR TITLE
feat(sdk): satellite-token auth + MPP payment for direct data-source queries (0.2.1)

### DIFF
--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-17
+
+### Added
+
+- `syftai.query_data_source` now authenticates and pays like the aggregator:
+  - Auto-mints a satellite token (audience = endpoint owner username) when an
+    owner is known via the new `owner_username` argument or
+    `EndpointRef.owner_username`; falls back to a guest token.
+  - Accepts a pre-minted `authorization_token` to send as `Authorization: Bearer`.
+  - New `pay` flag settles an MPP `402 Payment Required` challenge via the Hub
+    wallet (`/api/v1/wallet/pay`) and retries with the `X-Payment` credential.
+
+### Fixed
+
+- `syftai.query_data_source` now parses the canonical SyftAI-Space response
+  shape (`references.documents` with `similarity_score`), so documents are no
+  longer silently dropped. A legacy top-level `documents` list is still honoured.
+
 ## [0.2.0] - 2026-06-17
 
 ### Added

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syfthub-sdk"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python SDK for interacting with SyftHub API"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.10"

--- a/sdk/python/src/syfthub_sdk/__init__.py
+++ b/sdk/python/src/syfthub_sdk/__init__.py
@@ -100,7 +100,7 @@ from syfthub_sdk.models import (
 )
 from syfthub_sdk.syftai import SyftAIResource
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = [
     # Main client

--- a/sdk/python/src/syfthub_sdk/syftai.py
+++ b/sdk/python/src/syfthub_sdk/syftai.py
@@ -105,6 +105,7 @@ class SyftAIResource:
     def _build_headers(
         self,
         tenant_name: str | None = None,
+        authorization_token: str | None = None,
     ) -> dict[str, str]:
         """Build headers for SyftAI-Space request."""
         headers = {
@@ -112,7 +113,57 @@ class SyftAIResource:
         }
         if tenant_name:
             headers["X-Tenant-Name"] = tenant_name
+        if authorization_token:
+            headers["Authorization"] = f"Bearer {authorization_token}"
         return headers
+
+    def _mint_satellite_token(self, audience: str) -> str | None:
+        """Mint a satellite token for ``audience`` (the endpoint owner's username).
+
+        Mirrors the aggregator's token coordination layer (``query.py``): try an
+        authenticated token first, then fall back to a guest token. Returns
+        ``None`` if both fail, so the caller can still attempt an
+        unauthenticated request (preserving the previous behaviour).
+        """
+        if self._http.is_authenticated:
+            try:
+                data = self._http.get("/api/v1/token", params={"aud": audience})
+                if isinstance(data, dict) and data.get("target_token"):
+                    return str(data["target_token"])
+            except Exception:
+                logger.debug(
+                    "Authenticated satellite token failed for '%s'; trying guest",
+                    audience,
+                )
+        try:
+            data = self._http.get(
+                "/api/v1/token/guest",
+                params={"aud": audience},
+                include_auth=False,
+            )
+            if isinstance(data, dict) and data.get("target_token"):
+                return str(data["target_token"])
+        except Exception:
+            logger.debug("Guest satellite token failed for '%s'", audience)
+        return None
+
+    def _pay_mpp(self, www_authenticate: str, slug: str) -> str | None:
+        """Pay an MPP ``402`` challenge via the Hub wallet, return an X-Payment credential.
+
+        Mirrors the aggregator's ``mpp_payment.handle_mpp_payment``: the
+        ``WWW-Authenticate`` challenge is forwarded verbatim to the Hub's
+        ``/api/v1/wallet/pay``, which parses it and returns an ``x_payment``
+        string to attach to a retry. Returns ``None`` if no challenge was given.
+        """
+        if not www_authenticate:
+            return None
+        data = self._http.post(
+            "/api/v1/wallet/pay",
+            json={"www_authenticate": www_authenticate, "endpoint_slug": slug},
+        )
+        if isinstance(data, dict) and data.get("x_payment"):
+            return str(data["x_payment"])
+        return None
 
     @staticmethod
     def _endpoint_query_url(endpoint: EndpointRef) -> str:
@@ -136,21 +187,53 @@ class SyftAIResource:
         *,
         error_cls: type[RetrievalError | GenerationError],
         error_prefix: str,
+        authorization_token: str | None = None,
+        pay: bool = False,
         **error_kwargs: str,
     ) -> httpx.Response:
-        """POST to an endpoint, mapping connection/HTTP errors to error_cls."""
+        """POST to an endpoint, mapping connection/HTTP errors to error_cls.
+
+        If the endpoint replies ``402 Payment Required`` and ``pay`` is set, the
+        MPP challenge is settled via the Hub wallet and the request is retried
+        once with the resulting ``X-Payment`` credential — mirroring how the
+        aggregator's ``DataSourceClient.query`` handles payment at this layer.
+        """
+        query_url = self._endpoint_query_url(endpoint)
+        headers = self._build_headers(endpoint.tenant_name, authorization_token)
         try:
-            response = self._client.post(
-                self._endpoint_query_url(endpoint),
-                json=body,
-                headers=self._build_headers(endpoint.tenant_name),
-            )
+            response = self._client.post(query_url, json=body, headers=headers)
         except httpx.RequestError as e:
             raise error_cls(
                 f"Failed to connect to {error_prefix} '{endpoint.slug}': {e}",
                 detail=str(e),
                 **error_kwargs,
             ) from e
+
+        # MPP 402 payment flow: pay via the Hub wallet, then retry with X-Payment.
+        if response.status_code == 402 and pay:
+            try:
+                x_payment = self._pay_mpp(
+                    response.headers.get("www-authenticate", ""), endpoint.slug
+                )
+            except httpx.HTTPError as e:
+                raise error_cls(
+                    f"Payment failed for {error_prefix} '{endpoint.slug}': {e}",
+                    detail=str(e),
+                    **error_kwargs,
+                ) from e
+            if x_payment:
+                try:
+                    response = self._client.post(
+                        query_url,
+                        json=body,
+                        headers={**headers, "X-Payment": x_payment},
+                    )
+                except httpx.RequestError as e:
+                    raise error_cls(
+                        f"Failed to connect to {error_prefix} '{endpoint.slug}': {e}",
+                        detail=str(e),
+                        **error_kwargs,
+                    ) from e
 
         if response.status_code >= 400:
             message = self._extract_error_message(response)
@@ -170,11 +253,20 @@ class SyftAIResource:
         *,
         top_k: int = 5,
         similarity_threshold: float = 0.5,
+        authorization_token: str | None = None,
+        owner_username: str | None = None,
+        pay: bool = False,
     ) -> list[Document]:
         """Query a data source endpoint directly.
 
         Sends a query to a SyftAI-Space data source endpoint and returns
         the retrieved documents.
+
+        Authentication mirrors the aggregator: SyftAI-Space endpoints expect a
+        satellite bearer token whose audience is the endpoint owner's username.
+        If ``authorization_token`` is not supplied, one is minted automatically
+        when an owner is known (``owner_username`` argument or
+        ``endpoint.owner_username``).
 
         Args:
             endpoint: EndpointRef with URL and slug
@@ -182,6 +274,13 @@ class SyftAIResource:
             user_email: User email for visibility/policy checks
             top_k: Number of documents to retrieve (default: 5)
             similarity_threshold: Minimum similarity score (default: 0.5)
+            authorization_token: Pre-minted satellite token. If omitted, one is
+                minted from the resolved owner username.
+            owner_username: Endpoint owner username used as the satellite-token
+                audience. Falls back to ``endpoint.owner_username``.
+            pay: If True, settle an MPP ``402 Payment Required`` challenge via the
+                Hub wallet and retry. If False (default), a ``402`` raises
+                ``RetrievalError``.
 
         Returns:
             List of Document objects
@@ -191,13 +290,22 @@ class SyftAIResource:
 
         Example:
             docs = client.syftai.query_data_source(
-                endpoint=EndpointRef(url="http://syftai:8080", slug="docs"),
+                endpoint=EndpointRef(
+                    url="http://syftai:8080", slug="docs", owner_username="alice"
+                ),
                 query="What is machine learning?",
                 user_email="alice@example.com",
+                pay=True,  # auto-pay if the endpoint is metered
             )
             for doc in docs:
                 print(f"[{doc.score:.2f}] {doc.content[:100]}...")
         """
+        token = authorization_token
+        if token is None:
+            audience = owner_username or endpoint.owner_username
+            if audience:
+                token = self._mint_satellite_token(audience)
+
         request_body = {
             "user_email": user_email,
             "messages": query,  # SyftAI-Space expects "messages" for query text
@@ -210,21 +318,43 @@ class SyftAIResource:
             request_body,
             error_cls=RetrievalError,
             error_prefix="data source",
+            authorization_token=token,
+            pay=pay,
             source_path=endpoint.slug,
         )
 
-        data = response.json()
-        documents = []
+        return self._parse_documents(response.json())
 
-        for doc in data.get("documents", []):
-            documents.append(
-                Document(
-                    content=doc.get("content", ""),
-                    score=doc.get("score", 0.0),
-                    metadata=doc.get("metadata", {}),
+    @staticmethod
+    def _parse_documents(data: dict[str, object]) -> list[Document]:
+        """Parse documents from a SyftAI-Space query response.
+
+        Mirrors the aggregator's ``DataSourceClient._parse_syftai_response``:
+        the canonical shape nests documents under ``references.documents`` and
+        names the score ``similarity_score``. A legacy top-level ``documents``
+        list (with ``score``) is still honoured for backward compatibility.
+        """
+        references = data.get("references")
+        if isinstance(references, dict):
+            raw_docs = references.get("documents", [])
+            score_key = "similarity_score"
+        else:
+            raw_docs = data.get("documents", [])
+            score_key = "score"
+
+        documents: list[Document] = []
+        if isinstance(raw_docs, list):
+            for doc in raw_docs:
+                if not isinstance(doc, dict):
+                    continue
+                raw_score = doc.get(score_key, doc.get("score", 0.0))
+                documents.append(
+                    Document(
+                        content=doc.get("content", ""),
+                        score=float(raw_score or 0.0),
+                        metadata=doc.get("metadata", {}),
+                    )
                 )
-            )
-
         return documents
 
     def query_model(

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-17
+
+### Added
+
+- `syftai.queryDataSource` now authenticates and pays like the aggregator:
+  - Auto-mints a satellite token (audience = endpoint owner username) when an
+    owner is known via the new `ownerUsername` option or
+    `EndpointRef.ownerUsername`; falls back to a guest token.
+  - Accepts a pre-minted `authorizationToken` to send as `Authorization: Bearer`.
+  - New `pay` option settles an MPP `402 Payment Required` challenge via the Hub
+    wallet (`/api/v1/wallet/pay`) and retries with the `X-Payment` credential.
+
+### Fixed
+
+- `syftai.queryDataSource` now parses the canonical SyftAI-Space response shape
+  (`references.documents` with `similarity_score`), so documents are no longer
+  silently dropped. A legacy top-level `documents` list is still honoured.
+
 ## [0.2.0] - 2026-06-17
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@syfthub/sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@syfthub/sdk",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.39.2",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syfthub/sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "TypeScript SDK for SyftHub API",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -361,7 +361,7 @@ export class SyftHubClient {
    */
   get syftai(): SyftAIResource {
     if (!this._syftai) {
-      this._syftai = new SyftAIResource();
+      this._syftai = new SyftAIResource(this.http);
     }
     return this._syftai;
   }

--- a/sdk/typescript/src/models/chat.ts
+++ b/sdk/typescript/src/models/chat.ts
@@ -171,6 +171,22 @@ export interface QueryDataSourceOptions {
   topK?: number;
   /** Minimum similarity score (default: 0.5) */
   similarityThreshold?: number;
+  /**
+   * Pre-minted satellite token to send as `Authorization: Bearer`. If omitted,
+   * one is minted automatically when an owner is known (see `ownerUsername` /
+   * `endpoint.ownerUsername`).
+   */
+  authorizationToken?: string;
+  /**
+   * Endpoint owner username used as the satellite-token audience. Falls back to
+   * `endpoint.ownerUsername`.
+   */
+  ownerUsername?: string;
+  /**
+   * If true, settle an MPP `402 Payment Required` challenge via the Hub wallet
+   * and retry. If false (default), a `402` throws a `RetrievalError`.
+   */
+  pay?: boolean;
 }
 
 /**

--- a/sdk/typescript/src/resources/syftai.ts
+++ b/sdk/typescript/src/resources/syftai.ts
@@ -24,6 +24,7 @@
  */
 
 import type { Document, QueryDataSourceOptions, QueryModelOptions } from '../models/chat.js';
+import type { HTTPClient } from '../http.js';
 import { SyftHubError } from '../errors.js';
 import { readSSEEvents } from '../utils.js';
 
@@ -67,30 +68,130 @@ export class GenerationError extends SyftHubError {
  * For most use cases, prefer the higher-level `client.chat` API instead.
  */
 export class SyftAIResource {
-  // No dependencies - uses direct fetch to SyftAI-Space endpoints
+  /**
+   * @param http - Hub HTTP client, used to mint satellite tokens and settle
+   *   MPP payments. Endpoint queries themselves use direct `fetch`, since the
+   *   SyftAI-Space URL is arbitrary and not the Hub base URL.
+   */
+  constructor(private readonly http: HTTPClient) {}
+
+  /**
+   * Mint a satellite token for `audience` (the endpoint owner's username).
+   *
+   * Mirrors the aggregator's token coordination layer: try an authenticated
+   * token first, then fall back to a guest token. Returns `undefined` if both
+   * fail, so the caller can still attempt an unauthenticated request.
+   */
+  private async mintSatelliteToken(audience: string): Promise<string | undefined> {
+    if (this.http.hasTokens()) {
+      try {
+        const res = await this.http.get<{ targetToken?: string }>('/api/v1/token', {
+          aud: audience,
+        });
+        if (res.targetToken) return res.targetToken;
+      } catch {
+        // fall through to guest
+      }
+    }
+    try {
+      const res = await this.http.get<{ targetToken?: string }>(
+        '/api/v1/token/guest',
+        { aud: audience },
+        { includeAuth: false }
+      );
+      return res.targetToken;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Pay an MPP `402` challenge via the Hub wallet, returning an X-Payment credential.
+   *
+   * Mirrors the aggregator's `handleMppPayment`: the `WWW-Authenticate`
+   * challenge is forwarded verbatim to the Hub's `/api/v1/wallet/pay`, which
+   * parses it and returns an `x_payment` string to attach to a retry.
+   */
+  private async payMpp(wwwAuthenticate: string, slug: string): Promise<string | undefined> {
+    if (!wwwAuthenticate) return undefined;
+    const res = await this.http.post<{ xPayment?: string }>('/api/v1/wallet/pay', {
+      wwwAuthenticate,
+      endpointSlug: slug,
+    });
+    return res.xPayment;
+  }
 
   /**
    * Build headers for SyftAI-Space request.
    */
-  private buildHeaders(tenantName?: string): Record<string, string> {
+  private buildHeaders(tenantName?: string, authorizationToken?: string): Record<string, string> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
     };
     if (tenantName) {
       headers['X-Tenant-Name'] = tenantName;
     }
+    if (authorizationToken) {
+      headers['Authorization'] = `Bearer ${authorizationToken}`;
+    }
     return headers;
   }
 
   /**
+   * Parse documents from a SyftAI-Space query response.
+   *
+   * Mirrors the aggregator's `DataSourceClient._parse_syftai_response`: the
+   * canonical shape nests documents under `references.documents` and names the
+   * score `similarity_score`. A legacy top-level `documents` list (with
+   * `score`) is still honoured for backward compatibility.
+   */
+  private parseDocuments(data: Record<string, unknown>): Document[] {
+    const references = data['references'] as Record<string, unknown> | undefined;
+    let rawDocs: Record<string, unknown>[] | undefined;
+    let scoreKey = 'score';
+    if (references && typeof references === 'object') {
+      rawDocs = references['documents'] as Record<string, unknown>[] | undefined;
+      scoreKey = 'similarity_score';
+    } else {
+      rawDocs = data['documents'] as Record<string, unknown>[] | undefined;
+    }
+
+    const documents: Document[] = [];
+    if (Array.isArray(rawDocs)) {
+      for (const doc of rawDocs) {
+        documents.push({
+          content: String(doc['content'] ?? ''),
+          score: Number(doc[scoreKey] ?? doc['score'] ?? 0),
+          metadata: (doc['metadata'] as Record<string, unknown>) ?? {},
+        });
+      }
+    }
+    return documents;
+  }
+
+  /**
    * Query a data source endpoint directly.
+   *
+   * Authentication mirrors the aggregator: SyftAI-Space endpoints expect a
+   * satellite bearer token whose audience is the endpoint owner's username. If
+   * `authorizationToken` is not supplied, one is minted automatically when an
+   * owner is known (`ownerUsername` option or `endpoint.ownerUsername`).
    *
    * @param options - Query options
    * @returns Array of Document objects
    * @throws {RetrievalError} If the query fails
    */
   async queryDataSource(options: QueryDataSourceOptions): Promise<Document[]> {
-    const { endpoint, query, userEmail, topK = 5, similarityThreshold = 0.5 } = options;
+    const {
+      endpoint,
+      query,
+      userEmail,
+      topK = 5,
+      similarityThreshold = 0.5,
+      authorizationToken,
+      ownerUsername,
+      pay = false,
+    } = options;
 
     const url = `${endpoint.url.replace(/\/$/, '')}/api/v1/endpoints/${endpoint.slug}/query`;
 
@@ -101,19 +202,49 @@ export class SyftAIResource {
       similarity_threshold: similarityThreshold,
     };
 
-    let response: Response;
-    try {
-      response = await fetch(url, {
-        method: 'POST',
-        headers: this.buildHeaders(endpoint.tenantName),
-        body: JSON.stringify(requestBody),
-      });
-    } catch (error) {
-      throw new RetrievalError(
-        `Failed to connect to data source '${endpoint.slug}': ${error instanceof Error ? error.message : String(error)}`,
-        endpoint.slug,
-        error
-      );
+    // Resolve a satellite token: caller-supplied, else mint from the owner.
+    let token = authorizationToken;
+    if (!token) {
+      const audience = ownerUsername ?? endpoint.ownerUsername;
+      if (audience) {
+        token = await this.mintSatelliteToken(audience);
+      }
+    }
+    const headers = this.buildHeaders(endpoint.tenantName, token);
+
+    const postQuery = async (extraHeaders?: Record<string, string>): Promise<Response> => {
+      try {
+        return await fetch(url, {
+          method: 'POST',
+          headers: { ...headers, ...extraHeaders },
+          body: JSON.stringify(requestBody),
+        });
+      } catch (error) {
+        throw new RetrievalError(
+          `Failed to connect to data source '${endpoint.slug}': ${error instanceof Error ? error.message : String(error)}`,
+          endpoint.slug,
+          error
+        );
+      }
+    };
+
+    let response = await postQuery();
+
+    // MPP 402 payment flow: pay via the Hub wallet, then retry with X-Payment.
+    if (response.status === 402 && pay) {
+      let xPayment: string | undefined;
+      try {
+        xPayment = await this.payMpp(response.headers.get('www-authenticate') ?? '', endpoint.slug);
+      } catch (error) {
+        throw new RetrievalError(
+          `Payment failed for data source '${endpoint.slug}': ${error instanceof Error ? error.message : String(error)}`,
+          endpoint.slug,
+          error
+        );
+      }
+      if (xPayment) {
+        response = await postQuery({ 'X-Payment': xPayment });
+      }
     }
 
     if (!response.ok) {
@@ -128,18 +259,7 @@ export class SyftAIResource {
     }
 
     const data = (await response.json()) as Record<string, unknown>;
-    const documents: Document[] = [];
-
-    const docsData = data['documents'] as Record<string, unknown>[] | undefined;
-    if (Array.isArray(docsData)) {
-      for (const doc of docsData) {
-        documents.push({
-          content: String(doc['content'] ?? ''),
-          score: Number(doc['score'] ?? 0),
-          metadata: (doc['metadata'] as Record<string, unknown>) ?? {},
-        });
-      }
-    }
+    const documents = this.parseDocuments(data);
 
     return documents;
   }


### PR DESCRIPTION
## Summary

The low-level **direct** path — `client.syftai.query_data_source` (Python) / `client.syftai.queryDataSource` (TypeScript) — talks straight to a SyftAI-Space endpoint, bypassing the aggregator. It did so with **no authentication and no payment handling**, so:

- endpoints requiring a satellite token returned `401 Bearer token required`,
- metered endpoints returned `402 Payment Required`,
- and it parsed the **wrong response shape**, silently dropping every document.

Only the aggregator (`client.chat`) path worked. This PR brings the direct path in line with how the aggregator handles a per-endpoint call, **mirroring its separation of concerns** rather than duplicating logic.

## What changed

**Satellite token — injected, not baked into the leaf** (mirrors the aggregator's token coordination in `query.py`):
- callers may pass `authorization_token` / `authorizationToken`, **or**
- it is auto-minted using the endpoint owner as the audience (`owner_username` arg or `EndpointRef.owner_username`), with an authenticated→guest fallback.

**MPP 402 payment — handled at the leaf** (mirrors `DataSourceClient.query` + `mpp_payment.handle_mpp_payment`):
- new `pay` flag (default **false**). On `402` with `pay=true`, the `WWW-Authenticate` challenge is forwarded to the Hub wallet (`/api/v1/wallet/pay`) and the request retried with the returned `X-Payment` credential.
- default `pay=false` means a metered endpoint **raises** instead of silently spending.

**Response parsing fixed** (mirrors `_parse_syftai_response`):
- reads the canonical `references.documents` shape with `similarity_score`; keeps a legacy top-level `documents` fallback.

**Deliberately *not* duplicated:** the deprecated transaction-token body field, and client-side challenge parsing (the backend `wallet/pay` owns that).

**TypeScript wiring:** `SyftAIResource` now receives the `HTTPClient` (was dependency-free) to mint tokens / settle payments; endpoint queries stay on raw `fetch`.



## Backward compatibility

All new params are optional. Omit the owner ⇒ no token minted (old behavior); omit `pay` ⇒ a `402` raises instead of spending. Impact analysis on `query_data_source`: **0 upstream callers, LOW risk**.

## Verification

- **Live end-to-end (Python):** returned 5 documents against a real metered endpoint — auto-mint → `402` → auto-pay → retry → correct parse.
- **Python:** mypy ✓, ruff ✓, 14/14 unit tests ✓.
- **TypeScript:** tsc ✓, ESLint ✓, prettier `format:check` ✓, build ✓, 14/14 unit tests ✓.
- `gitnexus detect_changes`: LOW risk, 0 affected processes.

## Release

Bumps both SDKs to **0.2.1** (versions, lockfile, changelogs).

## Follow-ups (not in this PR)

- `query_model` / `queryModel` have the same token/payment gap and could reuse these helpers.
- The SDK **chat** path doesn't forward the user token to the aggregator, so paid endpoints fail there too — separate fix.
