### PR TITLE
fix(aggregator): surface a placeholder document for empty hybrid summaries

### DIFF
--- a/components/aggregator/src/aggregator/clients/data_source.py
+++ b/components/aggregator/src/aggregator/clients/data_source.py
@@ -429,7 +429,12 @@ class DataSourceClient:
         Hybrid endpoints (model_data_source) also return an AI-generated answer
         in summary.message.content. We surface that as a Document too, so hybrid
         sources contribute their generated answer alongside any retrieved docs
-        instead of reporting "0 documents retrieved".
+        instead of reporting "0 documents retrieved". If a summary block is
+        present but its content is empty (the endpoint's own LLM call produced
+        nothing), we still surface a placeholder Document (see
+        EMPTY_SUMMARY_MESSAGE) rather than silently dropping the source, so
+        hybrid sources report a consistent document count across repeated
+        identical queries.
         """
         documents: list[Document] = []
 
@@ -458,11 +463,22 @@ class DataSourceClient:
 
         return documents
 
-    @staticmethod
-    def _summary_to_document(summary: Any) -> Document | None:
-        """Convert a SyftAI-Space summary into a Document, if it has content.
+    # Placeholder shown when a hybrid endpoint returned a summary block but its
+    # message content was empty (e.g. the endpoint's own LLM call silently
+    # produced nothing). Surfacing this explicitly — rather than dropping the
+    # source entirely — keeps per-source document counts consistent across
+    # repeated identical queries and tells the model/user "this source had
+    # nothing to add" instead of making the source vanish without a trace.
+    EMPTY_SUMMARY_MESSAGE = "No related information found for this query."
 
-        Returns None when there is no summary or no non-empty content.
+    @classmethod
+    def _summary_to_document(cls, summary: Any) -> Document | None:
+        """Convert a SyftAI-Space summary into a Document.
+
+        Returns None only when there is no summary at all (the endpoint isn't
+        hybrid, or never attempted generation). When a summary IS present but
+        its message content is empty, returns a placeholder Document instead
+        of silently dropping the source.
         """
         if not summary or not isinstance(summary, dict):
             return None
@@ -476,7 +492,11 @@ class DataSourceClient:
             content = ""
 
         if not content:
-            return None
+            return Document(
+                content=cls.EMPTY_SUMMARY_MESSAGE,
+                score=1.0,
+                metadata={"source_type": "generated_empty", "model": summary.get("model")},
+            )
 
         return Document(
             content=str(content),

--- a/components/aggregator/tests/test_data_source_parse.py
+++ b/components/aggregator/tests/test_data_source_parse.py
@@ -78,7 +78,39 @@ def test_parse_empty_when_no_summary_and_no_references() -> None:
     assert docs == []
 
 
-def test_parse_ignores_empty_summary_content() -> None:
+def test_parse_returns_placeholder_for_empty_summary_content() -> None:
+    """A summary block with empty content (e.g. a silently-failed generation)
+    surfaces a placeholder Document instead of being dropped, so the source's
+    document count stays consistent across repeated identical queries."""
     client = DataSourceClient()
-    data = {"summary": {"message": {"role": "assistant", "content": ""}}, "references": None}
-    assert client._parse_syftai_response(data) == []
+    data = {
+        "summary": {"model": "gpt-x", "message": {"role": "assistant", "content": ""}},
+        "references": None,
+    }
+
+    docs = client._parse_syftai_response(data)
+
+    assert len(docs) == 1
+    assert docs[0].content == DataSourceClient.EMPTY_SUMMARY_MESSAGE
+    assert docs[0].score == 1.0
+    assert docs[0].metadata.get("source_type") == "generated_empty"
+    assert docs[0].metadata.get("model") == "gpt-x"
+
+
+def test_parse_includes_both_documents_and_empty_summary_placeholder() -> None:
+    """Hybrid source returns real docs plus an empty summary: the placeholder
+    still surfaces alongside the real documents, not instead of them."""
+    client = DataSourceClient()
+    data = {
+        "summary": {"message": {"role": "assistant", "content": ""}},
+        "references": {
+            "documents": [{"content": "doc one", "similarity_score": 0.8, "metadata": {}}]
+        },
+    }
+
+    docs = client._parse_syftai_response(data)
+
+    contents = [d.content for d in docs]
+    assert "doc one" in contents
+    assert DataSourceClient.EMPTY_SUMMARY_MESSAGE in contents
+    assert len(docs) == 2


### PR DESCRIPTION
## Summary

Alternative/complementary approach to #472's retry parity, addressing a second failure mode behind the same flaky hybrid-endpoint document counts (`federal-office-health-casework` et al.):

- A hybrid (`model_data_source`) endpoint's own `/query` handler runs an LLM generation step. When that call succeeds at the HTTP level but the completion content comes back empty (content filtering, truncation, or a flaky upstream provider silently returning nothing), syft-space still returns a well-formed `HTTP 200` with `summary.message.content == ""`. This is not a retryable error — #472's retry logic (correctly) doesn't touch it.
- `_summary_to_document` (added in #471) previously dropped this case entirely (`return None`), so the same hybrid endpoint would non-deterministically report 0 or 1 documents across repeated identical queries, depending only on whether that request's LLM call happened to produce content.
- `_summary_to_document` now returns a placeholder `Document` (`content = EMPTY_SUMMARY_MESSAGE`, `metadata.source_type = "generated_empty"`) whenever a `summary` block is present but its content is empty, instead of silently dropping the source. A `summary` that's entirely absent (non-hybrid endpoints, or endpoints that never attempted generation) still correctly returns no document — this distinction is preserved.
- Net effect: every hybrid source now contributes exactly one document per query — either its real generated answer or an explicit "no related information found" placeholder — making per-source document counts consistent across repeated identical queries, and making an empty generation visible to the model/user instead of indistinguishable from "this source was never queried."
- Verified via GitNexus `detect_changes` (compare vs `main`): scope fully confined to `_summary_to_document`/`_parse_syftai_response`, 0 affected execution flows, risk level **low**.

## Test plan

- [x] `pytest tests/test_data_source_parse.py` — updated/added tests: empty-summary-content now returns the placeholder (previously asserted `[]`), and a combined real-doc + empty-summary case still surfaces both
- [x] `pytest` (full aggregator suite) — 100 passed
- [x] `ruff check` — clean
- [x] `mypy` — clean