### PR TITLE
fix(aggregator): surface hybrid endpoint generated summary as a document

### DIFF
--- a/components/aggregator/src/aggregator/clients/data_source.py
+++ b/components/aggregator/src/aggregator/clients/data_source.py
@@ -376,26 +376,61 @@ class DataSourceClient:
         }
 
         We extract from references.documents and map similarity_score -> score.
+
+        Hybrid endpoints (model_data_source) also return an AI-generated answer
+        in summary.message.content. We surface that as a Document too, so hybrid
+        sources contribute their generated answer alongside any retrieved docs
+        instead of reporting "0 documents retrieved".
         """
         documents: list[Document] = []
 
         # Extract references from SyftAI-Space response
         references = data.get("references")
-        if not references:
-            logger.debug("No references in SyftAI-Space response")
-            return documents
+        if references:
+            raw_docs = references.get("documents", [])
 
-        raw_docs = references.get("documents", [])
-
-        for doc in raw_docs:
-            if isinstance(doc, dict):
-                documents.append(
-                    Document(
-                        content=doc.get("content", ""),
-                        # Map SyftAI-Space's similarity_score to score
-                        score=float(doc.get("similarity_score", 0.0)),
-                        metadata=doc.get("metadata", {}),
+            for doc in raw_docs:
+                if isinstance(doc, dict):
+                    documents.append(
+                        Document(
+                            content=doc.get("content", ""),
+                            # Map SyftAI-Space's similarity_score to score
+                            score=float(doc.get("similarity_score", 0.0)),
+                            metadata=doc.get("metadata", {}),
+                        )
                     )
-                )
+        else:
+            logger.debug("No references in SyftAI-Space response")
+
+        # Surface an AI-generated summary (hybrid endpoints) as a Document.
+        summary_doc = self._summary_to_document(data.get("summary"))
+        if summary_doc is not None:
+            documents.append(summary_doc)
 
         return documents
+
+    @staticmethod
+    def _summary_to_document(summary: Any) -> Document | None:
+        """Convert a SyftAI-Space summary into a Document, if it has content.
+
+        Returns None when there is no summary or no non-empty content.
+        """
+        if not summary or not isinstance(summary, dict):
+            return None
+
+        message = summary.get("message") or {}
+        if isinstance(message, dict):
+            content = message.get("content", "")
+        elif isinstance(message, str):
+            content = message
+        else:
+            content = ""
+
+        if not content:
+            return None
+
+        return Document(
+            content=str(content),
+            score=1.0,
+            metadata={"source_type": "generated", "model": summary.get("model")},
+        )

--- a/components/aggregator/tests/test_data_source_parse.py
+++ b/components/aggregator/tests/test_data_source_parse.py
@@ -1,0 +1,86 @@
+"""Tests for DataSourceClient response parsing.
+
+Covers hybrid (model_data_source) endpoints that return an AI-generated
+`summary` in addition to (or instead of) `references.documents`. The
+aggregator must surface the generated summary as a Document so hybrid
+sources don't report "0 documents retrieved".
+"""
+
+from aggregator.clients.data_source import DataSourceClient
+
+
+def test_parse_extracts_reference_documents() -> None:
+    client = DataSourceClient()
+    data = {
+        "summary": None,
+        "references": {
+            "documents": [
+                {
+                    "document_id": "d1",
+                    "content": "doc one",
+                    "metadata": {"k": "v"},
+                    "similarity_score": 0.9,
+                }
+            ]
+        },
+    }
+
+    docs = client._parse_syftai_response(data)
+
+    assert len(docs) == 1
+    assert docs[0].content == "doc one"
+    assert docs[0].score == 0.9
+
+
+def test_parse_surfaces_generated_summary_as_document() -> None:
+    """Hybrid source returns only a generated summary, no reference docs."""
+    client = DataSourceClient()
+    data = {
+        "summary": {
+            "model": "gpt-x",
+            "message": {"role": "assistant", "content": "The generated answer."},
+        },
+        "references": None,
+    }
+
+    docs = client._parse_syftai_response(data)
+
+    assert len(docs) == 1
+    assert docs[0].content == "The generated answer."
+    assert docs[0].metadata.get("source_type") == "generated"
+    assert docs[0].metadata.get("model") == "gpt-x"
+
+
+def test_parse_includes_both_documents_and_summary() -> None:
+    """Hybrid source returns both real docs and a generated summary."""
+    client = DataSourceClient()
+    data = {
+        "summary": {
+            "model": "gpt-x",
+            "message": {"role": "assistant", "content": "The generated answer."},
+        },
+        "references": {
+            "documents": [
+                {"content": "doc one", "similarity_score": 0.8, "metadata": {}}
+            ]
+        },
+    }
+
+    docs = client._parse_syftai_response(data)
+
+    contents = [d.content for d in docs]
+    assert "doc one" in contents
+    assert "The generated answer." in contents
+    assert len(docs) == 2
+
+
+def test_parse_empty_when_no_summary_and_no_references() -> None:
+    client = DataSourceClient()
+    docs = client._parse_syftai_response({"summary": None, "references": None})
+    assert docs == []
+
+
+def test_parse_ignores_empty_summary_content() -> None:
+    client = DataSourceClient()
+    data = {"summary": {"message": {"role": "assistant", "content": ""}}, "references": None}
+    assert client._parse_syftai_response(data) == []

--- a/components/aggregator/tests/test_data_source_parse.py
+++ b/components/aggregator/tests/test_data_source_parse.py
@@ -60,9 +60,7 @@ def test_parse_includes_both_documents_and_summary() -> None:
             "message": {"role": "assistant", "content": "The generated answer."},
         },
         "references": {
-            "documents": [
-                {"content": "doc one", "similarity_score": 0.8, "metadata": {}}
-            ]
+            "documents": [{"content": "doc one", "similarity_score": 0.8, "metadata": {}}]
         },
     }
 


### PR DESCRIPTION
## Problem

Querying a **hybrid** endpoint (`model_data_source`, containing both data and model) reported `documents_retrieved: 0` even though the source returned a full AI-generated answer.

The aggregator routes hybrid sources through `DataSourceClient.query()`, whose parser `_parse_syftai_response()` only read `references.documents` and **discarded the `summary` field**. A hybrid endpoint runs its own RAG and returns the AI answer in `summary.message.content`, often with an empty `references.documents` — so `documents = []`, `documents_retrieved` = 0, and the generated answer was thrown away at the retrieval layer.

## Fix

`_parse_syftai_response` now still extracts `references.documents`, and **additionally** folds a non-empty `summary.message.content` in as a `Document` (score `1.0`, `metadata={"source_type": "generated", "model": ...}`) via a new `_summary_to_document` helper. The generated answer is always surfaced when present, alongside any real reference docs — so hybrid sources contribute both.

The matching extraction already existed on the model path (`model.py:_extract_syftai_response`); this brings the data-source path in line.

## Tests

New `tests/test_data_source_parse.py` — 5 cases: reference-docs-only, summary-only, both, neither, empty-summary. Written failing first, now all green. Ruff clean. No regressions vs. baseline (the only suite delta is these tests going green).

## Notes / possible follow-ups (not in this PR)
- The generated `Document` has no `document_id`; downstream attribution/dedup that keys on an id may want one.
- Endpoint type is still hardcoded as `data_source` in the orchestrator; this fix works purely at the parse layer, independent of the backend's declared type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)