### PR TITLE
chore(sdk): bump python and typescript sdk to v0.3.1

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syfthub-sdk"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python SDK for interacting with SyftHub API"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.10"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syfthub/sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "TypeScript SDK for SyftHub API",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- Bumps `syfthub-sdk` (Python) from `0.3.0` → `0.3.1` in `sdk/python/pyproject.toml`
- Bumps `@syfthub/sdk` (TypeScript) from `0.3.0` → `0.3.1` in `sdk/typescript/package.json`

## Release process
Once this PR is merged, push the following tags to trigger the CI/CD release workflows:
```
git tag python-sdk/v0.3.1 && git tag typescript-sdk/v0.3.1
git push origin python-sdk/v0.3.1 typescript-sdk/v0.3.1
```
- `python-sdk/v0.3.1` → publishes to PyPI via the `Release Python SDK` workflow
- `typescript-sdk/v0.3.1` → publishes to npm via the `Release TypeScript SDK` workflow