### PR TITLE
ops(backend): raise prod backend mem_limit 1G → 5G

### DIFF
--- a/deploy/docker-compose.deploy.yml
+++ b/deploy/docker-compose.deploy.yml
@@ -163,7 +163,7 @@ services:
       resources:
         limits:
           cpus: '2'
-          memory: 1G
+          memory: 5G
         reservations:
           cpus: '0.5'
           memory: 256M


### PR DESCRIPTION
## What

Raise the prod backend container's memory limit from **1 GiB → 5 GiB** in `deploy/docker-compose.deploy.yml`.

## Why

On 2026-07-08 the prod backend ran under sustained `POST /api/v1/auth/login` load (two IPs sent ~11k requests each over 19h via `python-httpx`). The event-loop-blocking fix from #474 held up perfectly — `/health` stayed at ~5ms, request `duration_ms` p99 = 9ms (max 66ms), and **zero container restarts**. But one thing surfaced:

- At **06:52:34** the kernel cgroup OOM-killer killed a single uvicorn worker (`dmesg: "Memory cgroup out of memory ... Killed process (python)"`). The backend's 1 GiB limit is split across **4 uvicorn workers** (~250 MiB each), and a load burst pushed one worker's RSS over the cgroup ceiling.
- Effect: 4 transient 502s in a single second out of 30k+ requests (0.016%), self-healed as the worker respawned. The **container never restarted** (`RestartCount=0`) — the other 3 workers kept serving. This was a memory-sizing issue, *not* event-loop blocking.

## Capacity check

The prod VM has plenty of room:

| | |
|---|---|
| VM total RAM | 31 GiB |
| Actually used | ~3.6 GiB |
| Sum of all 8 container limits (before) | ~8.5 GiB |
| Unallocated headroom | ~22 GiB |

Raising backend to 5 GiB gives each of the 4 workers ~1.25 GiB of headroom. Even if every container simultaneously maxed its limit, the total stays ~12.5 GiB — well under 31 GiB. (The aggregator already sits at 5 GiB.)

## Scope

- One-line change: `services.backend.deploy.resources.limits.memory: 1G → 5G`.
- No application code touched. `docker compose config` validates.
- Only affects `docker-compose.deploy.yml` (prod). dev/staging compose files don't set this limit.
