### PR TITLE
feat(sdk): symmetric client.search.query() for retrieval-only queries; release 0.3.0

### DIFF
--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-17
+
+### Added
+
+- `client.search.query(...)` — retrieval-only search via the Aggregator,
+  symmetric to `client.chat.complete(...)`. Queries data sources for relevant
+  documents without invoking a model. Satellite-token auth and MPP payment are
+  handled server-side by the aggregator exactly as for chat. Returns a
+  `SearchResponse` with a `documents` list (`SearchDocument`) plus per-source
+  `retrieval_info` and timing `metadata`. The underlying primitive is
+  `client.chat.retrieve(...)`.
+
+### Fixed
+
+- The chat path now forwards the caller's Hub token as `user_token` to the
+  aggregator, so metered model/data-source endpoints that return
+  `402 Payment Required` are settled via the Hub wallet (previously only the
+  TypeScript SDK did this).
+
 ## [0.2.1] - 2026-06-17
 
 ### Added

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syfthub-sdk"
-version = "0.2.1"
+version = "0.3.0"
 description = "Python SDK for interacting with SyftHub API"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.10"

--- a/sdk/python/src/syfthub_sdk/__init__.py
+++ b/sdk/python/src/syfthub_sdk/__init__.py
@@ -86,6 +86,8 @@ from syfthub_sdk.models import (
     PeerTokenResponse,
     Policy,
     SatelliteTokenResponse,
+    SearchDocument,
+    SearchResponse,
     SourceInfo,
     SourceStatus,
     SyncEndpointsResponse,
@@ -98,9 +100,10 @@ from syfthub_sdk.models import (
     UserRole,
     Visibility,
 )
+from syfthub_sdk.search import SearchResource
 from syfthub_sdk.syftai import SyftAIResource
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 __all__ = [
     # Main client
@@ -134,6 +137,8 @@ __all__ = [
     "SourceStatus",
     "ChatMetadata",
     "ChatResponse",
+    "SearchDocument",
+    "SearchResponse",
     "TokenUsage",
     "Message",
     # Chat streaming events
@@ -148,6 +153,7 @@ __all__ = [
     # Resources (for type hints)
     "APITokensResource",
     "ChatResource",
+    "SearchResource",
     "SyftAIResource",
     # NATS models
     "NatsCredentials",

--- a/sdk/python/src/syfthub_sdk/auth.py
+++ b/sdk/python/src/syfthub_sdk/auth.py
@@ -55,6 +55,16 @@ class AuthResource:
         """
         self._http = http
 
+    def get_access_token(self) -> str | None:
+        """Return the current Hub bearer token (API token or JWT access token).
+
+        Used to authorize MPP wallet payments: the aggregator forwards this
+        token to the Hub's ``/wallet/pay`` endpoint when a data source or model
+        responds with ``402 Payment Required``. Returns ``None`` when the client
+        is unauthenticated (e.g. guest mode).
+        """
+        return self._http._get_bearer_token()
+
     def register(
         self,
         *,

--- a/sdk/python/src/syfthub_sdk/chat.py
+++ b/sdk/python/src/syfthub_sdk/chat.py
@@ -51,6 +51,8 @@ from syfthub_sdk.models import (
     EndpointPublic,
     EndpointRef,
     EndpointType,
+    SearchDocument,
+    SearchResponse,
     SourceInfo,
     SourceStatus,
     TokenUsage,
@@ -510,12 +512,16 @@ class ChatResource:
         messages: list[dict[str, str]] | None = None,
         peer_token: str | None = None,
         peer_channel: str | None = None,
+        user_token: str | None = None,
+        retrieval_only: bool = False,
     ) -> dict[str, Any]:
         """Build the request body for the aggregator.
 
         Includes endpoint_tokens mapping for satellite token authentication
-        and transaction_tokens for billing authorization.
-        User identity is derived from satellite tokens, not passed in request body.
+        and transaction_tokens for billing authorization. The user_token (the
+        caller's Hub bearer token) authorizes MPP wallet payments on 402
+        responses. User identity is derived from satellite tokens, not passed
+        in request body.
         """
         body: dict[str, Any] = {
             "prompt": prompt,
@@ -552,6 +558,14 @@ class ChatResource:
             body["peer_token"] = peer_token
         if peer_channel:
             body["peer_channel"] = peer_channel
+
+        # User token authorizes MPP wallet payments on 402 responses.
+        if user_token:
+            body["user_token"] = user_token
+
+        # Retrieval-only: aggregator skips reranking + generation.
+        if retrieval_only:
+            body["retrieval_only"] = True
 
         return body
 
@@ -640,11 +654,12 @@ class ChatResource:
         messages: list[dict[str, str]] | None,
         aggregator_url: str | None,
         guest_mode: bool = False,
+        retrieval_only: bool = False,
     ) -> tuple[dict[str, Any], str]:
         """Resolve endpoints, fetch tokens, and build the aggregator request body.
 
-        Returns (request_body, effective_aggregator_url). Called by both
-        complete() and stream() to avoid duplicating ~35 lines of setup.
+        Returns (request_body, effective_aggregator_url). Called by complete(),
+        stream() and retrieve() to avoid duplicating ~35 lines of setup.
         """
         effective_aggregator_url = (aggregator_url or self._aggregator_url).rstrip("/")
 
@@ -661,9 +676,12 @@ class ChatResource:
         if guest_mode:
             endpoint_tokens = self._auth.get_guest_satellite_tokens(unique_owners)
             transaction_tokens: dict[str, str] = {}
+            user_token: str | None = None
         else:
             endpoint_tokens = self._get_satellite_tokens_for_owners(unique_owners)
             transaction_tokens = self._get_transaction_tokens_for_owners(unique_owners)
+            # Authorizes MPP wallet payments when a metered endpoint returns 402.
+            user_token = self._auth.get_access_token()
 
         peer_token = None
         peer_channel = None
@@ -690,6 +708,8 @@ class ChatResource:
             messages=messages,
             peer_token=peer_token,
             peer_channel=peer_channel,
+            user_token=user_token,
+            retrieval_only=retrieval_only,
         )
         return request_body, effective_aggregator_url
 
@@ -839,6 +859,95 @@ class ChatResource:
             retrieval_info=self._parse_retrieval_info(data),
             metadata=metadata,
             usage=self._parse_usage(data),
+        )
+
+    # Placeholder model for retrieval-only requests. The aggregator requires a
+    # ``model`` field on every request, but short-circuits before dereferencing
+    # it when ``retrieval_only`` is set, so an empty ref is never contacted.
+    _RETRIEVAL_ONLY_MODEL = EndpointRef(url="", slug="", name="retrieval-only")
+
+    def retrieve(
+        self,
+        prompt: str,
+        data_sources: list[str | EndpointRef | EndpointPublic] | None = None,
+        *,
+        top_k: int = 5,
+        similarity_threshold: float = 0.5,
+        aggregator_url: str | None = None,
+        guest_mode: bool = False,
+    ) -> SearchResponse:
+        """Retrieve documents from data sources without model generation.
+
+        This drives the aggregator's retrieval-only path: data sources are
+        queried in parallel (with satellite-token auth and MPP payment handled
+        server-side, exactly like :meth:`complete`), but no model is invoked.
+
+        Prefer the symmetric ``client.search.query(...)`` facade; this is the
+        underlying primitive.
+
+        Args:
+            prompt: The search query.
+            data_sources: Data source endpoints (paths, EndpointRefs, or
+                EndpointPublic; ``collective/<slug>`` paths are expanded).
+            top_k: Number of documents to retrieve per source (default: 5).
+            similarity_threshold: Minimum similarity for retrieved docs
+                (default: 0.5).
+            aggregator_url: Custom aggregator URL (optional).
+            guest_mode: Use guest (unauthenticated) tokens (default: False).
+
+        Returns:
+            SearchResponse with retrieved documents and per-source metadata.
+
+        Raises:
+            EndpointResolutionError: If a data source cannot be resolved.
+            AggregatorError: If the aggregator service fails.
+        """
+        request_body, effective_aggregator_url = self._prepare_request(
+            prompt=prompt,
+            model=self._RETRIEVAL_ONLY_MODEL,
+            data_sources=data_sources,
+            top_k=top_k,
+            max_tokens=1,
+            temperature=0.0,
+            similarity_threshold=similarity_threshold,
+            stream=False,
+            messages=None,
+            aggregator_url=aggregator_url,
+            guest_mode=guest_mode,
+            retrieval_only=True,
+        )
+
+        try:
+            response = self._agg_client.post(
+                f"{effective_aggregator_url}/chat",
+                json=request_body,
+                headers={"Content-Type": "application/json"},
+            )
+        except httpx.RequestError as e:
+            raise AggregatorError(
+                f"Failed to connect to aggregator: {e}",
+                detail=str(e),
+            ) from e
+
+        if response.status_code >= 400:
+            self._handle_aggregator_error(response)
+
+        data = response.json()
+
+        metadata = self._parse_metadata(data) or ChatMetadata(
+            retrieval_time_ms=0,
+            generation_time_ms=0,
+            total_time_ms=0,
+        )
+        documents = [
+            SearchDocument(title=title, slug=source.slug, content=source.content)
+            for title, source in self._parse_sources(data).items()
+        ]
+
+        return SearchResponse(
+            documents=documents,
+            retrieval_info=self._parse_retrieval_info(data),
+            metadata=metadata,
         )
 
     def stream(

--- a/sdk/python/src/syfthub_sdk/client.py
+++ b/sdk/python/src/syfthub_sdk/client.py
@@ -20,6 +20,7 @@ from syfthub_sdk.exceptions import ConfigurationError
 from syfthub_sdk.hub import HubResource
 from syfthub_sdk.models import AuthTokens, RegisterResult, User
 from syfthub_sdk.my_endpoints import MyEndpointsResource
+from syfthub_sdk.search import SearchResource
 from syfthub_sdk.syftai import SyftAIResource
 from syfthub_sdk.users import UsersResource
 
@@ -143,6 +144,7 @@ class SyftHubClient:
 
         # Lazy-initialized resources
         self._chat: ChatResource | None = None
+        self._search: SearchResource | None = None
         self._syftai: SyftAIResource | None = None
         self._accounting: AccountingResource | None = None
         self._api_tokens: APITokensResource | None = None
@@ -253,6 +255,26 @@ class SyftHubClient:
                 aggregator_url=self._aggregator_url,
             )
         return self._chat
+
+    @property
+    def search(self) -> SearchResource:
+        """Retrieval-only search via the Aggregator (no model generation).
+
+        Symmetric counterpart to :attr:`chat`: queries data sources for
+        relevant documents without invoking a model. Satellite-token auth and
+        MPP payment are handled by the aggregator exactly as for chat.
+
+        Example:
+            response = client.search.query(
+                prompt="Hello, world!",
+                data_sources=["epfl-news/epfl-news"],
+            )
+            for doc in response.documents:
+                print(doc.title, doc.content[:80])
+        """
+        if self._search is None:
+            self._search = SearchResource(self.chat)
+        return self._search
 
     @property
     def syftai(self) -> SyftAIResource:

--- a/sdk/python/src/syfthub_sdk/models.py
+++ b/sdk/python/src/syfthub_sdk/models.py
@@ -487,6 +487,44 @@ class ChatResponse(BaseModel):
     model_config = {"frozen": True}
 
 
+class SearchDocument(BaseModel):
+    """A single document returned by a retrieval-only search.
+
+    Unlike :class:`Document` (the low-level direct-query shape), this carries
+    the document title and the source endpoint path, matching the aggregated
+    ``sources`` map returned by the aggregator's retrieval-only path.
+    """
+
+    title: str = Field(..., description="Document title (key in the sources map)")
+    slug: str = Field(
+        ..., description="Source endpoint path (owner/slug) the document came from"
+    )
+    content: str = Field(..., description="The document content")
+
+    model_config = {"frozen": True}
+
+
+class SearchResponse(BaseModel):
+    """Response from a retrieval-only search via the Aggregator.
+
+    Mirrors :class:`ChatResponse` minus the generated text: retrieval runs
+    across the data sources (with satellite-token auth and MPP payment handled
+    by the aggregator), but no model is invoked.
+    """
+
+    documents: list[SearchDocument] = Field(
+        default_factory=list,
+        description="Retrieved documents across all data sources",
+    )
+    retrieval_info: list[SourceInfo] = Field(
+        default_factory=list,
+        description="Metadata about each data source retrieval (status, count, errors)",
+    )
+    metadata: ChatMetadata = Field(..., description="Timing metadata")
+
+    model_config = {"frozen": True}
+
+
 class Message(BaseModel):
     """A chat message for model queries.
 

--- a/sdk/python/src/syfthub_sdk/search.py
+++ b/sdk/python/src/syfthub_sdk/search.py
@@ -1,0 +1,89 @@
+"""Search resource for retrieval-only queries via the Aggregator service.
+
+This is the symmetric counterpart to :class:`~syfthub_sdk.chat.ChatResource`:
+where ``client.chat.complete(...)`` retrieves context *and* generates a model
+response, ``client.search.query(...)`` retrieves documents from data sources
+without invoking any model.
+
+Example usage:
+    # Symmetric to client.chat.complete(...)
+    response = client.search.query(
+        prompt="What happened at EPFL this week?",
+        data_sources=["epfl-news/epfl-news"],
+    )
+    for doc in response.documents:
+        print(doc.title, "->", doc.content[:80])
+
+Authentication and billing are handled by the aggregator exactly as for chat:
+satellite tokens are minted per data source owner, and metered endpoints that
+respond with ``402 Payment Required`` are settled via the user's Hub wallet.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from syfthub_sdk.models import EndpointPublic, EndpointRef, SearchResponse
+
+if TYPE_CHECKING:
+    from syfthub_sdk.chat import ChatResource
+
+
+class SearchResource:
+    """Retrieval-only search via the Aggregator.
+
+    Thin facade over :meth:`ChatResource.retrieve`, exposed as ``client.search``
+    to mirror the shape of ``client.chat``.
+    """
+
+    def __init__(self, chat: ChatResource) -> None:
+        """Initialize the search resource.
+
+        Args:
+            chat: The chat resource that owns aggregator communication and
+                request preparation (satellite tokens, MPP, collective
+                expansion). Search reuses it rather than duplicating that logic.
+        """
+        self._chat = chat
+
+    def query(
+        self,
+        prompt: str,
+        data_sources: list[str | EndpointRef | EndpointPublic] | None = None,
+        *,
+        top_k: int = 5,
+        similarity_threshold: float = 0.5,
+        aggregator_url: str | None = None,
+        guest_mode: bool = False,
+    ) -> SearchResponse:
+        """Retrieve documents from data sources without model generation.
+
+        Args:
+            prompt: The search query.
+            data_sources: Data source endpoints (paths like ``owner/slug``,
+                ``EndpointRef``/``EndpointPublic`` objects, or
+                ``collective/<slug>`` paths which are expanded to members).
+            top_k: Number of documents to retrieve per source (default: 5).
+            similarity_threshold: Minimum similarity for retrieved docs
+                (default: 0.5).
+            aggregator_url: Custom aggregator URL (optional).
+            guest_mode: Use guest (unauthenticated) tokens (default: False).
+
+        Returns:
+            SearchResponse with retrieved documents and per-source metadata.
+
+        Example:
+            response = client.search.query(
+                prompt="Hello, world!",
+                data_sources=["epfl-news/epfl-news"],
+            )
+            print(len(response.documents), "documents")
+        """
+        return self._chat.retrieve(
+            prompt=prompt,
+            data_sources=data_sources,
+            top_k=top_k,
+            similarity_threshold=similarity_threshold,
+            aggregator_url=aggregator_url,
+            guest_mode=guest_mode,
+        )

--- a/sdk/python/tests/unit/test_search.py
+++ b/sdk/python/tests/unit/test_search.py
@@ -1,0 +1,181 @@
+"""Unit tests for SearchResource (retrieval-only via the Aggregator)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from syfthub_sdk import SyftHubClient
+from syfthub_sdk.exceptions import AggregatorError
+from syfthub_sdk.models import AuthTokens, EndpointRef, SearchDocument, SearchResponse
+
+
+@pytest.fixture
+def base_url() -> str:
+    return "https://test.syfthub.com"
+
+
+@pytest.fixture
+def aggregator_url(base_url: str) -> str:
+    return f"{base_url}/aggregator/api/v1"
+
+
+@pytest.fixture
+def fake_tokens() -> AuthTokens:
+    return AuthTokens(
+        access_token="fake-access-token",
+        refresh_token="fake-refresh-token",
+    )
+
+
+@pytest.fixture
+def mock_search_response() -> dict[str, Any]:
+    """Aggregator retrieval-only response: empty text, populated sources map."""
+    return {
+        "response": "",
+        "sources": {
+            "EPFL News #1": {"slug": "epfl-news/epfl-news", "content": "First story."},
+            "EPFL News #2": {"slug": "epfl-news/epfl-news", "content": "Second story."},
+        },
+        "retrieval_info": [
+            {
+                "path": "epfl-news/epfl-news",
+                "documents_retrieved": 2,
+                "status": "success",
+            }
+        ],
+        "metadata": {
+            "retrieval_time_ms": 120,
+            "generation_time_ms": 0,
+            "total_time_ms": 120,
+        },
+    }
+
+
+@pytest.fixture
+def mock_satellite_token_response() -> dict[str, Any]:
+    return {"target_token": "fake-satellite-token", "expires_in": 3600}
+
+
+class TestSearchQuery:
+    """Tests for SearchResource.query()."""
+
+    @respx.mock
+    def test_query_returns_documents(
+        self,
+        base_url: str,
+        aggregator_url: str,
+        fake_tokens: AuthTokens,
+        mock_search_response: dict[str, Any],
+        mock_satellite_token_response: dict[str, Any],
+    ) -> None:
+        respx.get(f"{base_url}/api/v1/token").mock(
+            return_value=httpx.Response(200, json=mock_satellite_token_response)
+        )
+        respx.post(f"{aggregator_url}/chat").mock(
+            return_value=httpx.Response(200, json=mock_search_response)
+        )
+
+        client = SyftHubClient(base_url=base_url)
+        client._http.set_tokens(fake_tokens)
+
+        ds = EndpointRef(
+            url="http://20.0.5.93:8081",
+            slug="epfl-news",
+            owner_username="epfl-news",
+        )
+        response = client.search.query(prompt="What happened?", data_sources=[ds])
+
+        assert isinstance(response, SearchResponse)
+        assert len(response.documents) == 2
+        assert all(isinstance(d, SearchDocument) for d in response.documents)
+        assert {d.content for d in response.documents} == {
+            "First story.",
+            "Second story.",
+        }
+        assert response.documents[0].slug == "epfl-news/epfl-news"
+        assert response.retrieval_info[0].documents_retrieved == 2
+        assert response.metadata.generation_time_ms == 0
+
+    @respx.mock
+    def test_query_sends_retrieval_only_and_user_token(
+        self,
+        base_url: str,
+        aggregator_url: str,
+        fake_tokens: AuthTokens,
+        mock_search_response: dict[str, Any],
+        mock_satellite_token_response: dict[str, Any],
+    ) -> None:
+        """The aggregator request must flag retrieval_only and forward the
+        user token (so metered sources can be paid server-side)."""
+        respx.get(f"{base_url}/api/v1/token").mock(
+            return_value=httpx.Response(200, json=mock_satellite_token_response)
+        )
+        route = respx.post(f"{aggregator_url}/chat").mock(
+            return_value=httpx.Response(200, json=mock_search_response)
+        )
+
+        client = SyftHubClient(base_url=base_url)
+        client._http.set_tokens(fake_tokens)
+
+        ds = EndpointRef(
+            url="http://20.0.5.93:8081", slug="epfl-news", owner_username="epfl-news"
+        )
+        client.search.query(prompt="hi", data_sources=[ds])
+
+        sent = json.loads(route.calls.last.request.content)
+        assert sent["retrieval_only"] is True
+        assert sent["user_token"] == "fake-access-token"
+        # Placeholder model is present but empty (never contacted by aggregator).
+        assert sent["model"]["url"] == ""
+        assert sent["model"]["slug"] == ""
+
+    @respx.mock
+    def test_query_guest_mode_omits_user_token(
+        self,
+        base_url: str,
+        aggregator_url: str,
+        mock_search_response: dict[str, Any],
+    ) -> None:
+        respx.get(f"{base_url}/api/v1/token/guest").mock(
+            return_value=httpx.Response(200, json={"target_token": "guest-tok"})
+        )
+        route = respx.post(f"{aggregator_url}/chat").mock(
+            return_value=httpx.Response(200, json=mock_search_response)
+        )
+
+        client = SyftHubClient(base_url=base_url)
+        ds = EndpointRef(
+            url="http://20.0.5.93:8081", slug="epfl-news", owner_username="epfl-news"
+        )
+        client.search.query(prompt="hi", data_sources=[ds], guest_mode=True)
+
+        sent = json.loads(route.calls.last.request.content)
+        assert sent["retrieval_only"] is True
+        assert "user_token" not in sent
+
+    @respx.mock
+    def test_query_aggregator_error(
+        self,
+        base_url: str,
+        aggregator_url: str,
+        fake_tokens: AuthTokens,
+    ) -> None:
+        respx.post(f"{aggregator_url}/chat").mock(
+            return_value=httpx.Response(500, json={"message": "boom"})
+        )
+
+        client = SyftHubClient(base_url=base_url)
+        client._http.set_tokens(fake_tokens)
+
+        ds = EndpointRef(url="http://20.0.5.93:8081", slug="epfl-news")
+        with pytest.raises(AggregatorError, match="boom"):
+            client.search.query(prompt="hi", data_sources=[ds])
+
+    def test_search_resource_is_cached(self, base_url: str) -> None:
+        client = SyftHubClient(base_url=base_url)
+        assert client.search is client.search

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -608,7 +608,7 @@ wheels = [
 
 [[package]]
 name = "syfthub-sdk"
-version = "0.1.1"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-17
+
+### Added
+
+- `client.search.query(...)` — retrieval-only search via the Aggregator,
+  symmetric to `client.chat.complete(...)`. Queries data sources for relevant
+  documents without invoking a model. Satellite-token auth and MPP payment are
+  handled server-side by the aggregator exactly as for chat. Resolves to a
+  `SearchResponse` with a `documents` array (`SearchDocument`) plus per-source
+  `retrievalInfo` and timing `metadata`. The underlying primitive is
+  `client.chat.retrieve(...)`. New types: `SearchQueryOptions`, `SearchResponse`,
+  `SearchDocument`.
+
 ## [0.2.1] - 2026-06-17
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@syfthub/sdk",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@syfthub/sdk",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.39.2",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syfthub/sdk",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "TypeScript SDK for SyftHub API",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -8,6 +8,7 @@ import { HubResource } from './resources/hub.js';
 import { AccountingResource } from './resources/accounting.js';
 import { AgentResource } from './resources/agent.js';
 import { ChatResource } from './resources/chat.js';
+import { SearchResource } from './resources/search.js';
 import { SyftAIResource } from './resources/syftai.js';
 
 /**
@@ -119,6 +120,7 @@ export class SyftHubClient {
   private _accounting?: AccountingResource;
   private _agent?: AgentResource;
   private _chat?: ChatResource;
+  private _search?: SearchResource;
   private _syftai?: SyftAIResource;
   private _apiTokens?: APITokensResource;
 
@@ -333,6 +335,29 @@ export class SyftHubClient {
       this._chat = new ChatResource(this.hub, this.auth, this.aggregatorUrl);
     }
     return this._chat;
+  }
+
+  /**
+   * Retrieval-only search via the Aggregator (no model generation).
+   *
+   * Symmetric counterpart to {@link chat}: queries data sources for relevant
+   * documents without invoking a model. Satellite-token auth and MPP payment
+   * are handled by the aggregator exactly as for chat.
+   *
+   * @example
+   * const result = await client.search.query({
+   *   prompt: 'Hello, world!',
+   *   dataSources: ['epfl-news/epfl-news'],
+   * });
+   * for (const doc of result.documents) {
+   *   console.log(doc.title, doc.content.slice(0, 80));
+   * }
+   */
+  get search(): SearchResource {
+    if (!this._search) {
+      this._search = new SearchResource(this.chat);
+    }
+    return this._search;
   }
 
   /**

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -125,6 +125,9 @@ export type {
   ChatResponse,
   Message,
   ChatOptions,
+  SearchDocument,
+  SearchQueryOptions,
+  SearchResponse,
   QueryDataSourceOptions,
   QueryModelOptions,
   // Chat streaming events
@@ -168,6 +171,9 @@ export type {
 
 // Chat Resource (for type hints)
 export { ChatResource } from './resources/chat.js';
+
+// Search Resource (retrieval-only via the Aggregator)
+export { SearchResource } from './resources/search.js';
 
 // SyftAI Resource (for type hints)
 export { SyftAIResource } from './resources/syftai.js';

--- a/sdk/typescript/src/models/chat.ts
+++ b/sdk/typescript/src/models/chat.ts
@@ -158,6 +158,61 @@ export interface ChatOptions {
 }
 
 /**
+ * A single document returned by a retrieval-only search.
+ *
+ * Unlike {@link Document} (the low-level direct-query shape), this carries the
+ * document title and the source endpoint path, matching the aggregated
+ * `sources` map returned by the aggregator's retrieval-only path.
+ */
+export interface SearchDocument {
+  /** Document title (key in the sources map) */
+  title: string;
+  /** Source endpoint path (owner/slug) the document came from */
+  slug: string;
+  /** The document content */
+  content: string;
+}
+
+/**
+ * Options for a retrieval-only search via the Aggregator.
+ *
+ * Symmetric to {@link ChatOptions} minus the model: data sources are queried
+ * for relevant documents, but no model is invoked.
+ */
+export interface SearchQueryOptions {
+  /** The search query */
+  prompt: string;
+  /** Data source endpoints (paths, EndpointRefs, or `collective/<slug>` paths) */
+  dataSources?: (string | EndpointRef)[];
+  /** Number of documents to retrieve per source (default: 5) */
+  topK?: number;
+  /** Minimum similarity for retrieved docs (default: 0.5) */
+  similarityThreshold?: number;
+  /** Custom aggregator URL to use instead of the default */
+  aggregatorUrl?: string;
+  /** Use guest mode for unauthenticated access to policy-free endpoints */
+  guestMode?: boolean;
+  /** AbortSignal for request cancellation */
+  signal?: AbortSignal;
+}
+
+/**
+ * Response from a retrieval-only search via the Aggregator.
+ *
+ * Mirrors {@link ChatResponse} minus the generated text: retrieval runs across
+ * the data sources (with satellite-token auth and MPP payment handled by the
+ * aggregator), but no model is invoked.
+ */
+export interface SearchResponse {
+  /** Retrieved documents across all data sources */
+  documents: SearchDocument[];
+  /** Metadata about each data source retrieval (status, count, errors) */
+  retrievalInfo: SourceInfo[];
+  /** Timing metadata */
+  metadata: ChatMetadata;
+}
+
+/**
  * Options for querying a data source directly.
  */
 export interface QueryDataSourceOptions {

--- a/sdk/typescript/src/models/index.ts
+++ b/sdk/typescript/src/models/index.ts
@@ -69,6 +69,9 @@ export type {
   ChatResponse,
   Message,
   ChatOptions,
+  SearchDocument,
+  SearchQueryOptions,
+  SearchResponse,
   QueryDataSourceOptions,
   QueryModelOptions,
   // Streaming events

--- a/sdk/typescript/src/resources/chat.ts
+++ b/sdk/typescript/src/resources/chat.ts
@@ -32,6 +32,9 @@ import type {
   DocumentSource,
   EndpointRef,
   Message,
+  SearchDocument,
+  SearchQueryOptions,
+  SearchResponse,
   SourceInfo,
   SourceStatus,
   TokenUsage,
@@ -338,7 +341,8 @@ export class ChatResource {
    */
   private async prepareRequest(
     options: ChatOptions,
-    stream: boolean
+    stream: boolean,
+    retrievalOnly = false
   ): Promise<{ requestBody: Record<string, unknown>; effectiveAggregatorUrl: string }> {
     const modelRef = await this.resolveEndpointRef(options.model, 'model');
 
@@ -383,6 +387,7 @@ export class ChatResource {
         messages: options.messages,
         peerToken,
         peerChannel,
+        retrievalOnly,
       }
     );
 
@@ -429,6 +434,7 @@ export class ChatResource {
       messages?: Message[];
       peerToken?: string;
       peerChannel?: string;
+      retrievalOnly?: boolean;
     }
   ): Record<string, unknown> {
     const body: Record<string, unknown> = {
@@ -470,6 +476,11 @@ export class ChatResource {
     }
     if (options.peerChannel) {
       body['peer_channel'] = options.peerChannel;
+    }
+
+    // Retrieval-only: aggregator skips reranking + generation.
+    if (options.retrievalOnly) {
+      body['retrieval_only'] = true;
     }
 
     return body;
@@ -603,6 +614,79 @@ export class ChatResource {
       usage,
       profitShare,
     };
+  }
+
+  /**
+   * Placeholder model for retrieval-only requests. The aggregator requires a
+   * `model` field on every request, but short-circuits before dereferencing it
+   * when `retrieval_only` is set, so an empty ref is never contacted.
+   */
+  private static readonly RETRIEVAL_ONLY_MODEL: EndpointRef = {
+    url: '',
+    slug: '',
+    name: 'retrieval-only',
+  };
+
+  /**
+   * Retrieve documents from data sources without model generation.
+   *
+   * Drives the aggregator's retrieval-only path: data sources are queried in
+   * parallel (with satellite-token auth and MPP payment handled server-side,
+   * exactly like {@link complete}), but no model is invoked.
+   *
+   * Prefer the symmetric `client.search.query(...)` facade; this is the
+   * underlying primitive.
+   *
+   * @param options - Search options
+   * @returns SearchResponse with retrieved documents and per-source metadata
+   * @throws {EndpointResolutionError} If a data source cannot be resolved
+   * @throws {AggregatorError} If the aggregator service fails
+   */
+  async retrieve(options: SearchQueryOptions): Promise<SearchResponse> {
+    const chatOptions: ChatOptions = {
+      prompt: options.prompt,
+      model: ChatResource.RETRIEVAL_ONLY_MODEL,
+      dataSources: options.dataSources,
+      topK: options.topK,
+      similarityThreshold: options.similarityThreshold,
+      aggregatorUrl: options.aggregatorUrl,
+      guestMode: options.guestMode,
+    };
+
+    const { requestBody, effectiveAggregatorUrl } = await this.prepareRequest(
+      chatOptions,
+      false,
+      true
+    );
+
+    const response = await fetch(`${effectiveAggregatorUrl}/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(requestBody),
+      signal: options.signal,
+    });
+
+    if (!response.ok) {
+      return this.handleAggregatorErrorResponse(response);
+    }
+
+    const data = (await response.json()) as Record<string, unknown>;
+
+    const sources = this.parseDocumentSources(
+      data['sources'] as Record<string, unknown> | undefined
+    );
+    const documents: SearchDocument[] = Object.entries(sources).map(([title, source]) => ({
+      title,
+      slug: source.slug,
+      content: source.content,
+    }));
+
+    const retrievalInfo = this.parseRetrievalInfo(
+      data['retrieval_info'] as Record<string, unknown>[] | undefined
+    );
+    const metadata = this.parseMetadata((data['metadata'] as Record<string, unknown>) ?? {});
+
+    return { documents, retrievalInfo, metadata };
   }
 
   /**

--- a/sdk/typescript/src/resources/search.ts
+++ b/sdk/typescript/src/resources/search.ts
@@ -1,0 +1,56 @@
+/**
+ * Search resource for retrieval-only queries via the Aggregator service.
+ *
+ * Symmetric counterpart to {@link ChatResource}: where `client.chat.complete()`
+ * retrieves context *and* generates a model response, `client.search.query()`
+ * retrieves documents from data sources without invoking any model.
+ *
+ * @example
+ * // Symmetric to client.chat.complete(...)
+ * const result = await client.search.query({
+ *   prompt: 'What happened at EPFL this week?',
+ *   dataSources: ['epfl-news/epfl-news'],
+ * });
+ * for (const doc of result.documents) {
+ *   console.log(doc.title, '->', doc.content.slice(0, 80));
+ * }
+ *
+ * Authentication and billing are handled by the aggregator exactly as for chat:
+ * satellite tokens are minted per data source owner, and metered endpoints that
+ * respond with `402 Payment Required` are settled via the user's Hub wallet.
+ */
+
+import type { SearchQueryOptions, SearchResponse } from '../models/chat.js';
+import type { ChatResource } from './chat.js';
+
+/**
+ * Retrieval-only search via the Aggregator.
+ *
+ * Thin facade over {@link ChatResource.retrieve}, exposed as `client.search` to
+ * mirror the shape of `client.chat`.
+ */
+export class SearchResource {
+  /**
+   * @param chat - The chat resource that owns aggregator communication and
+   *   request preparation (satellite tokens, MPP, collective expansion). Search
+   *   reuses it rather than duplicating that logic.
+   */
+  constructor(private readonly chat: ChatResource) {}
+
+  /**
+   * Retrieve documents from data sources without model generation.
+   *
+   * @param options - Search options (prompt, data sources, top-k, etc.)
+   * @returns SearchResponse with retrieved documents and per-source metadata
+   *
+   * @example
+   * const result = await client.search.query({
+   *   prompt: 'Hello, world!',
+   *   dataSources: ['epfl-news/epfl-news'],
+   * });
+   * console.log(result.documents.length, 'documents');
+   */
+  async query(options: SearchQueryOptions): Promise<SearchResponse> {
+    return this.chat.retrieve(options);
+  }
+}

--- a/sdk/typescript/tests/search.test.ts
+++ b/sdk/typescript/tests/search.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for SearchResource (retrieval-only via the Aggregator).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SyftHubClient } from '../src/client.js';
+import type { EndpointRef } from '../src/models/index.js';
+import { AggregatorError, SearchResource } from '../src/index.js';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('SearchResource', () => {
+  const baseUrl = 'https://test.syfthub.com';
+  let client: SyftHubClient;
+
+  const mockSearchResponse = {
+    response: '',
+    sources: {
+      'EPFL News #1': { slug: 'epfl-news/epfl-news', content: 'First story.' },
+      'EPFL News #2': { slug: 'epfl-news/epfl-news', content: 'Second story.' },
+    },
+    retrieval_info: [
+      { path: 'epfl-news/epfl-news', documents_retrieved: 2, status: 'success' },
+    ],
+    metadata: { retrieval_time_ms: 120, generation_time_ms: 0, total_time_ms: 120 },
+  };
+
+  const dataSource: EndpointRef = {
+    url: 'http://20.0.5.93:8081',
+    slug: 'epfl-news',
+    ownerUsername: 'epfl-news',
+  };
+
+  /** Default handler: satellite token + aggregator /chat. */
+  function installDefaultFetch(): void {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('/api/v1/token')) {
+        return new Response(JSON.stringify({ target_token: 'sat-tok' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.includes('/chat') && !url.includes('/stream')) {
+        return new Response(JSON.stringify(mockSearchResponse), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response('Not found', { status: 404 });
+    });
+  }
+
+  /** Pull the JSON body sent to the aggregator /chat endpoint. */
+  function lastChatRequestBody(): Record<string, unknown> {
+    const call = mockFetch.mock.calls.find(
+      ([url]) => String(url).includes('/chat') && !String(url).includes('/stream')
+    );
+    if (!call) throw new Error('no /chat request was made');
+    return JSON.parse((call[1] as RequestInit).body as string) as Record<string, unknown>;
+  }
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    client = new SyftHubClient({ baseUrl });
+    client.setTokens({ accessToken: 'fake-access-token', refreshToken: 'fake-refresh-token' });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns parsed documents', async () => {
+    installDefaultFetch();
+
+    const result = await client.search.query({
+      prompt: 'What happened?',
+      dataSources: [dataSource],
+    });
+
+    expect(result.documents).toHaveLength(2);
+    expect(result.documents.map((d) => d.content).sort()).toEqual([
+      'First story.',
+      'Second story.',
+    ]);
+    expect(result.documents[0].slug).toBe('epfl-news/epfl-news');
+    expect(result.documents[0].title).toContain('EPFL News');
+    expect(result.retrievalInfo[0].documentsRetrieved).toBe(2);
+    expect(result.metadata.generationTimeMs).toBe(0);
+  });
+
+  it('sends retrieval_only and forwards the user token', async () => {
+    installDefaultFetch();
+
+    await client.search.query({ prompt: 'hi', dataSources: [dataSource] });
+
+    const body = lastChatRequestBody();
+    expect(body['retrieval_only']).toBe(true);
+    expect(body['user_token']).toBe('fake-access-token');
+    // Placeholder model present but empty (never contacted by the aggregator).
+    expect((body['model'] as Record<string, unknown>)['url']).toBe('');
+    expect((body['model'] as Record<string, unknown>)['slug']).toBe('');
+  });
+
+  it('omits user token in guest mode', async () => {
+    installDefaultFetch();
+
+    await client.search.query({ prompt: 'hi', dataSources: [dataSource], guestMode: true });
+
+    const body = lastChatRequestBody();
+    expect(body['retrieval_only']).toBe(true);
+    expect(body['user_token']).toBeUndefined();
+  });
+
+  it('throws AggregatorError on failure', async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('/api/v1/token')) {
+        return new Response(JSON.stringify({ target_token: 'sat-tok' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ message: 'boom' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    await expect(
+      client.search.query({ prompt: 'hi', dataSources: [dataSource] })
+    ).rejects.toThrow(AggregatorError);
+  });
+
+  it('exposes a cached SearchResource', () => {
+    expect(client.search).toBeInstanceOf(SearchResource);
+    expect(client.search).toBe(client.search);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `client.search` namespace symmetric to `client.chat`, on **both** the Python and TypeScript SDKs:

```python
client.chat.complete(prompt=..., model=..., data_sources=[...])   # retrieve + generate
client.search.query(prompt=..., data_sources=[...])               # retrieve only
```

```ts
await client.chat.complete({ prompt, model, dataSources });        // retrieve + generate
await client.search.query({ prompt, dataSources });                // retrieve only
```

## How it works

- Drives the aggregator's **existing `retrieval_only` path** (the orchestrator short-circuits before reranking/generation at `orchestrator.py:333`), so there is **no aggregator change** and it works against the already-deployed service.
- Satellite-token auth and MPP payment are handled **server-side**, exactly as for chat.
- `search.query` is a thin facade over a new `ChatResource.retrieve()` primitive (so no orchestration logic is duplicated). `retrieve()` sends:
  - `retrieval_only: true`
  - a placeholder model (required by the request schema but never dereferenced on this path)
  - the caller's `user_token`, so **metered data sources are paid server-side**.
- Returns a `SearchResponse` with a `documents` list (`SearchDocument`: `title` / `slug` / `content`) plus per-source `retrieval_info` and timing `metadata`.

## Bonus fix

The **Python** chat path was not forwarding `user_token` to the aggregator (the TypeScript SDK already did). Now both `chat` and `search` forward it, so metered model/data-source endpoints returning `402 Payment Required` are settled via the Hub wallet.

## API surface

- Python: `client.search.query(...)`, `client.chat.retrieve(...)`, new models `SearchResponse` / `SearchDocument`.
- TypeScript: `client.search.query(...)`, `client.chat.retrieve(...)`, new types `SearchQueryOptions` / `SearchResponse` / `SearchDocument`.

## Known tradeoff

The retrieval-only path returns documents **without similarity scores** — the aggregator's aggregated `sources` map carries `{slug, content}` only. Callers needing scores can use the low-level `client.syftai.query_data_source(...)` (shipped in 0.2.1).

## Versioning

Bumps both SDKs to **0.3.0** (new feature). CHANGELOGs updated.

## Testing

| | Python | TypeScript |
|---|---|---|
| lint | ✅ ruff | ✅ eslint |
| types | ✅ mypy | ✅ tsc |
| unit tests | ✅ 61 (4 new, `test_search.py`) | ✅ 55 (5 new, `search.test.ts`) |
| build | — | ✅ tsup |

`gitnexus detect_changes`: medium risk, 1 affected process (chat `complete` via `_prepare_request`) — additive/backward-compatible; existing chat tests confirm no regression.

