### PR TITLE
feat(collectives): owner filter by username + member-of endpoint

### DIFF
--- a/components/backend/src/syfthub/api/endpoints/collectives.py
+++ b/components/backend/src/syfthub/api/endpoints/collectives.py
@@ -57,7 +57,9 @@ async def list_collectives(
     service: Annotated[CollectiveService, Depends(get_collective_service)],
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=100),
-    owner_id: Optional[int] = Query(None, description="Filter by owning user ID"),
+    owner_username: Optional[str] = Query(
+        None, description="Filter by owning username"
+    ),
     search: Optional[str] = Query(
         None,
         min_length=1,
@@ -67,7 +69,7 @@ async def list_collectives(
 ) -> List[CollectiveResponse]:
     """List collectives, newest first. Collectives are publicly viewable."""
     return service.list_collectives(
-        skip=skip, limit=limit, owner_id=owner_id, search=search
+        skip=skip, limit=limit, owner_username=owner_username, search=search
     )
 
 
@@ -95,6 +97,20 @@ async def list_collectives_for_endpoint(
     member of any collective, or when the endpoint can't be resolved.
     """
     return service.list_collectives_for_endpoint(owner_username, slug)
+
+
+@router.get("/by-member-username/{username}", response_model=List[CollectiveResponse])
+async def list_collectives_for_user_endpoints(
+    username: str,
+    service: Annotated[CollectiveService, Depends(get_collective_service)],
+) -> List[CollectiveResponse]:
+    """List distinct approved collectives where any endpoint owned by ``username`` is a member.
+
+    Public-readable. Returns an empty list when the username does not exist or
+    has no approved memberships. A user with multiple endpoints in the same
+    collective sees that collective only once.
+    """
+    return service.list_collectives_for_user_endpoints(username)
 
 
 @router.get("/by-slug/{slug}/endpoint-paths", response_model=List[str])

--- a/components/backend/src/syfthub/repositories/collective.py
+++ b/components/backend/src/syfthub/repositories/collective.py
@@ -229,6 +229,34 @@ class CollectiveMemberRepository(BaseRepository[CollectiveMemberModel]):
         except SQLAlchemyError:
             return []
 
+    def list_collectives_for_user(
+        self,
+        user_id: int,
+        statuses: Optional[Sequence[str]] = None,
+    ) -> List[CollectiveResponse]:
+        """List distinct collectives where any endpoint owned by user_id is a member.
+
+        Joins collective_members → endpoints to filter by endpoint owner, then
+        deduplicates via GROUP BY so a user with multiple endpoints in the same
+        collective only appears once. Ordered newest-first by collective creation.
+        """
+        try:
+            stmt = (
+                select(CollectiveModel)
+                .join(self.model, self.model.collective_id == CollectiveModel.id)
+                .join(EndpointModel, EndpointModel.id == self.model.endpoint_id)
+                .where(EndpointModel.user_id == user_id)
+            )
+            if statuses:
+                stmt = stmt.where(self.model.status.in_(list(statuses)))
+            stmt = stmt.group_by(CollectiveModel.id).order_by(
+                CollectiveModel.created_at.desc()
+            )
+            models = self.session.execute(stmt).scalars().all()
+            return [CollectiveResponse.model_validate(m) for m in models]
+        except SQLAlchemyError:
+            return []
+
     def count_members(self, collective_id: int, status: str) -> int:
         """Count a single collective's memberships with the given status."""
         try:

--- a/components/backend/src/syfthub/services/collective_service.py
+++ b/components/backend/src/syfthub/services/collective_service.py
@@ -456,17 +456,48 @@ class CollectiveService(BaseService):
         self,
         skip: int = 0,
         limit: int = 50,
-        owner_id: Optional[int] = None,
+        owner_username: Optional[str] = None,
         search: Optional[str] = None,
     ) -> List[CollectiveResponse]:
         """List collectives, newest first.
 
-        Optionally filtered by ``owner_id`` and/or a ``search`` string.
+        Optionally filtered by ``owner_username`` (resolved to an owner_id
+        internally) and/or a ``search`` string. Returns an empty list when
+        ``owner_username`` is provided but does not match any user.
         """
+        owner_id: Optional[int] = None
+        if owner_username is not None:
+            owner = self.user_repo.get_by_username(owner_username)
+            if owner is None:
+                return []
+            owner_id = owner.id
         collectives = self.collective_repo.list_collectives(
             skip, limit, owner_id, search
         )
         # Grouped queries for all counts instead of N per-row queries.
+        ids = [c.id for c in collectives]
+        approved = MembershipStatus.APPROVED.value
+        member_counts = self.member_repo.count_members_bulk(ids, approved)
+        owner_counts = self.member_repo.count_owners_bulk(ids, approved)
+        for collective in collectives:
+            collective.member_count = member_counts.get(collective.id, 0)
+            collective.owner_count = owner_counts.get(collective.id, 0)
+        return collectives
+
+    def list_collectives_for_user_endpoints(
+        self, username: str
+    ) -> List[CollectiveResponse]:
+        """List distinct collectives where any endpoint owned by ``username`` is an approved member.
+
+        Public-readable. Returns only ``APPROVED`` memberships. Returns an
+        empty list when the username does not exist or has no memberships.
+        """
+        owner = self.user_repo.get_by_username(username)
+        if owner is None:
+            return []
+        collectives = self.member_repo.list_collectives_for_user(
+            owner.id, [MembershipStatus.APPROVED.value]
+        )
         ids = [c.id for c in collectives]
         approved = MembershipStatus.APPROVED.value
         member_counts = self.member_repo.count_members_bulk(ids, approved)

--- a/components/frontend/src/hooks/use-collectives.ts
+++ b/components/frontend/src/hooks/use-collectives.ts
@@ -26,6 +26,7 @@ import {
   inviteEndpointByPath,
   listCollectives,
   listCollectivesForEndpoint,
+  listCollectivesForUserEndpoints,
   listCollectivesPaginated,
   listMembers,
   removeMember,
@@ -40,11 +41,23 @@ import { collectiveKeys } from '@/lib/query-keys';
 // Queries
 // =============================================================================
 
-/** List collectives, optionally filtered to those owned by `ownerId`. */
-export function useCollectives(ownerId?: number) {
+/** List collectives, optionally filtered to those owned by `ownerUsername`. */
+export function useCollectives(ownerUsername?: string) {
   return useQuery({
-    queryKey: collectiveKeys.list(ownerId),
-    queryFn: () => listCollectives({ ownerId, limit: 100 })
+    queryKey: collectiveKeys.list(ownerUsername),
+    queryFn: () => listCollectives({ ownerUsername, limit: 100 })
+  });
+}
+
+/**
+ * List distinct approved collectives where any endpoint owned by `username` is
+ * a member. Backs a "joined collectives" view on a user profile page.
+ */
+export function useCollectivesForUserEndpoints(username: string | undefined | null) {
+  return useQuery({
+    queryKey: collectiveKeys.byMemberUsername(username ?? ''),
+    queryFn: () => (username ? listCollectivesForUserEndpoints(username) : []),
+    enabled: Boolean(username)
   });
 }
 

--- a/components/frontend/src/lib/collectives-api.ts
+++ b/components/frontend/src/lib/collectives-api.ts
@@ -198,20 +198,36 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
 export interface ListCollectivesParams {
   skip?: number;
   limit?: number;
-  ownerId?: number;
+  ownerUsername?: string;
   /** Server-side search over name, description and tags. */
   search?: string;
 }
 
-/** List collectives, newest first. Optionally filter by owning user / search. */
+/** List collectives, newest first. Optionally filter by owning username / search. */
 export async function listCollectives(params: ListCollectivesParams = {}): Promise<Collective[]> {
   const query = new URLSearchParams();
   if (params.skip !== undefined) query.set('skip', String(params.skip));
   if (params.limit !== undefined) query.set('limit', String(params.limit));
-  if (params.ownerId !== undefined) query.set('owner_id', String(params.ownerId));
+  if (params.ownerUsername) query.set('owner_username', params.ownerUsername);
   if (params.search?.trim()) query.set('search', params.search.trim());
   const suffix = query.toString();
   return request<Collective[]>(suffix ? `?${suffix}` : '');
+}
+
+/**
+ * List distinct approved collectives where any endpoint owned by `username` is
+ * a member. Public-readable. Returns an empty array when the user does not exist
+ * or has no approved memberships.
+ */
+export async function listCollectivesForUserEndpoints(username: string): Promise<Collective[]> {
+  const response = await fetch(`${BASE}/by-member-username/${encodeURIComponent(username)}`);
+  if (response.status === 404) return [];
+  if (!response.ok) {
+    throw new Error(
+      await errorMessage(response, `Failed to load collectives (${response.status})`)
+    );
+  }
+  return (await response.json()) as Collective[];
 }
 
 /** A page of collectives plus whether another page follows. */

--- a/components/frontend/src/lib/query-keys.ts
+++ b/components/frontend/src/lib/query-keys.ts
@@ -51,7 +51,8 @@ export const walletKeys = {
 
 export const collectiveKeys = {
   all: ['collectives'] as const,
-  list: (ownerId?: number) => [...collectiveKeys.all, 'list', ownerId ?? 'all'] as const,
+  list: (ownerUsername?: string) =>
+    [...collectiveKeys.all, 'list', ownerUsername ?? 'all'] as const,
   paginated: (page: number, limit: number, search?: string) =>
     [...collectiveKeys.all, 'list', 'paginated', page, limit, search ?? ''] as const,
   detail: (slug: string) => [...collectiveKeys.all, 'detail', slug] as const,
@@ -62,7 +63,9 @@ export const collectiveKeys = {
   invitation: (collectiveId: number, endpointId: number) =>
     [...collectiveKeys.all, 'invitation', collectiveId, endpointId] as const,
   byEndpoint: (owner: string, slug: string) =>
-    [...collectiveKeys.all, 'byEndpoint', owner, slug] as const
+    [...collectiveKeys.all, 'byEndpoint', owner, slug] as const,
+  byMemberUsername: (username: string) =>
+    [...collectiveKeys.all, 'byMemberUsername', username] as const
 };
 
 export const sharedEndpointKeys = {


### PR DESCRIPTION
## Summary

- **Replace `owner_id` with `owner_username`** on `GET /api/v1/collectives`: the filter now accepts a string username instead of a numeric user ID; username→id resolution happens inside the service layer, consistent with other collective endpoints.
- **New `GET /api/v1/collectives/by-member-username/{username}`**: returns the distinct approved collectives where any endpoint owned by `username` is a member — closes the N+1 gap that previously required a per-endpoint fan-out to reconstruct a user's collective memberships.

## What changed

| Layer | File | Change |
|-------|------|--------|
| API | `collectives.py` | `owner_id: int` → `owner_username: str` query param; new `by-member-username/{username}` route |
| Service | `collective_service.py` | `list_collectives` resolves username→id internally; new `list_collectives_for_user_endpoints` |
| Repo | `collective.py` | New `CollectiveMemberRepository.list_collectives_for_user()` — single JOIN query with `GROUP BY` dedup |
| Frontend | `collectives-api.ts` | `ownerId→ownerUsername` in `ListCollectivesParams`; new `listCollectivesForUserEndpoints()` |
| Frontend | `use-collectives.ts` | `useCollectives` param updated; new `useCollectivesForUserEndpoints()` hook |
| Frontend | `query-keys.ts` | `list` key type updated; new `byMemberUsername` key |

## Test plan

- [ ] `GET /api/v1/collectives?owner_username=<existing_user>` returns only collectives owned by that user
- [ ] `GET /api/v1/collectives?owner_username=<nonexistent>` returns `[]`
- [ ] `GET /api/v1/collectives` (no filter) still returns all collectives
- [ ] `GET /api/v1/collectives/by-member-username/<user>` returns distinct collectives where that user's endpoints are approved members
- [ ] User with multiple endpoints in the same collective sees that collective only once in the response
- [ ] `GET /api/v1/collectives/by-member-username/<nonexistent>` returns `[]`
- [ ] `useCollectivesForUserEndpoints(username)` hook renders correctly on a profile page