### PR TITLE
Implement cluster wallet policies and enhance prepaid billing flow

### DIFF
--- a/components/backend/src/syfthub/models/xendit_subscription.py
+++ b/components/backend/src/syfthub/models/xendit_subscription.py
@@ -41,7 +41,11 @@ class UserXenditSubscriptionModel(BaseModel, TimestampMixin):
     credits_url: Mapped[str] = mapped_column(Text, nullable=False)
     payment_url: Mapped[str] = mapped_column(Text, nullable=False)
 
-    # Display + auth metadata.
+    # Display + auth metadata. ``endpoint_owner`` is the satellite-token
+    # *audience* for the wallet: the wallet-hosting account for cluster
+    # (managed) wallets, the endpoint owner for self-hosted ones. The credits
+    # panel re-mints tokens for this username, and its dedupe-by-owner view
+    # collapses every endpoint backed by one shared wallet into a single row.
     currency: Mapped[str] = mapped_column(String(8), nullable=False, default="IDR")
     endpoint_owner: Mapped[str] = mapped_column(String(50), nullable=False)
     endpoint_slug: Mapped[Optional[str]] = mapped_column(

--- a/components/backend/src/syfthub/schemas/collective.py
+++ b/components/backend/src/syfthub/schemas/collective.py
@@ -560,7 +560,7 @@ class MemberBillingDetail(BaseModel):
 
     kind: str = Field(..., description="One of 'prepaid', 'mpp', 'free'")
     provider: Optional[str] = Field(
-        None, description="Prepaid gateway provider ('xendit' / 'stripe')"
+        None, description="Prepaid gateway provider ('xendit' / 'stripe' / 'cluster')"
     )
     currency: Optional[str] = Field(None, description="Prepaid currency code")
     price_per_unit: Optional[float] = Field(
@@ -578,6 +578,17 @@ class MemberBillingDetail(BaseModel):
     )
     bundles: List[MoneyBundle] = Field(
         default_factory=list, description="Purchasable prepaid bundles"
+    )
+    wallet_id: Optional[str] = Field(
+        None,
+        description="Shared wallet identifier (cluster prepaid only) — stable "
+        "grouping key across the endpoints backed by one wallet",
+    )
+    wallet_owner_username: Optional[str] = Field(
+        None,
+        description="Username of the wallet-hosting account, i.e. the "
+        "satellite-token audience (cluster prepaid only; audience falls back "
+        "to the endpoint owner when absent)",
     )
 
 

--- a/components/backend/src/syfthub/schemas/endpoint.py
+++ b/components/backend/src/syfthub/schemas/endpoint.py
@@ -44,6 +44,21 @@ def get_matching_types(endpoint_type: EndpointType) -> list[str]:
         return [endpoint_type.value]
 
 
+# Policy ``type`` values that bill via publisher-side prepaid credits (the
+# buyer funds a wallet with the publisher and tops it up via ``payment_url``).
+# ``cluster`` is a station-hosted *shared* wallet: many spaces publish the same
+# ``wallet_id`` under one wallet-owner account, so one balance backs them all.
+# Single source of truth — keep in lockstep with the frontend
+# ``PREPAID_BALANCE_TYPES`` set in ``policy-item.tsx``.
+PREPAID_POLICY_TYPES: frozenset[str] = frozenset({"xendit", "stripe", "cluster"})
+
+# The station-hosted shared-wallet policy type. Unlike ``xendit``/``stripe``,
+# its config must name the wallet-owning Hub account (``wallet_owner``) so the
+# satellite-token audience can be derived; see
+# ``EndpointService._process_cluster_policies``.
+CLUSTER_POLICY_TYPE = "cluster"
+
+
 class Policy(BaseModel):
     """Policy configuration for endpoints.
 

--- a/components/backend/src/syfthub/services/collective_service.py
+++ b/components/backend/src/syfthub/services/collective_service.py
@@ -46,6 +46,7 @@ from syfthub.schemas.collective import (
     slugify_shared_endpoint_name,
 )
 from syfthub.schemas.endpoint import (
+    PREPAID_POLICY_TYPES,
     Endpoint,
     EndpointType,
     EndpointVisibility,
@@ -69,8 +70,9 @@ _JOINABLE_ENDPOINT_TYPES: frozenset[str] = frozenset(
 
 # Policy ``type`` values that bill via publisher-side prepaid credits (the buyer
 # funds a wallet with the publisher and we read/charge it). These map onto the
-# chat PaymentGate / wallet-panel settlement UX.
-_PREPAID_PROVIDERS: frozenset[str] = frozenset({"xendit", "stripe"})
+# chat PaymentGate / wallet-panel settlement UX. Defined in ``schemas.endpoint``
+# as the single source of truth (also drives the 'prepaid' discovery tag).
+_PREPAID_PROVIDERS: frozenset[str] = PREPAID_POLICY_TYPES
 
 # The single canonical pay-as-you-go (MPP) policy ``type`` — billed per request
 # against the buyer's single Hub (MPP) wallet, with no upfront prepaid wallet per
@@ -141,6 +143,14 @@ def _parse_prepaid_config(config: dict[str, Any]) -> Optional[dict[str, Any]]:
                     MoneyBundle(name=entry["name"], amount=float(entry["amount"]))
                 )
 
+    # Cluster (station-hosted shared wallet) extras. ``wallet_owner_username``
+    # is server-derived at publish time and names the satellite-token audience;
+    # absent on self-hosted xendit/stripe policies (audience = endpoint owner).
+    wallet_id = _pick(config, "wallet_id", "walletId")
+    wallet_owner_username = _pick(
+        config, "wallet_owner_username", "walletOwnerUsername"
+    )
+
     return {
         "currency": currency if isinstance(currency, str) else "IDR",
         "price_per_unit": float(price) if isinstance(price, (int, float)) else None,
@@ -149,6 +159,12 @@ def _parse_prepaid_config(config: dict[str, Any]) -> Optional[dict[str, Any]]:
         "credits_url": credits_url,
         "invoices_url": invoices_url if _is_url(invoices_url) else None,
         "bundles": bundles,
+        "wallet_id": wallet_id if isinstance(wallet_id, str) and wallet_id else None,
+        "wallet_owner_username": (
+            wallet_owner_username
+            if isinstance(wallet_owner_username, str) and wallet_owner_username
+            else None
+        ),
     }
 
 

--- a/components/backend/src/syfthub/services/collective_service.py
+++ b/components/backend/src/syfthub/services/collective_service.py
@@ -46,6 +46,7 @@ from syfthub.schemas.collective import (
     slugify_shared_endpoint_name,
 )
 from syfthub.schemas.endpoint import (
+    CLUSTER_POLICY_TYPE,
     PREPAID_POLICY_TYPES,
     Endpoint,
     EndpointType,
@@ -110,12 +111,50 @@ def _parse_unit(config: dict[str, Any]) -> str:
     return "request"
 
 
-def _parse_prepaid_config(config: dict[str, Any]) -> Optional[dict[str, Any]]:
+def _wallet_identity(
+    config: dict[str, Any], policy_type: str
+) -> tuple[Optional[str], Optional[str]]:
+    """The ``(wallet_id, wallet_owner_username)`` a policy may claim.
+
+    Only a ``cluster`` policy may carry a wallet identity of its own. Its
+    ``wallet_owner`` and every wallet URL are verified against that owner's
+    registered domain when it is published, so the claim has been proven.
+    Self-hosted (``xendit`` / ``stripe``) policy URLs are never
+    domain-verified, so the same fields on one are ignored: honouring them
+    would let a publisher group their endpoint into somebody else's wallet,
+    or have buyers mint satellite tokens for an account they don't own and
+    collect those tokens at a host they do.
+
+    Gating on read — rather than trusting publish-time stripping alone —
+    also neutralizes rows stored before that stripping existed.
+    """
+    if policy_type.lower() != CLUSTER_POLICY_TYPE:
+        return None, None
+    wallet_id = _pick(config, "wallet_id", "walletId")
+    wallet_owner_username = _pick(
+        config, "wallet_owner_username", "walletOwnerUsername"
+    )
+    return (
+        wallet_id if isinstance(wallet_id, str) and wallet_id else None,
+        (
+            wallet_owner_username
+            if isinstance(wallet_owner_username, str) and wallet_owner_username
+            else None
+        ),
+    )
+
+
+def _parse_prepaid_config(
+    config: dict[str, Any], policy_type: str
+) -> Optional[dict[str, Any]]:
     """Normalize a prepaid policy ``config`` into billing-detail kwargs.
 
     Returns ``None`` when the policy lacks the URLs needed to read a balance or
     purchase credits — such a policy can't drive settlement, so the member is
     treated as if it had no prepaid policy at all.
+
+    ``policy_type`` gates the wallet identity fields: only ``cluster`` may
+    carry them (see ``_wallet_identity``).
     """
     payment_url = _pick(config, "payment_url", "paymentUrl")
     credits_url = _pick(config, "credits_url", "creditsUrl")
@@ -143,13 +182,7 @@ def _parse_prepaid_config(config: dict[str, Any]) -> Optional[dict[str, Any]]:
                     MoneyBundle(name=entry["name"], amount=float(entry["amount"]))
                 )
 
-    # Cluster (station-hosted shared wallet) extras. ``wallet_owner_username``
-    # is server-derived at publish time and names the satellite-token audience;
-    # absent on self-hosted xendit/stripe policies (audience = endpoint owner).
-    wallet_id = _pick(config, "wallet_id", "walletId")
-    wallet_owner_username = _pick(
-        config, "wallet_owner_username", "walletOwnerUsername"
-    )
+    wallet_id, wallet_owner_username = _wallet_identity(config, policy_type)
 
     return {
         "currency": currency if isinstance(currency, str) else "IDR",
@@ -159,12 +192,8 @@ def _parse_prepaid_config(config: dict[str, Any]) -> Optional[dict[str, Any]]:
         "credits_url": credits_url,
         "invoices_url": invoices_url if _is_url(invoices_url) else None,
         "bundles": bundles,
-        "wallet_id": wallet_id if isinstance(wallet_id, str) and wallet_id else None,
-        "wallet_owner_username": (
-            wallet_owner_username
-            if isinstance(wallet_owner_username, str) and wallet_owner_username
-            else None
-        ),
+        "wallet_id": wallet_id,
+        "wallet_owner_username": wallet_owner_username,
     }
 
 
@@ -242,7 +271,7 @@ def _classify_billing(endpoint: Endpoint) -> MemberBillingDetail:
         ptype = str(_policy_field(policy, "type", "")).lower()
         config = _policy_field(policy, "config", {}) or {}
         if ptype in _PREPAID_PROVIDERS:
-            parsed = _parse_prepaid_config(config)
+            parsed = _parse_prepaid_config(config, ptype)
             if parsed is not None:
                 return MemberBillingDetail(kind="prepaid", provider=ptype, **parsed)
         elif ptype in _MPP_POLICY_TYPES and mpp_config is None:

--- a/components/backend/src/syfthub/services/endpoint_service.py
+++ b/components/backend/src/syfthub/services/endpoint_service.py
@@ -15,6 +15,8 @@ from syfthub.repositories.endpoint import EndpointRepository, EndpointStarReposi
 from syfthub.repositories.user import UserRepository
 from syfthub.schemas.auth import UserRole
 from syfthub.schemas.endpoint import (
+    CLUSTER_POLICY_TYPE,
+    PREPAID_POLICY_TYPES,
     RESERVED_SLUGS,
     Endpoint,
     EndpointAdminUpdate,
@@ -169,18 +171,159 @@ class EndpointService(BaseService):
 
     @staticmethod
     def _inject_prepaid_tag(tags: list[str], policies: list[Policy]) -> list[str]:
-        """Inject 'prepaid' tag if a xendit policy is present.
+        """Inject 'prepaid' tag if a prepaid-credits policy is present.
 
         Silently skips if the tags list already has 10 or more entries and
         'prepaid' is not present (preserves the 10-tag soft limit for
         user-supplied tags without rejecting the request).
         """
-        has_xendit_policy = any(p.type.lower() == "xendit" for p in policies)
-        if has_xendit_policy and "prepaid" not in tags:
+        has_prepaid_policy = any(
+            p.type.lower() in PREPAID_POLICY_TYPES for p in policies
+        )
+        if has_prepaid_policy and "prepaid" not in tags:
             if len(tags) >= 10:
                 return tags
             return [*tags, "prepaid"]
         return tags
+
+    @staticmethod
+    def _iter_policy_leaf_configs(policies: Any) -> Any:
+        """Yield ``(type, config)`` for every enabled leaf policy.
+
+        Accepts both shapes a policy arrives in: validated ``Policy`` models
+        (top-level entries) and raw dicts (children that composite policies
+        nest under ``config["policies"]``). Composite wrappers (``all_of`` /
+        ``any_of`` / …) are descended into rather than yielded — a billing
+        policy inside a wrapper is just as active as a top-level one, so
+        publish-time validation must see it exactly like the billing
+        classifier in ``collective_service`` does. A disabled policy (or
+        wrapper) skips its whole subtree.
+
+        Yielded configs are the live dicts: mutating one mutates the policy
+        that will be stored.
+        """
+        for policy in policies or []:
+            if isinstance(policy, dict):
+                ptype = policy.get("type", "")
+                enabled = policy.get("enabled", True)
+                config = policy.get("config") or {}
+            else:
+                ptype = policy.type
+                enabled = policy.enabled
+                config = policy.config
+            if not enabled or not isinstance(config, dict):
+                continue
+            children = config.get("policies")
+            if isinstance(children, list) and children:
+                yield from EndpointService._iter_policy_leaf_configs(children)
+            else:
+                yield str(ptype), config
+
+    @staticmethod
+    def _host_under_domain(url: str, domain_host: str) -> bool:
+        """Whether ``url``'s host equals or is a subdomain of ``domain_host``.
+
+        ``domain_host`` must be a bare lowercase hostname (no scheme or port).
+        For ``domain_host="spaces.openmined.org"``:
+
+        - ``https://spaces.openmined.org/api/...`` → True (exact match)
+        - ``https://wallet.spaces.openmined.org/...`` → True (subdomain)
+        - ``https://spaces.openmined.org.evil.com/...`` → False
+        """
+        host = (urlparse(url).hostname or "").lower()
+        return bool(host) and (host == domain_host or host.endswith("." + domain_host))
+
+    def _process_cluster_policies(self, policies: list[Policy]) -> Optional[str]:
+        """Validate ``cluster`` (station-hosted shared wallet) policies in place.
+
+        Runs on every publish path (create, update, sync) before policies are
+        stored. A ``cluster`` policy claims its wallet is hosted by another
+        Hub account (``wallet_owner``), and buyers' satellite tokens are
+        minted for that account — so the claim is verified here, not trusted:
+
+        1. ``wallet_id`` must be a non-empty string.
+        2. ``wallet_owner`` must be the id of an existing, active user.
+        3. ``payment_url`` and ``credits_url`` (plus ``invoices_url`` when
+           present) must be http(s) URLs whose hosts fall under the wallet
+           owner's registered ``domain``. This stops a malicious publisher
+           from routing buyers' satellite tokens to a host the wallet owner
+           doesn't control.
+
+        On success, each cluster config is enriched **in place** with the
+        server-derived ``wallet_owner_username`` — the audience the frontend
+        mints satellite tokens for. Any client-supplied value is overwritten:
+        usernames are mutable and reusable on SyftHub, so the id stays
+        canonical and the username is re-derived on every publish.
+
+        Returns:
+            The first failed check as a human-readable message (callers
+            surface it as a 422 or a sync validation error), or ``None``
+            when every cluster policy validates. Endpoints with no cluster
+            policy always pass.
+        """
+        for ptype, config in self._iter_policy_leaf_configs(policies):
+            if ptype.lower() != CLUSTER_POLICY_TYPE:
+                continue
+
+            wallet_id = config.get("wallet_id") or config.get("walletId")
+            if not isinstance(wallet_id, str) or not wallet_id.strip():
+                return "cluster policy requires a non-empty 'wallet_id'"
+
+            raw_owner = config.get("wallet_owner")
+            if raw_owner is None:
+                raw_owner = config.get("walletOwner")
+            if isinstance(raw_owner, str) and raw_owner.isdigit():
+                raw_owner = int(raw_owner)
+            if not isinstance(raw_owner, int) or isinstance(raw_owner, bool):
+                return "cluster policy requires 'wallet_owner' (Hub user id)"
+
+            owner = self.user_repository.get_by_id(raw_owner)
+            if owner is None or not owner.is_active:
+                return (
+                    f"cluster policy 'wallet_owner' {raw_owner} does not "
+                    "resolve to an active user"
+                )
+            if not owner.domain:
+                return (
+                    f"cluster wallet owner '{owner.username}' has no registered "
+                    "domain on SyftHub; the wallet URLs cannot be verified"
+                )
+            domain = owner.domain
+            if "://" not in domain:
+                domain = f"https://{domain}"
+            domain_host = (urlparse(domain).hostname or "").lower()
+            if not domain_host:
+                return (
+                    f"cluster wallet owner '{owner.username}' has an invalid "
+                    "registered domain"
+                )
+
+            payment_url = config.get("payment_url") or config.get("paymentUrl")
+            credits_url = config.get("credits_url") or config.get("creditsUrl")
+            invoices_url = config.get("invoices_url") or config.get("invoicesUrl")
+            for field_name, url, required in (
+                ("payment_url", payment_url, True),
+                ("credits_url", credits_url, True),
+                ("invoices_url", invoices_url, False),
+            ):
+                if url is None and not required:
+                    continue
+                if not isinstance(url, str) or not url.startswith(
+                    ("https://", "http://")
+                ):
+                    return f"cluster policy requires a valid http(s) '{field_name}'"
+                if not self._host_under_domain(url, domain_host):
+                    return (
+                        f"cluster policy '{field_name}' host is not under the "
+                        f"wallet owner's registered domain '{domain_host}'"
+                    )
+
+            # Server-derived enrichment: canonical id + current username. The
+            # frontend uses the username as the satellite-token audience.
+            config["wallet_owner"] = owner.id
+            config["wallet_owner_username"] = owner.username
+
+        return None
 
     def create_endpoint(
         self,
@@ -196,6 +339,13 @@ class EndpointService(BaseService):
         # This ensures every endpoint has at least one contributor (the creator)
         if current_user and current_user.id not in valid_contributors:
             valid_contributors.append(current_user.id)
+
+        cluster_error = self._process_cluster_policies(endpoint_data.policies)
+        if cluster_error:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=cluster_error,
+            )
 
         # Auto-generate slug if not provided
         final_slug = endpoint_data.slug
@@ -328,6 +478,12 @@ class EndpointService(BaseService):
             endpoint_data.contributors = valid_contributors
 
         if endpoint_data.policies is not None:
+            cluster_error = self._process_cluster_policies(endpoint_data.policies)
+            if cluster_error:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=cluster_error,
+                )
             effective_tags = (
                 endpoint_data.tags
                 if endpoint_data.tags is not None
@@ -1077,6 +1233,16 @@ class EndpointService(BaseService):
             # Always add current user as contributor
             if current_user.id not in valid_contributors:
                 valid_contributors.append(current_user.id)
+
+            # Validate + enrich cluster (shared wallet) policies
+            cluster_error = self._process_cluster_policies(endpoint_data.policies)
+            if cluster_error:
+                validation_errors.append(
+                    SyncValidationError(
+                        index=index, field="policies", error=cluster_error
+                    )
+                )
+                continue
 
             # Prepare the validated endpoint data
             final_tags = self._inject_prepaid_tag(

--- a/components/backend/src/syfthub/services/endpoint_service.py
+++ b/components/backend/src/syfthub/services/endpoint_service.py
@@ -243,6 +243,22 @@ class EndpointService(BaseService):
         host = (urlparse(url).hostname or "").lower()
         return bool(host) and (host == domain_host or host.endswith("." + domain_host))
 
+    # Server-owned: names the satellite-token audience and is derived from the
+    # verified ``wallet_owner`` id. Publishers never send it (syft-space
+    # publishes the id), so any incoming value is dropped on every policy type
+    # before validation re-injects the real one.
+    _SERVER_OWNED_CONFIG_KEYS = ("wallet_owner_username", "walletOwnerUsername")
+
+    # Legitimately publisher-supplied, but only meaningful under a verified
+    # cluster claim; dropped from other prepaid policies (see
+    # _process_cluster_policies).
+    _CLUSTER_ONLY_CONFIG_KEYS = (
+        "wallet_id",
+        "walletId",
+        "wallet_owner",
+        "walletOwner",
+    )
+
     def _process_cluster_policies(self, policies: list[Policy]) -> Optional[str]:
         """Validate ``cluster`` (station-hosted shared wallet) policies in place.
 
@@ -263,7 +279,16 @@ class EndpointService(BaseService):
         server-derived ``wallet_owner_username`` — the audience the frontend
         mints satellite tokens for. Any client-supplied value is overwritten:
         usernames are mutable and reusable on SyftHub, so the id stays
-        canonical and the username is re-derived on every publish.
+        canonical and the username is re-derived on every publish. Accepted
+        camelCase spellings are rewritten to the canonical snake_case keys,
+        so stored configs always have one shape.
+
+        Non-``cluster`` prepaid policies get the wallet identity/audience
+        fields **stripped**: the frontend mints satellite tokens for
+        ``wallet_owner_username`` whenever it is present on any prepaid
+        policy, and self-hosted policy URLs are not domain-verified — left
+        in place, a publisher could route tokens minted for an arbitrary
+        account to a host they control (token exfiltration).
 
         Returns:
             The first failed check as a human-readable message (callers
@@ -272,7 +297,15 @@ class EndpointService(BaseService):
             policy always pass.
         """
         for ptype, config in self._iter_policy_configs(policies):
-            if ptype.lower() != CLUSTER_POLICY_TYPE:
+            # No publisher may name the token audience, on any policy type.
+            for key in self._SERVER_OWNED_CONFIG_KEYS:
+                config.pop(key, None)
+
+            ptype_lower = ptype.lower()
+            if ptype_lower != CLUSTER_POLICY_TYPE:
+                if ptype_lower in PREPAID_POLICY_TYPES:
+                    for key in self._CLUSTER_ONLY_CONFIG_KEYS:
+                        config.pop(key, None)
                 continue
 
             wallet_id = config.get("wallet_id") or config.get("walletId")
@@ -336,10 +369,26 @@ class EndpointService(BaseService):
                         f"wallet owner's registered domain '{domain_host}'"
                     )
 
-            # Server-derived enrichment: canonical id + current username. The
-            # frontend uses the username as the satellite-token audience.
+            # Canonicalize to snake_case + server-derived enrichment (the
+            # frontend uses the username as the satellite-token audience).
+            # camelCase spellings are dropped so stored configs have exactly
+            # one shape.
+            for camel_key in (
+                "walletId",
+                "walletOwner",
+                "walletOwnerUsername",
+                "paymentUrl",
+                "creditsUrl",
+                "invoicesUrl",
+            ):
+                config.pop(camel_key, None)
+            config["wallet_id"] = wallet_id
             config["wallet_owner"] = owner.id
             config["wallet_owner_username"] = owner.username
+            config["payment_url"] = payment_url
+            config["credits_url"] = credits_url
+            if invoices_url is not None:
+                config["invoices_url"] = invoices_url
 
         return None
 

--- a/components/backend/src/syfthub/services/endpoint_service.py
+++ b/components/backend/src/syfthub/services/endpoint_service.py
@@ -40,6 +40,7 @@ from syfthub.schemas.endpoint import (
     get_matching_types,
 )
 from syfthub.schemas.search import EndpointSearchResponse, EndpointSearchResult
+from syfthub.schemas.user import TUNNELING_PREFIX
 from syfthub.services.base import BaseService
 from syfthub.services.rag_service import RAGService, get_rag_service
 
@@ -173,12 +174,18 @@ class EndpointService(BaseService):
     def _inject_prepaid_tag(tags: list[str], policies: list[Policy]) -> list[str]:
         """Inject 'prepaid' tag if a prepaid-credits policy is present.
 
+        Uses the same traversal as cluster validation and billing
+        classification, so a prepaid policy nested inside a composite
+        wrapper tags the endpoint exactly like a top-level one, and a
+        disabled policy never does.
+
         Silently skips if the tags list already has 10 or more entries and
         'prepaid' is not present (preserves the 10-tag soft limit for
         user-supplied tags without rejecting the request).
         """
         has_prepaid_policy = any(
-            p.type.lower() in PREPAID_POLICY_TYPES for p in policies
+            ptype.lower() in PREPAID_POLICY_TYPES
+            for ptype, _ in EndpointService._iter_policy_configs(policies)
         )
         if has_prepaid_policy and "prepaid" not in tags:
             if len(tags) >= 10:
@@ -187,17 +194,21 @@ class EndpointService(BaseService):
         return tags
 
     @staticmethod
-    def _iter_policy_leaf_configs(policies: Any) -> Any:
-        """Yield ``(type, config)`` for every enabled leaf policy.
+    def _iter_policy_configs(policies: Any) -> Any:
+        """Yield ``(type, config)`` for every enabled policy, wrappers included.
 
         Accepts both shapes a policy arrives in: validated ``Policy`` models
         (top-level entries) and raw dicts (children that composite policies
         nest under ``config["policies"]``). Composite wrappers (``all_of`` /
-        ``any_of`` / …) are descended into rather than yielded — a billing
-        policy inside a wrapper is just as active as a top-level one, so
-        publish-time validation must see it exactly like the billing
-        classifier in ``collective_service`` does. A disabled policy (or
-        wrapper) skips its whole subtree.
+        ``any_of`` / …) are yielded too, then descended into — consumers
+        filter on ``type``, so wrapper entries are inert to them.
+
+        The parent is yielded even when it has children: a policy can carry
+        a billing ``type`` *and* a nested ``policies`` list, and consumers
+        that read policies at the top level would treat it as live billing —
+        skipping it here would let a publisher dodge cluster validation by
+        attaching a dummy child list. A disabled policy (or wrapper) skips
+        its whole subtree.
 
         Yielded configs are the live dicts: mutating one mutates the policy
         that will be stored.
@@ -213,11 +224,10 @@ class EndpointService(BaseService):
                 config = policy.config
             if not enabled or not isinstance(config, dict):
                 continue
+            yield str(ptype), config
             children = config.get("policies")
             if isinstance(children, list) and children:
-                yield from EndpointService._iter_policy_leaf_configs(children)
-            else:
-                yield str(ptype), config
+                yield from EndpointService._iter_policy_configs(children)
 
     @staticmethod
     def _host_under_domain(url: str, domain_host: str) -> bool:
@@ -261,7 +271,7 @@ class EndpointService(BaseService):
             when every cluster policy validates. Endpoints with no cluster
             policy always pass.
         """
-        for ptype, config in self._iter_policy_leaf_configs(policies):
+        for ptype, config in self._iter_policy_configs(policies):
             if ptype.lower() != CLUSTER_POLICY_TYPE:
                 continue
 
@@ -287,6 +297,14 @@ class EndpointService(BaseService):
                 return (
                     f"cluster wallet owner '{owner.username}' has no registered "
                     "domain on SyftHub; the wallet URLs cannot be verified"
+                )
+            if owner.domain.startswith(TUNNELING_PREFIX):
+                # Tunneling spaces have no public hostname, so host-based
+                # wallet URL verification can never succeed — reject clearly
+                # instead of failing against a bogus "tunneling" host.
+                return (
+                    f"cluster wallet owner '{owner.username}' uses a tunneling "
+                    "domain; cluster wallet URLs require a public http(s) domain"
                 )
             domain = owner.domain
             if "://" not in domain:

--- a/components/backend/tests/test_collective_billing.py
+++ b/components/backend/tests/test_collective_billing.py
@@ -69,7 +69,7 @@ def test_parse_unit_defaults_to_request() -> None:
 
 
 def test_parse_prepaid_config_valid() -> None:
-    parsed = _parse_prepaid_config(_PREPAID_CONFIG)
+    parsed = _parse_prepaid_config(_PREPAID_CONFIG, "xendit")
     assert parsed is not None
     assert parsed["currency"] == "IDR"
     assert parsed["price_per_unit"] == 2500
@@ -86,7 +86,8 @@ def test_parse_prepaid_config_accepts_camel_case() -> None:
         {
             "paymentUrl": "https://pay.example.com/invoice",
             "creditsUrl": "https://pay.example.com/balance",
-        }
+        },
+        "xendit",
     )
     assert parsed is not None
     assert parsed["payment_url"] == "https://pay.example.com/invoice"
@@ -98,29 +99,38 @@ def test_parse_prepaid_config_legacy_price_key() -> None:
     config = {**_PREPAID_CONFIG}
     del config["price"]
     config["price_per_request"] = 999
-    parsed = _parse_prepaid_config(config)
+    parsed = _parse_prepaid_config(config, "xendit")
     assert parsed is not None
     assert parsed["price_per_unit"] == 999
 
 
 def test_parse_prepaid_config_requires_both_urls() -> None:
     # Missing credits_url → not settlable → None.
-    assert _parse_prepaid_config({"payment_url": "https://pay.example.com"}) is None
+    assert (
+        _parse_prepaid_config({"payment_url": "https://pay.example.com"}, "xendit")
+        is None
+    )
     # Missing payment_url → None.
-    assert _parse_prepaid_config({"credits_url": "https://pay.example.com"}) is None
+    assert (
+        _parse_prepaid_config({"credits_url": "https://pay.example.com"}, "xendit")
+        is None
+    )
     # Non-http values are rejected.
     assert (
-        _parse_prepaid_config({"payment_url": "ftp://x", "credits_url": "ftp://y"})
+        _parse_prepaid_config(
+            {"payment_url": "ftp://x", "credits_url": "ftp://y"}, "xendit"
+        )
         is None
     )
 
 
 def test_parse_prepaid_config_invoices_url_optional() -> None:
-    parsed = _parse_prepaid_config(_PREPAID_CONFIG)
+    parsed = _parse_prepaid_config(_PREPAID_CONFIG, "xendit")
     assert parsed is not None
     assert parsed["invoices_url"] is None
     parsed2 = _parse_prepaid_config(
-        {**_PREPAID_CONFIG, "invoices_url": "https://pay.example.com/invoices"}
+        {**_PREPAID_CONFIG, "invoices_url": "https://pay.example.com/invoices"},
+        "xendit",
     )
     assert parsed2 is not None
     assert parsed2["invoices_url"] == "https://pay.example.com/invoices"
@@ -222,17 +232,40 @@ def test_classify_stripe_provider_recorded() -> None:
 
 
 def test_parse_prepaid_config_cluster_wallet_fields() -> None:
-    parsed = _parse_prepaid_config(_CLUSTER_CONFIG)
+    parsed = _parse_prepaid_config(_CLUSTER_CONFIG, "cluster")
     assert parsed is not None
     assert parsed["wallet_id"] == "018f2c3a-7b1e-4c2d-9a6f-3e8d5b1c4a90"
     assert parsed["wallet_owner_username"] == "station"
 
 
 def test_parse_prepaid_config_wallet_fields_absent_for_self_hosted() -> None:
-    parsed = _parse_prepaid_config(_PREPAID_CONFIG)
+    parsed = _parse_prepaid_config(_PREPAID_CONFIG, "xendit")
     assert parsed is not None
     assert parsed["wallet_id"] is None
     assert parsed["wallet_owner_username"] is None
+
+
+def test_parse_prepaid_config_ignores_wallet_identity_on_self_hosted() -> None:
+    """A self-hosted policy carrying wallet identity fields — a row stored
+    before publish-time stripping existed. Its URLs were never domain-verified,
+    so the claim must be dropped on read: the identity would group the endpoint
+    into someone else's wallet and mint buyer tokens for an account the
+    publisher does not own."""
+    parsed = _parse_prepaid_config(_CLUSTER_CONFIG, "xendit")
+    assert parsed is not None
+    assert parsed["wallet_id"] is None
+    assert parsed["wallet_owner_username"] is None
+    # The self-hosted fields it legitimately owns still work.
+    assert parsed["payment_url"] == "https://pay.example.com/invoice"
+
+
+def test_classify_ignores_wallet_identity_on_self_hosted_policy() -> None:
+    """Same guard through the classifier the billing summary actually calls."""
+    detail = _classify_billing(_endpoint(_policy("xendit", _CLUSTER_CONFIG)))
+    assert detail.kind == "prepaid"
+    assert detail.provider == "xendit"
+    assert detail.wallet_id is None
+    assert detail.wallet_owner_username is None
 
 
 def test_classify_cluster_as_prepaid() -> None:

--- a/components/backend/tests/test_collective_billing.py
+++ b/components/backend/tests/test_collective_billing.py
@@ -36,6 +36,15 @@ _PREPAID_CONFIG = {
     "bundles": [{"name": "Starter", "amount": 50000}],
 }
 
+# Station-hosted shared wallet: same envelope plus the wallet identity fields.
+# ``wallet_owner_username`` is injected server-side at publish time.
+_CLUSTER_CONFIG = {
+    **_PREPAID_CONFIG,
+    "wallet_id": "018f2c3a-7b1e-4c2d-9a6f-3e8d5b1c4a90",
+    "wallet_owner": 42,
+    "wallet_owner_username": "station",
+}
+
 
 # ----------------------------------------------------------------------
 # _parse_unit
@@ -210,6 +219,29 @@ def test_classify_stripe_provider_recorded() -> None:
     detail = _classify_billing(_endpoint(_policy("stripe", _PREPAID_CONFIG)))
     assert detail.kind == "prepaid"
     assert detail.provider == "stripe"
+
+
+def test_parse_prepaid_config_cluster_wallet_fields() -> None:
+    parsed = _parse_prepaid_config(_CLUSTER_CONFIG)
+    assert parsed is not None
+    assert parsed["wallet_id"] == "018f2c3a-7b1e-4c2d-9a6f-3e8d5b1c4a90"
+    assert parsed["wallet_owner_username"] == "station"
+
+
+def test_parse_prepaid_config_wallet_fields_absent_for_self_hosted() -> None:
+    parsed = _parse_prepaid_config(_PREPAID_CONFIG)
+    assert parsed is not None
+    assert parsed["wallet_id"] is None
+    assert parsed["wallet_owner_username"] is None
+
+
+def test_classify_cluster_as_prepaid() -> None:
+    detail = _classify_billing(_endpoint(_policy("cluster", _CLUSTER_CONFIG)))
+    assert detail.kind == "prepaid"
+    assert detail.provider == "cluster"
+    assert detail.wallet_id == "018f2c3a-7b1e-4c2d-9a6f-3e8d5b1c4a90"
+    assert detail.wallet_owner_username == "station"
+    assert detail.payment_url == "https://pay.example.com/invoice"
 
 
 # ----------------------------------------------------------------------

--- a/components/backend/tests/test_endpoints.py
+++ b/components/backend/tests/test_endpoints.py
@@ -2455,3 +2455,250 @@ def test_uptime_rejects_window_over_cap(client: TestClient) -> None:
     assert any(
         "window_hours" in (err.get("loc") or []) for err in body.get("detail", [])
     ), body
+
+
+# ----------------------------------------------------------------------
+# Cluster (station-hosted shared wallet) policy validation + enrichment
+# ----------------------------------------------------------------------
+#
+# A ``cluster`` policy claims its wallet is hosted by another Hub account
+# (``wallet_owner``). Publish-time validation resolves that id to an active
+# user, requires every wallet URL host to fall under that user's registered
+# domain, and injects the server-derived ``wallet_owner_username`` (the
+# satellite-token audience) into the stored config.
+
+_STATION_DOMAIN = "https://spaces.openmined.org"
+_STATION_WALLET_ID = "018f2c3a-7b1e-4c2d-9a6f-3e8d5b1c4a90"
+
+
+@pytest.fixture
+def station_owner(client: TestClient) -> dict:
+    """Register the wallet-owning 'station' account with a registered domain."""
+    user_data = {
+        "username": "station",
+        "email": "station@example.com",
+        "full_name": "Station Owner",
+        "password": "stationpass123",
+    }
+    response = client.post("/api/v1/auth/register", json=user_data)
+    user_id = response.json()["user"]["id"]
+
+    from syfthub.database.connection import get_db_session
+    from syfthub.repositories.user import UserRepository
+
+    session = next(get_db_session())
+    try:
+        # update_domain does not commit; the caller owns the transaction.
+        UserRepository(session).update_domain(user_id, _STATION_DOMAIN)
+        session.commit()
+    finally:
+        session.close()
+
+    return {"id": user_id, "username": "station"}
+
+
+def _cluster_policy(wallet_owner_id: int, **config_overrides: object) -> dict:
+    """A cluster policy payload matching the syft-space publish shape."""
+    base = f"{_STATION_DOMAIN}/api/v1/credits/{_STATION_WALLET_ID}"
+    config: dict = {
+        "price": 2.5,
+        "unit_type": "request",
+        "applied_to": ["*"],
+        "currency": "PHP",
+        "wallet_id": _STATION_WALLET_ID,
+        "wallet_owner": wallet_owner_id,
+        "bundles": [
+            {"name": "Starter", "amount": 100},
+            {"name": "Pro", "amount": 1000},
+        ],
+        "payment_url": f"{base}/invoices",
+        "invoices_url": f"{base}/invoices/me",
+        "credits_url": f"{base}/balance",
+    }
+    config.update(config_overrides)
+    return {
+        "type": "cluster",
+        "version": "1.0",
+        "enabled": True,
+        "description": "Pay per request",
+        "config": config,
+    }
+
+
+def _cluster_endpoint_payload(policy: dict, name: str = "Legal RAG") -> dict:
+    return {
+        "name": name,
+        "type": "model",
+        "visibility": "public",
+        "policies": [policy],
+    }
+
+
+def test_cluster_policy_create_enriches_owner_username(
+    client: TestClient, user1_token: str, station_owner: dict
+) -> None:
+    """Valid cluster policy publishes, gets the audience injected + prepaid tag."""
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    payload = _cluster_endpoint_payload(_cluster_policy(station_owner["id"]))
+
+    response = client.post("/api/v1/endpoints", json=payload, headers=headers)
+    assert response.status_code == 201, response.text
+
+    data = response.json()
+    config = data["policies"][0]["config"]
+    assert config["wallet_owner"] == station_owner["id"]
+    assert config["wallet_owner_username"] == "station"
+    assert "prepaid" in data["tags"]
+
+
+def test_cluster_policy_owner_username_is_server_derived(
+    client: TestClient, user1_token: str, station_owner: dict
+) -> None:
+    """A client-supplied wallet_owner_username is overwritten, never trusted."""
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    policy = _cluster_policy(station_owner["id"], wallet_owner_username="someone-else")
+    response = client.post(
+        "/api/v1/endpoints", json=_cluster_endpoint_payload(policy), headers=headers
+    )
+    assert response.status_code == 201, response.text
+    config = response.json()["policies"][0]["config"]
+    assert config["wallet_owner_username"] == "station"
+
+
+def test_cluster_policy_accepts_subdomain_of_owner_domain(
+    client: TestClient, user1_token: str, station_owner: dict
+) -> None:
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    sub = f"https://wallet.spaces.openmined.org/api/v1/credits/{_STATION_WALLET_ID}"
+    policy = _cluster_policy(
+        station_owner["id"],
+        payment_url=f"{sub}/invoices",
+        invoices_url=f"{sub}/invoices/me",
+        credits_url=f"{sub}/balance",
+    )
+    response = client.post(
+        "/api/v1/endpoints", json=_cluster_endpoint_payload(policy), headers=headers
+    )
+    assert response.status_code == 201, response.text
+
+
+def test_cluster_policy_rejects_unknown_wallet_owner(
+    client: TestClient, user1_token: str
+) -> None:
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    payload = _cluster_endpoint_payload(_cluster_policy(999999))
+    response = client.post("/api/v1/endpoints", json=payload, headers=headers)
+    assert response.status_code == 422
+    assert "wallet_owner" in response.json()["detail"]
+
+
+def test_cluster_policy_rejects_missing_wallet_id(
+    client: TestClient, user1_token: str, station_owner: dict
+) -> None:
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    policy = _cluster_policy(station_owner["id"])
+    del policy["config"]["wallet_id"]
+    response = client.post(
+        "/api/v1/endpoints", json=_cluster_endpoint_payload(policy), headers=headers
+    )
+    assert response.status_code == 422
+    assert "wallet_id" in response.json()["detail"]
+
+
+def test_cluster_policy_rejects_url_outside_owner_domain(
+    client: TestClient, user1_token: str, station_owner: dict
+) -> None:
+    """A credits_url on a foreign host would exfiltrate satellite tokens."""
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    policy = _cluster_policy(
+        station_owner["id"], credits_url="https://evil.example.com/balance"
+    )
+    response = client.post(
+        "/api/v1/endpoints", json=_cluster_endpoint_payload(policy), headers=headers
+    )
+    assert response.status_code == 422
+    assert "credits_url" in response.json()["detail"]
+
+
+def test_cluster_policy_rejects_owner_without_domain(
+    client: TestClient, user1_token: str, user2_token: str
+) -> None:
+    """user2 exists but has no registered domain → URLs cannot be verified."""
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    me = client.get(
+        "/api/v1/users/me", headers={"Authorization": f"Bearer {user2_token}"}
+    )
+    user2_id = me.json()["id"]
+    payload = _cluster_endpoint_payload(_cluster_policy(user2_id))
+    response = client.post("/api/v1/endpoints", json=payload, headers=headers)
+    assert response.status_code == 422
+    assert "domain" in response.json()["detail"]
+
+
+def test_cluster_policy_update_enriches_owner_username(
+    client: TestClient, user1_token: str, station_owner: dict
+) -> None:
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    create = client.post(
+        "/api/v1/endpoints",
+        json={"name": "Plain Endpoint", "type": "model", "visibility": "public"},
+        headers=headers,
+    )
+    assert create.status_code == 201
+    endpoint_id = create.json()["id"]
+
+    response = client.patch(
+        f"/api/v1/endpoints/{endpoint_id}",
+        json={"policies": [_cluster_policy(station_owner["id"])]},
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["policies"][0]["config"]["wallet_owner_username"] == "station"
+    assert "prepaid" in data["tags"]
+
+
+def test_cluster_policy_sync_enriches_owner_username(
+    client: TestClient, user1_token: str, station_owner: dict
+) -> None:
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    sync_data = {
+        "endpoints": [
+            {
+                "name": "Legal RAG",
+                "slug": "legal-rag",
+                "type": "model",
+                "visibility": "public",
+                "policies": [_cluster_policy(station_owner["id"])],
+            }
+        ]
+    }
+    response = client.post("/api/v1/endpoints/sync", json=sync_data, headers=headers)
+    assert response.status_code == 200, response.text
+
+    data = response.json()
+    assert data["synced"] == 1
+    config = data["endpoints"][0]["policies"][0]["config"]
+    assert config["wallet_owner_username"] == "station"
+
+
+def test_cluster_policy_sync_rejects_invalid_wallet_owner(
+    client: TestClient, user1_token: str
+) -> None:
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    sync_data = {
+        "endpoints": [
+            {
+                "name": "Legal RAG",
+                "slug": "legal-rag",
+                "type": "model",
+                "visibility": "public",
+                "policies": [_cluster_policy(999999)],
+            }
+        ]
+    }
+    response = client.post("/api/v1/endpoints/sync", json=sync_data, headers=headers)
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["code"] == "VALIDATION_ERROR"
+    assert detail["errors"][0]["field"] == "policies"

--- a/components/backend/tests/test_endpoints.py
+++ b/components/backend/tests/test_endpoints.py
@@ -2710,6 +2710,89 @@ def test_cluster_policy_rejects_owner_without_domain(
     assert "domain" in response.json()["detail"]
 
 
+def test_non_cluster_prepaid_policy_strips_wallet_audience_fields(
+    client: TestClient, user1_token: str
+) -> None:
+    """Self-hosted prepaid URLs are not domain-verified, so wallet identity/
+    audience fields on them would let a publisher route satellite tokens
+    minted for an arbitrary account to a host they control."""
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    policy = {
+        **_XENDIT_POLICY_MINIMAL,
+        "config": {
+            **_XENDIT_POLICY_MINIMAL["config"],
+            "wallet_id": "spoofed-wallet",
+            "walletId": "spoofed-wallet",
+            "wallet_owner": 42,
+            "walletOwner": 42,
+            "wallet_owner_username": "victim-station",
+            "walletOwnerUsername": "victim-station",
+        },
+    }
+    endpoint_data = {
+        "name": "Spoofing Xendit Endpoint",
+        "type": "model",
+        "visibility": "public",
+        "policies": [policy],
+    }
+    response = client.post("/api/v1/endpoints", json=endpoint_data, headers=headers)
+    assert response.status_code == 201, response.text
+    config = response.json()["policies"][0]["config"]
+    for key in (
+        "wallet_id",
+        "walletId",
+        "wallet_owner",
+        "walletOwner",
+        "wallet_owner_username",
+        "walletOwnerUsername",
+    ):
+        assert key not in config
+    # The legitimate self-hosted fields survive.
+    assert config["payment_url"] == _XENDIT_POLICY_MINIMAL["config"]["payment_url"]
+
+
+def test_cluster_policy_camelcase_config_is_canonicalized(
+    client: TestClient, user1_token: str, station_owner: dict
+) -> None:
+    """camelCase spellings are accepted on input but stored as snake_case."""
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    base = f"{_STATION_DOMAIN}/api/v1/credits/{_STATION_WALLET_ID}"
+    policy = {
+        "type": "cluster",
+        "version": "1.0",
+        "enabled": True,
+        "config": {
+            "price": 2.5,
+            "unit_type": "request",
+            "walletId": _STATION_WALLET_ID,
+            "walletOwner": station_owner["id"],
+            "paymentUrl": f"{base}/invoices",
+            "invoicesUrl": f"{base}/invoices/me",
+            "creditsUrl": f"{base}/balance",
+        },
+    }
+    response = client.post(
+        "/api/v1/endpoints", json=_cluster_endpoint_payload(policy), headers=headers
+    )
+    assert response.status_code == 201, response.text
+    config = response.json()["policies"][0]["config"]
+    assert config["wallet_id"] == _STATION_WALLET_ID
+    assert config["wallet_owner"] == station_owner["id"]
+    assert config["wallet_owner_username"] == "station"
+    assert config["payment_url"] == f"{base}/invoices"
+    assert config["credits_url"] == f"{base}/balance"
+    assert config["invoices_url"] == f"{base}/invoices/me"
+    for camel_key in (
+        "walletId",
+        "walletOwner",
+        "walletOwnerUsername",
+        "paymentUrl",
+        "creditsUrl",
+        "invoicesUrl",
+    ):
+        assert camel_key not in config
+
+
 def test_cluster_policy_rejects_tunneling_domain_owner(
     client: TestClient, user1_token: str, user2_token: str
 ) -> None:

--- a/components/backend/tests/test_endpoints.py
+++ b/components/backend/tests/test_endpoints.py
@@ -1454,6 +1454,44 @@ def test_xendit_policy_auto_injects_prepaid_tag_on_update(
     assert "prepaid" in response.json()["tags"]
 
 
+def test_prepaid_policy_nested_in_wrapper_injects_prepaid_tag(
+    client: TestClient, user1_token: str
+) -> None:
+    """A prepaid policy inside a composite wrapper is active billing, so it
+    must tag the endpoint just like a top-level one."""
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    endpoint_data = {
+        "name": "Wrapped Xendit Endpoint",
+        "type": "model",
+        "visibility": "public",
+        "policies": [
+            {
+                "type": "all_of",
+                "config": {"policies": [_XENDIT_POLICY_MINIMAL]},
+            }
+        ],
+    }
+    response = client.post("/api/v1/endpoints", json=endpoint_data, headers=headers)
+    assert response.status_code == 201, response.text
+    assert "prepaid" in response.json()["tags"]
+
+
+def test_disabled_prepaid_policy_does_not_inject_prepaid_tag(
+    client: TestClient, user1_token: str
+) -> None:
+    """A disabled prepaid policy is not active billing — no tag."""
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    endpoint_data = {
+        "name": "Disabled Xendit Endpoint",
+        "type": "model",
+        "visibility": "public",
+        "policies": [{**_XENDIT_POLICY_MINIMAL, "enabled": False}],
+    }
+    response = client.post("/api/v1/endpoints", json=endpoint_data, headers=headers)
+    assert response.status_code == 201, response.text
+    assert "prepaid" not in response.json()["tags"]
+
+
 def test_xendit_auto_tag_skips_when_tag_limit_reached(
     client: TestClient, user1_token: str
 ) -> None:
@@ -2620,6 +2658,43 @@ def test_cluster_policy_rejects_url_outside_owner_domain(
     assert "credits_url" in response.json()["detail"]
 
 
+def test_cluster_policy_with_children_cannot_dodge_validation(
+    client: TestClient, user1_token: str, station_owner: dict
+) -> None:
+    """A nested ``policies`` list must not turn a cluster policy into a
+    skipped "wrapper" — that would store an unverified credits_url and an
+    attacker-chosen audience."""
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    policy = _cluster_policy(
+        station_owner["id"],
+        credits_url="https://evil.example.com/balance",
+        policies=[{"type": "free", "version": "1.0", "enabled": True, "config": {}}],
+    )
+    response = client.post(
+        "/api/v1/endpoints", json=_cluster_endpoint_payload(policy), headers=headers
+    )
+    assert response.status_code == 422
+    assert "credits_url" in response.json()["detail"]
+
+
+def test_cluster_policy_with_children_is_still_enriched(
+    client: TestClient, user1_token: str, station_owner: dict
+) -> None:
+    """A valid cluster policy that also nests children keeps its own
+    validation + audience enrichment."""
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    policy = _cluster_policy(
+        station_owner["id"],
+        policies=[{"type": "free", "version": "1.0", "enabled": True, "config": {}}],
+    )
+    response = client.post(
+        "/api/v1/endpoints", json=_cluster_endpoint_payload(policy), headers=headers
+    )
+    assert response.status_code == 201, response.text
+    config = response.json()["policies"][0]["config"]
+    assert config["wallet_owner_username"] == "station"
+
+
 def test_cluster_policy_rejects_owner_without_domain(
     client: TestClient, user1_token: str, user2_token: str
 ) -> None:
@@ -2633,6 +2708,34 @@ def test_cluster_policy_rejects_owner_without_domain(
     response = client.post("/api/v1/endpoints", json=payload, headers=headers)
     assert response.status_code == 422
     assert "domain" in response.json()["detail"]
+
+
+def test_cluster_policy_rejects_tunneling_domain_owner(
+    client: TestClient, user1_token: str, user2_token: str
+) -> None:
+    """Tunneling spaces have no public hostname, so wallet URL verification
+    cannot work — the policy must be rejected with a clear message."""
+    headers = {"Authorization": f"Bearer {user1_token}"}
+    me = client.get(
+        "/api/v1/users/me", headers={"Authorization": f"Bearer {user2_token}"}
+    )
+    user2_id = me.json()["id"]
+
+    from syfthub.database.connection import get_db_session
+    from syfthub.repositories.user import UserRepository
+
+    session = next(get_db_session())
+    try:
+        # update_domain does not commit; the caller owns the transaction.
+        UserRepository(session).update_domain(user2_id, "tunneling:user2")
+        session.commit()
+    finally:
+        session.close()
+
+    payload = _cluster_endpoint_payload(_cluster_policy(user2_id))
+    response = client.post("/api/v1/endpoints", json=payload, headers=headers)
+    assert response.status_code == 422
+    assert "tunneling" in response.json()["detail"]
 
 
 def test_cluster_policy_update_enriches_owner_username(

--- a/components/frontend/Dockerfile.dev
+++ b/components/frontend/Dockerfile.dev
@@ -9,6 +9,9 @@ FROM node:20-alpine
 WORKDIR /app/sdk/typescript
 COPY sdk/typescript ./
 
+# Build SDK so dist/ exists for the file: dependency
+RUN npm ci --ignore-scripts && npm run build
+
 # Set working directory for frontend (mirrors repo: components/frontend)
 WORKDIR /app/components/frontend
 

--- a/components/frontend/package-lock.json
+++ b/components/frontend/package-lock.json
@@ -76,7 +76,7 @@
     },
     "../../sdk/typescript": {
       "name": "@syfthub/sdk",
-      "version": "0.1.1",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.39.2",
@@ -88,7 +88,7 @@
         "tsup": "^8.3.5",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.56.1",
-        "vite": "^6.2.0",
+        "vite": "^8.0.16",
         "vitest": "^4.1.0"
       },
       "engines": {

--- a/components/frontend/src/components/chat/payment-gate.tsx
+++ b/components/frontend/src/components/chat/payment-gate.tsx
@@ -63,7 +63,7 @@ export function PaymentGate({
       void registerOnFunding({
         creditsUrl: p.creditsUrl,
         paymentUrl: p.paymentUrl,
-        endpointOwner: p.endpoints[0]?.owner ?? '',
+        audience: p.audience,
         endpointSlug: p.endpoints[0]?.slug ?? null,
         currency: p.currency,
         lastKnownBalance: balance

--- a/components/frontend/src/components/chat/prepaid-account-row.tsx
+++ b/components/frontend/src/components/chat/prepaid-account-row.tsx
@@ -106,7 +106,9 @@ export function PrepaidAccountRow({
   const handleBuy = async () => {
     if (!selectedBundle || !primaryEndpoint) return;
     setPurchase({ state: 'creating' });
-    const token = await getSatelliteToken(primaryEndpoint.owner);
+    // Mint for the wallet's audience — the wallet-hosting account for
+    // cluster wallets, the endpoint owner otherwise.
+    const token = await getSatelliteToken(pending.audience);
     if (!token) {
       setPurchase({
         state: 'error',

--- a/components/frontend/src/components/collectives/collective-accounts-modal.tsx
+++ b/components/frontend/src/components/collectives/collective-accounts-modal.tsx
@@ -88,7 +88,7 @@ export function CollectiveAccountsModal({
       void registerOnFunding({
         creditsUrl: p.creditsUrl,
         paymentUrl: p.paymentUrl,
-        endpointOwner: p.endpoints[0]?.owner ?? '',
+        audience: p.audience,
         endpointSlug: p.endpoints[0]?.slug ?? null,
         currency: p.currency,
         lastKnownBalance: balance

--- a/components/frontend/src/components/endpoint/policy-item.tsx
+++ b/components/frontend/src/components/endpoint/policy-item.tsx
@@ -26,12 +26,14 @@ import { MppPolicyContent } from './mpp-policy-content';
 import { formatConfigKey } from './policy-format';
 import { XenditPolicyContent } from './xendit-policy-content';
 
-// Policy types that drive the prepaid-credits card. Both providers share the
+// Policy types that drive the prepaid-credits card. All providers share the
 // same config shape (bundles + currency + payment_url + credits_url +
-// invoices_url + price + unit_type), so the card and BundlePicker are reused.
-// Adding a future prepaid provider is one entry here plus a theme entry in
-// POLICY_TYPE_CONFIG.
-const PREPAID_BALANCE_TYPES = new Set<PrepaidProvider>(['xendit', 'stripe']);
+// invoices_url + price + unit_type), so the card and BundlePicker are reused;
+// `cluster` (a station-hosted wallet shared across spaces) additionally
+// carries wallet_id + wallet_owner_username. Adding a future prepaid provider
+// is one entry here plus a theme entry in POLICY_TYPE_CONFIG. Keep in
+// lockstep with the backend `PREPAID_POLICY_TYPES` in `schemas/endpoint.py`.
+const PREPAID_BALANCE_TYPES = new Set<PrepaidProvider>(['xendit', 'stripe', 'cluster']);
 function isPrepaidBalanceType(type: string): type is PrepaidProvider {
   return (PREPAID_BALANCE_TYPES as Set<string>).has(type);
 }
@@ -53,9 +55,12 @@ const MPP_PROVIDER_LABEL = 'Tempo';
 
 // Display name shown under a balance card's title, keyed by policy type (e.g.
 // "via Xendit", "via Tempo"). Returns null for non-balance policy types.
+// UX terminology: a cluster wallet surfaces as "Managed Wallet" — never
+// expose the internal "station"/"cluster" wording in the UI.
 const BALANCE_PROVIDER_LABELS: Record<string, string> = {
   xendit: 'Xendit',
   stripe: 'Stripe',
+  cluster: 'Managed Wallet',
   mpp: MPP_PROVIDER_LABEL
 };
 function getBalanceProviderLabel(policyType: string): string | null {
@@ -101,6 +106,16 @@ const POLICY_TYPE_CONFIG: Record<
     bgColor: 'bg-indigo-50 dark:bg-indigo-950/30',
     borderColor: 'border-indigo-200 dark:border-indigo-800',
     description: 'Top up credits to use this endpoint.'
+  },
+  // Station-hosted shared wallet: one balance backs every endpoint published
+  // against the same wallet_id, so topping up here funds all of them.
+  cluster: {
+    icon: CreditCard,
+    label: 'Prepaid credits',
+    color: 'text-teal-600 dark:text-teal-400',
+    bgColor: 'bg-teal-50 dark:bg-teal-950/30',
+    borderColor: 'border-teal-200 dark:border-teal-800',
+    description: 'Top up a shared wallet used across every endpoint it backs.'
   },
   // Access control policies
   public: {

--- a/components/frontend/src/components/endpoint/xendit-policy-content.tsx
+++ b/components/frontend/src/components/endpoint/xendit-policy-content.tsx
@@ -190,13 +190,15 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
       setPurchase((previous) => (previous.state === 'idle' ? previous : { state: 'idle' }));
 
       // Active wallet detected — record it on the user's account so the
-      // unified credits panel can list it. Idempotent server-side.
-      if (!hasRegisteredReference.current && paymentUrl && endpointOwner && creditsUrl) {
+      // unified credits panel can list it. Idempotent server-side. Registered
+      // under the wallet's audience so the panel re-mints for the right
+      // account (managed wallets settle with the wallet owner).
+      if (!hasRegisteredReference.current && paymentUrl && audience && creditsUrl) {
         hasRegisteredReference.current = true;
         void registerOnFunding({
           creditsUrl,
           paymentUrl,
-          endpointOwner,
+          audience,
           endpointSlug: endpointSlug ?? null,
           currency,
           lastKnownBalance: balance

--- a/components/frontend/src/components/endpoint/xendit-policy-content.tsx
+++ b/components/frontend/src/components/endpoint/xendit-policy-content.tsx
@@ -17,7 +17,8 @@ import {
   getSatelliteToken,
   openCheckoutWindow,
   parseXenditConfig,
-  POLL_INTERVAL_MS
+  POLL_INTERVAL_MS,
+  resolveWalletAudience
 } from '@/lib/xendit-client';
 import { useModalStore } from '@/stores/modal-store';
 
@@ -124,8 +125,11 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
   const parsed = useMemo(() => parseXenditConfig(config), [config]);
   const { bundles, currency, paymentUrl, creditsUrl, invoicesUrl, pricePerUnit, unit } = parsed;
   // Satellite tokens go to the wallet's audience: the wallet-hosting account
-  // for station-hosted cluster wallets, the endpoint owner otherwise.
-  const audience = parsed.walletOwnerUsername ?? endpointOwner;
+  // for station-hosted cluster wallets, the endpoint owner otherwise. The
+  // provider IS the policy type, which gates who may name a foreign audience.
+  const audience = endpointOwner
+    ? resolveWalletAudience(parsed, provider, endpointOwner)
+    : undefined;
 
   const [subscription, setSubscription] = useState<SubscriptionState>({ state: 'loading' });
   const [purchase, setPurchase] = useState<PurchaseState>({ state: 'idle' });
@@ -265,7 +269,7 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
     if (!audience) {
       setPurchase({
         state: 'error',
-        message: 'Wallet owner unknown — cannot mint satellite token.'
+        message: 'Cannot determine the account to authorize payment with.'
       });
       return;
     }

--- a/components/frontend/src/components/endpoint/xendit-policy-content.tsx
+++ b/components/frontend/src/components/endpoint/xendit-policy-content.tsx
@@ -201,7 +201,7 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
       // unified credits panel can list it. Idempotent server-side. Registered
       // under the wallet's audience so the panel re-mints for the right
       // account (managed wallets settle with the wallet owner).
-      if (!hasRegisteredReference.current && paymentUrl && audience && creditsUrl) {
+      if (!hasRegisteredReference.current && paymentUrl) {
         hasRegisteredReference.current = true;
         void registerOnFunding({
           creditsUrl,

--- a/components/frontend/src/components/endpoint/xendit-policy-content.tsx
+++ b/components/frontend/src/components/endpoint/xendit-policy-content.tsx
@@ -3,11 +3,12 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ArrowRight from 'lucide-react/dist/esm/icons/arrow-right';
 import CheckCircle2 from 'lucide-react/dist/esm/icons/check-circle-2';
 import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
+import LogIn from 'lucide-react/dist/esm/icons/log-in';
 import RefreshCw from 'lucide-react/dist/esm/icons/refresh-cw';
 
 import { BundlePicker } from '@/components/endpoint/bundle-picker';
+import { useAuth } from '@/context/auth-context';
 import { useRegisterOnFundingDetected } from '@/hooks/use-xendit-subscriptions';
-import { syftClient } from '@/lib/sdk-client';
 import { cn } from '@/lib/utils';
 import {
   createInvoice,
@@ -18,6 +19,7 @@ import {
   parseXenditConfig,
   POLL_INTERVAL_MS
 } from '@/lib/xendit-client';
+import { useModalStore } from '@/stores/modal-store';
 
 type SubscriptionState =
   | { state: 'loading' }
@@ -110,6 +112,13 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
   provider = 'xendit'
 }: Readonly<XenditPolicyContentProperties>) {
   const theme = PROVIDER_THEME[provider];
+  // Auth state drives both the balance check (satellite tokens need a signed-in
+  // user) and the CTA: logged-out viewers get "Sign in to buy credits" instead
+  // of a Buy button that would fail. Reactive, so signing in via the modal
+  // re-runs the balance check without a page reload.
+  const { user } = useAuth();
+  const isAuthenticated = user !== null;
+  const openLogin = useModalStore((state) => state.openLogin);
   // Re-parse only when config identity changes — otherwise the bundles array
   // would get a fresh reference each render and re-fire the validation effect.
   const parsed = useMemo(() => parseXenditConfig(config), [config]);
@@ -144,8 +153,7 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
   // back on "awaiting payment" after closing the checkout popup.
   const checkBalance = useCallback(
     async (options: { silent?: boolean; signal?: AbortSignal; checkPending?: boolean } = {}) => {
-      const tokens = syftClient.getTokens();
-      if (!tokens || !creditsUrl || !audience) {
+      if (!isAuthenticated || !creditsUrl || !audience) {
         setSubscription((previous) =>
           previous.state === 'inactive' ? previous : { state: 'inactive' }
         );
@@ -206,6 +214,7 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
       }
     },
     [
+      isAuthenticated,
       creditsUrl,
       invoicesUrl,
       audience,
@@ -247,9 +256,10 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
 
   const handleSubscribe = async (bundleName: string) => {
     if (!paymentUrl || !enabled) return;
-    const tokens = syftClient.getTokens();
-    if (!tokens) {
-      setPurchase({ state: 'error', message: 'Sign in to subscribe.' });
+    // Fallback only — the CTA swaps to "Sign in to buy credits" when logged
+    // out, so this is unreachable through normal UI flow.
+    if (!isAuthenticated) {
+      openLogin();
       return;
     }
     if (!audience) {
@@ -322,29 +332,45 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
             unit={unit}
             triggerClassName={theme.pickerFocusClass}
           />
-          <button
-            type='button'
-            disabled={!canPurchase || isCreatingAny}
-            onClick={() => void handleSubscribe(selectedBundleName)}
-            className={cn(
-              'group inline-flex h-10 w-full items-center justify-center gap-1.5 rounded-md text-sm font-medium transition-colors',
-              theme.buttonClass,
-              'focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
-              theme.focusRingClass
-            )}
-          >
-            {isCreatingAny ? (
-              <>
-                <Loader2 className='h-3.5 w-3.5 animate-spin' />
-                Opening checkout…
-              </>
-            ) : (
-              <>
-                Buy credits
-                <ArrowRight className='h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5' />
-              </>
-            )}
-          </button>
+          {isAuthenticated ? (
+            <button
+              type='button'
+              disabled={!canPurchase || isCreatingAny}
+              onClick={() => void handleSubscribe(selectedBundleName)}
+              className={cn(
+                'group inline-flex h-10 w-full items-center justify-center gap-1.5 rounded-md text-sm font-medium transition-colors',
+                theme.buttonClass,
+                'focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+                theme.focusRingClass
+              )}
+            >
+              {isCreatingAny ? (
+                <>
+                  <Loader2 className='h-3.5 w-3.5 animate-spin' />
+                  Opening checkout…
+                </>
+              ) : (
+                <>
+                  Buy credits
+                  <ArrowRight className='h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5' />
+                </>
+              )}
+            </button>
+          ) : (
+            <button
+              type='button'
+              onClick={openLogin}
+              className={cn(
+                'group inline-flex h-10 w-full items-center justify-center gap-1.5 rounded-md text-sm font-medium transition-colors',
+                theme.buttonClass,
+                'focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+                theme.focusRingClass
+              )}
+            >
+              <LogIn className='h-3.5 w-3.5' />
+              Sign in to buy credits
+            </button>
+          )}
         </div>
       )}
 

--- a/components/frontend/src/components/endpoint/xendit-policy-content.tsx
+++ b/components/frontend/src/components/endpoint/xendit-policy-content.tsx
@@ -31,12 +31,15 @@ type PurchaseState =
   | { state: 'error'; message: string };
 
 /**
- * Prepaid-balance providers. Both publish policy.config in the same shape
+ * Prepaid-balance providers. All publish policy.config in the same shape
  * (bundles + currency + payment_url + credits_url + invoices_url + price +
  * unit_type), so the buy-credits card body is identical; only the button
- * theme and the "Sign in to subscribe" copy change per provider.
+ * theme and the provider label change. `cluster` additionally carries
+ * `wallet_id` + `wallet_owner_username` (a station-hosted wallet shared
+ * across spaces — satellite tokens are minted for the wallet owner, not the
+ * endpoint owner).
  */
-export type PrepaidProvider = 'xendit' | 'stripe';
+export type PrepaidProvider = 'xendit' | 'stripe' | 'cluster';
 
 interface ProviderTheme {
   label: string;
@@ -73,6 +76,19 @@ const PROVIDER_THEME: Record<PrepaidProvider, ProviderTheme> = {
     ),
     focusRingClass: 'focus-visible:ring-indigo-400/50 dark:focus-visible:ring-indigo-500/40',
     pickerFocusClass: 'focus:ring-indigo-400/40 dark:focus:ring-indigo-500/30'
+  },
+  cluster: {
+    // UX term for a station/cluster wallet — never surface "station" in the UI.
+    label: 'Managed Wallet',
+    buttonClass: cn(
+      'bg-teal-600 text-white shadow-sm',
+      'hover:bg-teal-500 active:bg-teal-700',
+      'disabled:cursor-not-allowed disabled:bg-teal-600/40 disabled:shadow-none',
+      'dark:bg-teal-500 dark:hover:bg-teal-400 dark:active:bg-teal-600',
+      'dark:disabled:bg-teal-500/30'
+    ),
+    focusRingClass: 'focus-visible:ring-teal-400/50 dark:focus-visible:ring-teal-500/40',
+    pickerFocusClass: 'focus:ring-teal-400/40 dark:focus:ring-teal-500/30'
   }
 };
 
@@ -98,6 +114,9 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
   // would get a fresh reference each render and re-fire the validation effect.
   const parsed = useMemo(() => parseXenditConfig(config), [config]);
   const { bundles, currency, paymentUrl, creditsUrl, invoicesUrl, pricePerUnit, unit } = parsed;
+  // Satellite tokens go to the wallet's audience: the wallet-hosting account
+  // for station-hosted cluster wallets, the endpoint owner otherwise.
+  const audience = parsed.walletOwnerUsername ?? endpointOwner;
 
   const [subscription, setSubscription] = useState<SubscriptionState>({ state: 'loading' });
   const [purchase, setPurchase] = useState<PurchaseState>({ state: 'idle' });
@@ -126,14 +145,14 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
   const checkBalance = useCallback(
     async (options: { silent?: boolean; signal?: AbortSignal; checkPending?: boolean } = {}) => {
       const tokens = syftClient.getTokens();
-      if (!tokens || !creditsUrl || !endpointOwner) {
+      if (!tokens || !creditsUrl || !audience) {
         setSubscription((previous) =>
           previous.state === 'inactive' ? previous : { state: 'inactive' }
         );
         return;
       }
       if (!options.silent) setSubscription({ state: 'loading' });
-      const satelliteToken = await getSatelliteToken(endpointOwner);
+      const satelliteToken = await getSatelliteToken(audience);
       if (options.signal?.aborted) return;
       if (!satelliteToken) {
         setSubscription((previous) =>
@@ -184,7 +203,16 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
         });
       }
     },
-    [creditsUrl, invoicesUrl, endpointOwner, paymentUrl, endpointSlug, currency, registerOnFunding]
+    [
+      creditsUrl,
+      invoicesUrl,
+      audience,
+      endpointOwner,
+      paymentUrl,
+      endpointSlug,
+      currency,
+      registerOnFunding
+    ]
   );
 
   const refreshBalance = useCallback(() => checkBalance(), [checkBalance]);
@@ -222,15 +250,15 @@ export const XenditPolicyContent = memo(function XenditPolicyContent({
       setPurchase({ state: 'error', message: 'Sign in to subscribe.' });
       return;
     }
-    if (!endpointOwner) {
+    if (!audience) {
       setPurchase({
         state: 'error',
-        message: 'Endpoint owner unknown — cannot mint satellite token.'
+        message: 'Wallet owner unknown — cannot mint satellite token.'
       });
       return;
     }
     setPurchase({ state: 'creating', bundleName });
-    const satelliteToken = await getSatelliteToken(endpointOwner);
+    const satelliteToken = await getSatelliteToken(audience);
     if (!satelliteToken) {
       setPurchase({ state: 'error', message: 'Failed to get satellite token from SyftHub.' });
       return;

--- a/components/frontend/src/components/settings/profile-settings-tab.tsx
+++ b/components/frontend/src/components/settings/profile-settings-tab.tsx
@@ -39,6 +39,16 @@ interface ProfileFormData {
 
 const BIO_MAX_LENGTH = 2000;
 
+// The backend requires a protocol on `domain`; default to https:// when the
+// user typed a bare host, but keep an explicit http:// (local dev).
+function normalizeDomainInput(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed && !/^(https?:\/\/|tunneling:)/.test(trimmed)) {
+    return `https://${trimmed}`;
+  }
+  return trimmed;
+}
+
 export function ProfileSettingsTab() {
   const { user, updateUser } = useAuth();
   const { closeSettings } = useSettingsModalStore();
@@ -235,10 +245,7 @@ export function ProfileSettingsTab() {
       updates.avatar_url = formData.avatar_url.trim();
     }
     if (formData.domain !== (user?.domain ?? '')) {
-      // Strip protocol if user accidentally included it
-      let domainValue = formData.domain.trim();
-      domainValue = domainValue.replace(/^https?:\/\//, '');
-      updates.domain = domainValue;
+      updates.domain = normalizeDomainInput(formData.domain);
     }
     if (formData.bio !== (user?.bio ?? '')) {
       updates.bio = formData.bio;
@@ -459,8 +466,8 @@ export function ProfileSettingsTab() {
               disabled={isLoading}
             />
             <p className='text-muted-foreground text-xs'>
-              Enter the base domain for your endpoints without the protocol (https:// will be added
-              automatically).
+              Enter the base domain for your endpoints. https:// is assumed unless you include a
+              protocol (e.g. http:// for local development).
             </p>
           </div>
         </div>

--- a/components/frontend/src/components/settings/profile-settings-tab.tsx
+++ b/components/frontend/src/components/settings/profile-settings-tab.tsx
@@ -40,13 +40,15 @@ interface ProfileFormData {
 const BIO_MAX_LENGTH = 2000;
 
 // The backend requires a protocol on `domain`; default to https:// when the
-// user typed a bare host, but keep an explicit http:// (local dev).
+// user typed a bare host, but keep an explicit http:// (local dev) or
+// tunneling: prefix. Pasted schemes are lowercased — the backend matches
+// them case-sensitively.
 function normalizeDomainInput(value: string): string {
   const trimmed = value.trim();
-  if (trimmed && !/^(https?:\/\/|tunneling:)/.test(trimmed)) {
-    return `https://${trimmed}`;
-  }
-  return trimmed;
+  if (!trimmed) return trimmed;
+  const scheme = /^(https?:\/\/|tunneling:)/i.exec(trimmed)?.[0];
+  if (!scheme) return `https://${trimmed}`;
+  return scheme.toLowerCase() + trimmed.slice(scheme.length);
 }
 
 export function ProfileSettingsTab() {

--- a/components/frontend/src/hooks/use-collective-query-readiness.ts
+++ b/components/frontend/src/hooks/use-collective-query-readiness.ts
@@ -74,12 +74,19 @@ export function useCollectiveQueryReadiness(
   const { isConfigured } = useWalletContext();
   const { balance: walletBalance } = useWalletBalance();
 
-  const creditsUrls = useMemo(
-    () => wallets.map((w) => w.creditsUrl).toSorted((a, b) => a.localeCompare(b)),
+  // The cache identity must cover everything the fetch depends on: walletKey
+  // (the balance-map key), owner (the token audience) and creditsUrl (the
+  // fetch target) — a republish can change walletKey/audience while the URL
+  // stays the same, and a key of URLs alone would then serve a stale map.
+  const walletIdentities = useMemo(
+    () =>
+      wallets
+        .map((w) => `${w.walletKey}|${w.owner}|${w.creditsUrl}`)
+        .toSorted((a, b) => a.localeCompare(b)),
     [wallets]
   );
   const balancesQuery = useQuery({
-    queryKey: billingSummaryKeys.readiness(creditsUrls),
+    queryKey: billingSummaryKeys.readiness(walletIdentities),
     enabled: enabled && wallets.length > 0,
     staleTime: 15_000,
     queryFn: async ({ signal }) => {

--- a/components/frontend/src/hooks/use-collective-query-readiness.ts
+++ b/components/frontend/src/hooks/use-collective-query-readiness.ts
@@ -44,9 +44,11 @@ export function useCollectiveQueryReadiness(
       const b = member.billing;
       if (b.kind !== 'prepaid' || !b.credits_url || !member.endpoint_owner_username) continue;
       descriptors.push({
-        walletKey: b.credits_url,
+        // wallet_id (cluster) beats credits_url as the grouping key; the
+        // token audience is the wallet-hosting account when published.
+        walletKey: b.wallet_id ?? b.credits_url,
         creditsUrl: b.credits_url,
-        owner: member.endpoint_owner_username,
+        owner: b.wallet_owner_username ?? member.endpoint_owner_username,
         threshold: b.price_per_unit ?? 1
       });
     }
@@ -89,11 +91,11 @@ export function useCollectiveQueryReadiness(
           if (token) tokenByOwner.set(owner, token);
         })
       );
-      // walletKey === creditsUrl here, so the tuples key the balance map by URL.
+      // Tuples key the balance map by walletKey (wallet_id or credits_url).
       // Keep the raw null (unreachable wallet) — it must BLOCK ready below.
       const updates = await fetchWalletBalances(wallets, tokenByOwner, signal);
       const out: Record<string, number | null> = {};
-      for (const [creditsUrl, balance] of updates) out[creditsUrl] = balance;
+      for (const [walletKey, balance] of updates) out[walletKey] = balance;
       return out;
     }
   });
@@ -105,7 +107,7 @@ export function useCollectiveQueryReadiness(
 
   const balances = balancesQuery.data ?? {};
   const prepaidReady = wallets.every((w) => {
-    const balance = balances[w.creditsUrl];
+    const balance = balances[w.walletKey];
     return typeof balance === 'number' && balance >= w.threshold;
   });
   // The Hub wallet settles only its own currency; an MPP member priced in any

--- a/components/frontend/src/hooks/use-prepaid-wallet-balances.ts
+++ b/components/frontend/src/hooks/use-prepaid-wallet-balances.ts
@@ -26,10 +26,13 @@ import { fetchBalance, getSatelliteToken, POLL_INTERVAL_MS } from '@/lib/xendit-
 // ── shared pure core (no React) ──────────────────────────────────────────────
 
 export interface PrepaidWalletDescriptor {
-  /** Stable identity = credits_url. Multiple endpoints/members collapse to one. */
+  /** Stable identity: wallet_id (cluster) or credits_url (self-hosted). */
   walletKey: string;
   creditsUrl: string;
-  /** Owner used to mint the satellite token. = endpoints[0].owner for the gate. */
+  /**
+   * Satellite-token audience for this wallet: the wallet-hosting account
+   * (cluster) or the endpoint owner (self-hosted).
+   */
   owner: string;
   /** Minimum balance considered "funded" — pricePerUnit ?? 1. */
   threshold: number;
@@ -38,15 +41,15 @@ export interface PrepaidWalletDescriptor {
 /**
  * Adapt a PendingSubscription (gate + modal) to the core descriptor.
  *
- * NOTE: this bakes in the gate's "owner = first endpoint of the wallet"
- * assumption and the "threshold defaults to 1" rule. A call site that owns a
- * wallet via a non-first endpoint must build the descriptor itself.
+ * NOTE: this bakes in the "threshold defaults to 1" rule. The token audience
+ * comes pre-resolved on the subscription (`audience`), so shared cluster
+ * wallets mint for the wallet-hosting account, not the first endpoint's owner.
  */
 export function descriptorFromPending(p: PendingSubscription): PrepaidWalletDescriptor {
   return {
     walletKey: p.walletKey,
     creditsUrl: p.creditsUrl,
-    owner: p.endpoints[0]?.owner ?? '',
+    owner: p.audience,
     threshold: p.pricePerUnit ?? 1
   };
 }
@@ -68,7 +71,7 @@ export function descriptorMapFromPending(
   return byKey;
 }
 
-/** Dedup descriptors by walletKey (credits_url), first-wins. */
+/** Dedup descriptors by walletKey, first-wins. */
 export function dedupeWalletsByKey(wallets: PrepaidWalletDescriptor[]): PrepaidWalletDescriptor[] {
   const byKey = new Map<string, PrepaidWalletDescriptor>();
   for (const wallet of wallets) {
@@ -77,7 +80,7 @@ export function dedupeWalletsByKey(wallets: PrepaidWalletDescriptor[]): PrepaidW
   return [...byKey.values()];
 }
 
-/** Distinct owners across descriptors, insertion order (token-fetch dedup). */
+/** Distinct token audiences across descriptors, insertion order (token-fetch dedup). */
 export function distinctWalletOwners(wallets: PrepaidWalletDescriptor[]): string[] {
   const owners = new Set<string>();
   for (const wallet of wallets) owners.add(wallet.owner);

--- a/components/frontend/src/hooks/use-xendit-precheck.ts
+++ b/components/frontend/src/hooks/use-xendit-precheck.ts
@@ -236,20 +236,25 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
         })
       );
 
-      // One balance fetch per distinct credits_url. Multiple endpoints can
-      // share a wallet — paying once funds them all — but the gate UI lists
-      // each endpoint separately, so we need to know each row's status
-      // without re-hitting the same credits_url.
-      const distinctCreditsUrls = [...new Set(candidates.map((c) => c.policy.creditsUrl))];
-      const balanceByCreditsUrl = new Map<string, number | null>();
+      // One balance fetch per distinct wallet (walletKey), each using that
+      // wallet's own audience. Multiple endpoints can share a wallet — paying
+      // once funds them all — but the gate UI lists each endpoint separately,
+      // so we need each row's status without re-hitting the same wallet.
+      // Deduping by walletKey (not creditsUrl) keeps the audience paired with
+      // its wallet: two wallets could share a URL yet mint different tokens.
+      const walletSamples = new Map<string, XenditCandidate>();
+      for (const c of candidates) {
+        if (!walletSamples.has(c.policy.walletKey)) {
+          walletSamples.set(c.policy.walletKey, c);
+        }
+      }
+      const balanceByWalletKey = new Map<string, number | null>();
       await Promise.all(
-        distinctCreditsUrls.map(async (creditsUrl) => {
-          const sample = candidates.find((c) => c.policy.creditsUrl === creditsUrl);
-          if (!sample) return;
-          const token = tokenByAudience.get(sample.policy.audience);
+        [...walletSamples.values()].map(async (c) => {
+          const token = tokenByAudience.get(c.policy.audience);
           if (!token) return;
-          const balance = await fetchBalance(creditsUrl, token, signal);
-          balanceByCreditsUrl.set(creditsUrl, balance);
+          const balance = await fetchBalance(c.policy.creditsUrl, token, signal);
+          balanceByWalletKey.set(c.policy.walletKey, balance);
         })
       );
 
@@ -260,7 +265,7 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
       // once.
       const out: PendingSubscription[] = [];
       for (const c of candidates) {
-        const balance = balanceByCreditsUrl.get(c.policy.creditsUrl);
+        const balance = balanceByWalletKey.get(c.policy.walletKey);
         if (balance === null || balance === undefined) continue;
         const threshold = c.policy.pricePerUnit ?? 1;
         if (balance >= threshold) continue;

--- a/components/frontend/src/hooks/use-xendit-precheck.ts
+++ b/components/frontend/src/hooks/use-xendit-precheck.ts
@@ -33,7 +33,8 @@ import {
   getSatelliteToken,
   isPrepaidPolicyType,
   parseXenditConfig,
-  resolveWalletAudience
+  resolveWalletAudience,
+  resolveWalletKey
 } from '@/lib/xendit-client';
 
 export type EndpointRole = 'model' | 'data_source';
@@ -104,8 +105,8 @@ function resolveXenditPolicy(policy: Policy, endpointOwner: string): ResolvedXen
     currency: parsed.currency,
     pricePerUnit: parsed.pricePerUnit,
     unit: parsed.unit,
-    walletKey: parsed.walletId ?? parsed.creditsUrl,
-    audience: resolveWalletAudience(parsed, endpointOwner)
+    walletKey: resolveWalletKey(parsed, policy.type, parsed.creditsUrl),
+    audience: resolveWalletAudience(parsed, policy.type, endpointOwner)
   };
 }
 

--- a/components/frontend/src/hooks/use-xendit-precheck.ts
+++ b/components/frontend/src/hooks/use-xendit-precheck.ts
@@ -2,11 +2,13 @@
  * useXenditPrecheck
  *
  * Pre-flight subscription check run before a chat message is sent.
- * Inspects the model + selected data sources for Xendit prepaid-credits
- * policies, dedupes by credits_url (one wallet may back multiple endpoints),
- * and fetches each balance via a satellite token. Returns the rows that
- * still need a paid subscription so the chat view can open the gate
- * modal — or an empty array when the user is clear to send.
+ * Inspects the model + selected data sources for prepaid-credits policies
+ * (xendit / stripe / cluster), dedupes by wallet (one wallet may back
+ * multiple endpoints), and fetches each balance via a satellite token
+ * minted for the wallet's audience — the wallet-hosting account for
+ * station-hosted cluster wallets, the endpoint owner otherwise. Returns
+ * the rows that still need a paid subscription so the chat view can open
+ * the gate modal — or an empty array when the user is clear to send.
  *
  * A selected **Collective API** is a single ChatSource with no policies of its
  * own (`full_path` = `collective/<slug>[/<shared-slug>]`); the SDK fans it out
@@ -26,7 +28,13 @@ import type { MoneyBundle, ParsedXenditConfig, PolicyUnit } from '@/lib/xendit-c
 import { collectivePrepaidMembers, parseCollectivePath } from '@/lib/collective-billing';
 import { getCollectiveBillingSummary } from '@/lib/collectives-api';
 import { syftClient } from '@/lib/sdk-client';
-import { fetchBalance, getSatelliteToken, parseXenditConfig } from '@/lib/xendit-client';
+import {
+  fetchBalance,
+  getSatelliteToken,
+  isPrepaidPolicyType,
+  parseXenditConfig,
+  resolveWalletAudience
+} from '@/lib/xendit-client';
 
 export type EndpointRole = 'model' | 'data_source';
 
@@ -42,10 +50,18 @@ export interface EndpointReference {
 }
 
 export interface PendingSubscription {
-  /** Stable identity = credits_url. Rows sharing a wallet share this key. */
+  /**
+   * Stable wallet identity: the published `wallet_id` (cluster) or
+   * `credits_url` (self-hosted). Rows sharing a wallet share this key.
+   */
   walletKey: string;
   /** All endpoints covered by this single wallet subscription. */
   endpoints: EndpointReference[];
+  /**
+   * Satellite-token audience for this wallet's gateway: the wallet-hosting
+   * account (cluster) or the endpoint owner (self-hosted).
+   */
+  audience: string;
   paymentUrl: string;
   creditsUrl: string;
   bundles: MoneyBundle[];
@@ -70,11 +86,15 @@ interface ResolvedXenditPolicy {
   currency: string;
   pricePerUnit: number | null;
   unit: PolicyUnit;
+  /** Grouping key: published wallet_id (cluster) or credits_url. */
+  walletKey: string;
+  /** Already-resolved satellite-token audience for this wallet. */
+  audience: string;
 }
 
-function resolveXenditPolicy(policy: Policy): ResolvedXenditPolicy | null {
+function resolveXenditPolicy(policy: Policy, endpointOwner: string): ResolvedXenditPolicy | null {
   if (!policy.enabled) return null;
-  if (policy.type.toLowerCase() !== 'xendit') return null;
+  if (!isPrepaidPolicyType(policy.type)) return null;
   const parsed: ParsedXenditConfig = parseXenditConfig(policy.config);
   if (!parsed.paymentUrl || !parsed.creditsUrl) return null;
   return {
@@ -83,7 +103,9 @@ function resolveXenditPolicy(policy: Policy): ResolvedXenditPolicy | null {
     bundles: parsed.bundles,
     currency: parsed.currency,
     pricePerUnit: parsed.pricePerUnit,
-    unit: parsed.unit
+    unit: parsed.unit,
+    walletKey: parsed.walletId ?? parsed.creditsUrl,
+    audience: resolveWalletAudience(parsed, endpointOwner)
   };
 }
 
@@ -112,7 +134,7 @@ function candidatesFromSource(source: ChatSource, role: EndpointRole): XenditCan
   if (!ref) return [];
   const out: XenditCandidate[] = [];
   for (const policy of source.policies) {
-    const xendit = resolveXenditPolicy(policy);
+    const xendit = resolveXenditPolicy(policy, ref.owner);
     if (xendit) out.push({ endpoint: ref, policy: xendit, removable: true });
   }
   return out;
@@ -135,7 +157,9 @@ function candidateFromCollectiveMember(member: CollectivePrepaidMember): XenditC
       bundles: member.bundles,
       currency: member.currency,
       pricePerUnit: member.pricePerUnit,
-      unit: member.unit
+      unit: member.unit,
+      walletKey: member.walletId ?? member.creditsUrl,
+      audience: member.audience
     },
     removable: false
   };
@@ -200,14 +224,15 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
       const candidates = [...collectCandidates(model, dataSources), ...collectiveLists.flat()];
       if (candidates.length === 0) return [];
 
-      // One satellite token per distinct owner — multiple wallets owned by
-      // the same publisher reuse the token.
-      const owners = [...new Set(candidates.map((c) => c.endpoint.owner))];
-      const tokenByOwner = new Map<string, string>();
+      // One satellite token per distinct audience — the wallet-hosting
+      // account for cluster wallets, the endpoint owner otherwise. Multiple
+      // wallets sharing an audience reuse the token.
+      const audiences = [...new Set(candidates.map((c) => c.policy.audience))];
+      const tokenByAudience = new Map<string, string>();
       await Promise.all(
-        owners.map(async (owner) => {
-          const token = await getSatelliteToken(owner);
-          if (token) tokenByOwner.set(owner, token);
+        audiences.map(async (audience) => {
+          const token = await getSatelliteToken(audience);
+          if (token) tokenByAudience.set(audience, token);
         })
       );
 
@@ -221,7 +246,7 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
         distinctCreditsUrls.map(async (creditsUrl) => {
           const sample = candidates.find((c) => c.policy.creditsUrl === creditsUrl);
           if (!sample) return;
-          const token = tokenByOwner.get(sample.endpoint.owner);
+          const token = tokenByAudience.get(sample.policy.audience);
           if (!token) return;
           const balance = await fetchBalance(creditsUrl, token, signal);
           balanceByCreditsUrl.set(creditsUrl, balance);
@@ -229,9 +254,10 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
       );
 
       // One PendingSubscription per endpoint. Rows that share a wallet keep
-      // the same `walletKey` (= credits_url) so the gate's polling loop and
-      // auto-registration can dedupe by wallet, and a single payment flips
-      // every sibling row to active at once.
+      // the same `walletKey` (wallet_id for cluster, credits_url otherwise)
+      // so the gate's polling loop and auto-registration can dedupe by
+      // wallet, and a single payment flips every sibling row to active at
+      // once.
       const out: PendingSubscription[] = [];
       for (const c of candidates) {
         const balance = balanceByCreditsUrl.get(c.policy.creditsUrl);
@@ -239,8 +265,9 @@ export function useXenditPrecheck(options: UseXenditPrecheckOptions): UseXenditP
         const threshold = c.policy.pricePerUnit ?? 1;
         if (balance >= threshold) continue;
         out.push({
-          walletKey: c.policy.creditsUrl,
+          walletKey: c.policy.walletKey,
           endpoints: [c.endpoint],
+          audience: c.policy.audience,
           paymentUrl: c.policy.paymentUrl,
           creditsUrl: c.policy.creditsUrl,
           bundles: c.policy.bundles,

--- a/components/frontend/src/hooks/use-xendit-subscriptions.ts
+++ b/components/frontend/src/hooks/use-xendit-subscriptions.ts
@@ -4,7 +4,13 @@
  * Surfaces the publisher-side wallets a user has funded. Subscription rows
  * live on the SyftHub backend (just metadata + last-known balance), but the
  * authoritative balance is always fetched live from the publisher's
- * `credits_url` with a per-publisher satellite token.
+ * `credits_url` with a satellite token minted for the row's audience.
+ *
+ * The backend `endpoint_owner` column IS that audience: the wallet-hosting
+ * account for cluster (managed) wallets, the endpoint owner for self-hosted
+ * ones. Since every endpoint backed by one managed wallet shares the same
+ * audience, the panel's dedupe-by-owner naturally collapses a shared wallet
+ * to a single row.
  */
 
 import { useCallback } from 'react';
@@ -39,7 +45,12 @@ function removeFromSubscriptionsCache(
 export interface RegisterXenditSubscriptionInput {
   creditsUrl: string;
   paymentUrl: string;
-  endpointOwner: string;
+  /**
+   * Satellite-token audience for the wallet — stored as `endpoint_owner` on
+   * the backend. Pass the resolved audience (wallet owner for cluster
+   * wallets, endpoint owner otherwise), never the raw endpoint owner.
+   */
+  audience: string;
   endpointSlug?: string | null;
   currency: string;
   lastKnownBalance?: number | null;
@@ -69,7 +80,7 @@ export function useRegisterXenditSubscription() {
       return getWalletClient().upsertXenditSubscription({
         credits_url: input.creditsUrl,
         payment_url: input.paymentUrl,
-        endpoint_owner: input.endpointOwner,
+        endpoint_owner: input.audience,
         endpoint_slug: input.endpointSlug ?? null,
         currency: input.currency,
         last_known_balance: input.lastKnownBalance ?? null
@@ -130,9 +141,10 @@ export interface SubscriptionBalanceResult {
 /**
  * Live-fetch a subscription's balance from its publisher.
  *
- * Mints a satellite token for the endpoint owner and queries credits_url.
- * Polls every `pollIntervalMs` while `enabled` is true (typically while the
- * credits panel is open). Returns `null` balance when fetching fails.
+ * Mints a satellite token for the row's audience (`endpoint_owner`) and
+ * queries credits_url. Polls every `pollIntervalMs` while `enabled` is true
+ * (typically while the credits panel is open). Returns `null` balance when
+ * fetching fails.
  */
 export function useSubscriptionBalance(
   subscription: Pick<XenditSubscription, 'credits_url' | 'endpoint_owner'>,

--- a/components/frontend/src/lib/__tests__/collective-billing.test.ts
+++ b/components/frontend/src/lib/__tests__/collective-billing.test.ts
@@ -56,6 +56,16 @@ function summary(members: CollectiveMemberBilling[]): CollectiveBillingSummary {
   };
 }
 
+/** Station-hosted shared wallet: same envelope + wallet identity fields. */
+function clusterBilling(over: Partial<MemberBillingDetail> = {}): MemberBillingDetail {
+  return prepaidBilling({
+    provider: 'cluster',
+    wallet_id: '018f2c3a-7b1e-4c2d-9a6f-3e8d5b1c4a90',
+    wallet_owner_username: 'station',
+    ...over
+  });
+}
+
 const freeBilling: MemberBillingDetail = {
   kind: 'free',
   provider: null,
@@ -150,6 +160,18 @@ describe('collectivePrepaidMembers', () => {
       expect(collectivePrepaidMembers(empty)).toEqual([]);
     }
   });
+
+  it('resolves the token audience to the endpoint owner for self-hosted wallets', () => {
+    const result = collectivePrepaidMembers(summary([member(1, prepaidBilling())]));
+    expect(result[0]?.audience).toBe('alice');
+    expect(result[0]?.walletId).toBeNull();
+  });
+
+  it('resolves the token audience to the wallet owner for cluster wallets', () => {
+    const result = collectivePrepaidMembers(summary([member(1, clusterBilling())]));
+    expect(result[0]?.audience).toBe('station');
+    expect(result[0]?.walletId).toBe('018f2c3a-7b1e-4c2d-9a6f-3e8d5b1c4a90');
+  });
 });
 
 // ── collectivePrepaidGroups ──────────────────────────────────────────────────
@@ -174,5 +196,24 @@ describe('collectivePrepaidGroups', () => {
   it('seeds each subscription balance at 0', () => {
     const groups = collectivePrepaidGroups(summary([member(1, prepaidBilling())]));
     expect(groups[0]?.balance).toBe(0);
+  });
+
+  it('groups cluster members by wallet_id even when their URLs drift', () => {
+    // Each space publishes the station URLs independently, so the strings can
+    // drift (trailing slash, casing…) while the wallet is one and the same.
+    const groups = collectivePrepaidGroups(
+      summary([
+        member(1, clusterBilling()),
+        member(2, clusterBilling({ credits_url: 'https://pay.example.com/balance/' })),
+        member(3, prepaidBilling()) // self-hosted, same credits_url as member 1
+      ])
+    );
+    expect(groups).toHaveLength(2);
+    const cluster = groups.find((g) => g.walletKey === '018f2c3a-7b1e-4c2d-9a6f-3e8d5b1c4a90');
+    expect(cluster?.endpoints).toHaveLength(2);
+    expect(cluster?.audience).toBe('station');
+    const selfHosted = groups.find((g) => g.walletKey === 'https://pay.example.com/balance');
+    expect(selfHosted?.endpoints).toHaveLength(1);
+    expect(selfHosted?.audience).toBe('alice');
   });
 });

--- a/components/frontend/src/lib/__tests__/wallet-identity.test.ts
+++ b/components/frontend/src/lib/__tests__/wallet-identity.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Wallet identity gating.
+ *
+ * Only a `cluster` policy may carry a `wallet_id` / `wallet_owner_username`
+ * of its own — those claims are verified against the wallet owner's registered
+ * domain at publish time. The same fields on a self-hosted policy are ignored,
+ * including on rows stored before publish-time stripping existed.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { resolveWalletAudience, resolveWalletKey } from '@/lib/xendit-client';
+
+const CREDITS_URL = 'https://station.example.com/api/v1/credits/018f2c3a/balance';
+const ENDPOINT_OWNER = 'publisher';
+
+// A cluster wallet as stored after successful publish-time validation.
+const VERIFIED = {
+  walletId: '018f2c3a-7b1e-4c2d-9a6f-3e8d5b1c4a90',
+  walletOwnerUsername: 'station42'
+};
+
+describe('resolveWalletAudience', () => {
+  it('honors the wallet owner on a verified cluster policy', () => {
+    expect(resolveWalletAudience(VERIFIED, 'cluster', ENDPOINT_OWNER)).toBe('station42');
+  });
+
+  it('is case-insensitive about the policy type', () => {
+    expect(resolveWalletAudience(VERIFIED, 'CLUSTER', ENDPOINT_OWNER)).toBe('station42');
+  });
+
+  it('ignores a wallet owner claimed by a self-hosted policy', () => {
+    // Poisoned row: minting for station42 would hand that account's token to
+    // whatever host this policy's unverified credits_url points at.
+    expect(resolveWalletAudience(VERIFIED, 'xendit', ENDPOINT_OWNER)).toBe(ENDPOINT_OWNER);
+    expect(resolveWalletAudience(VERIFIED, 'stripe', ENDPOINT_OWNER)).toBe(ENDPOINT_OWNER);
+  });
+
+  it('falls back to the endpoint owner when a cluster policy names nobody', () => {
+    expect(resolveWalletAudience({ walletOwnerUsername: null }, 'cluster', ENDPOINT_OWNER)).toBe(
+      ENDPOINT_OWNER
+    );
+  });
+});
+
+describe('resolveWalletKey', () => {
+  it('groups a verified cluster policy by its wallet id', () => {
+    expect(resolveWalletKey(VERIFIED, 'cluster', CREDITS_URL)).toBe(VERIFIED.walletId);
+  });
+
+  it('ignores a wallet id claimed by a self-hosted policy', () => {
+    // Otherwise the row joins a wallet it does not own: its balance would
+    // stand in for the real one and mark those endpoints funded.
+    expect(resolveWalletKey(VERIFIED, 'xendit', CREDITS_URL)).toBe(CREDITS_URL);
+  });
+
+  it('falls back to credits_url when a cluster policy has no wallet id', () => {
+    expect(resolveWalletKey({ walletId: null }, 'cluster', CREDITS_URL)).toBe(CREDITS_URL);
+  });
+});

--- a/components/frontend/src/lib/collective-billing.ts
+++ b/components/frontend/src/lib/collective-billing.ts
@@ -55,6 +55,13 @@ export interface CollectivePrepaidMember {
   name: string;
   /** owner/slug, as displayed and as the satellite-token subject. */
   path: string;
+  /**
+   * Satellite-token audience for this member's wallet: the wallet-hosting
+   * account (cluster) or the endpoint owner (self-hosted).
+   */
+  audience: string;
+  /** Published shared-wallet id (cluster only); null for self-hosted. */
+  walletId: string | null;
   paymentUrl: string;
   creditsUrl: string;
   bundles: MoneyBundle[];
@@ -80,6 +87,8 @@ export function collectivePrepaidMembers(
       slug: member.endpoint_slug,
       name: member.endpoint_name ?? member.endpoint_slug,
       path: `${member.endpoint_owner_username}/${member.endpoint_slug}`,
+      audience: b.wallet_owner_username ?? member.endpoint_owner_username,
+      walletId: b.wallet_id ?? null,
       paymentUrl: b.payment_url,
       creditsUrl: b.credits_url,
       bundles: b.bundles.map((bundle) => ({ name: bundle.name, amount: bundle.amount })),
@@ -104,10 +113,11 @@ function memberReference(member: CollectivePrepaidMember): EndpointReference {
 }
 
 /**
- * Group a collective's prepaid members by publisher wallet (`credits_url`) into
+ * Group a collective's prepaid members by publisher wallet into
  * {@link PendingSubscription}s — one row per wallet, the shape the collective
- * accounts modal renders. Members sharing a wallet collapse into one row whose
- * `endpoints` lists them all (paying once funds them all).
+ * accounts modal renders. The wallet key is the published `wallet_id`
+ * (cluster) or `credits_url` (self-hosted); members sharing a wallet collapse
+ * into one row whose `endpoints` lists them all (paying once funds them all).
  */
 export function collectivePrepaidGroups(
   summary: CollectiveBillingSummary | null | undefined
@@ -115,14 +125,16 @@ export function collectivePrepaidGroups(
   const byWallet = new Map<string, PendingSubscription>();
   for (const member of collectivePrepaidMembers(summary)) {
     const reference = memberReference(member);
-    const existing = byWallet.get(member.creditsUrl);
+    const walletKey = member.walletId ?? member.creditsUrl;
+    const existing = byWallet.get(walletKey);
     if (existing) {
       existing.endpoints.push(reference);
       continue;
     }
-    byWallet.set(member.creditsUrl, {
-      walletKey: member.creditsUrl,
+    byWallet.set(walletKey, {
+      walletKey,
       endpoints: [reference],
+      audience: member.audience,
       paymentUrl: member.paymentUrl,
       creditsUrl: member.creditsUrl,
       bundles: member.bundles,

--- a/components/frontend/src/lib/collectives-api.ts
+++ b/components/frontend/src/lib/collectives-api.ts
@@ -572,6 +572,13 @@ export interface MemberBillingDetail {
   credits_url: string | null;
   invoices_url: string | null;
   bundles: BillingMoneyBundle[];
+  /** Shared wallet id (cluster prepaid only) — stable grouping key. */
+  wallet_id?: string | null;
+  /**
+   * Wallet-hosting account = satellite-token audience (cluster prepaid
+   * only; audience falls back to the endpoint owner when absent).
+   */
+  wallet_owner_username?: string | null;
 }
 
 /** A member endpoint's identity plus its normalized billing detail. */

--- a/components/frontend/src/lib/query-keys.ts
+++ b/components/frontend/src/lib/query-keys.ts
@@ -79,6 +79,6 @@ export const billingSummaryKeys = {
   all: ['billing-summary'] as const,
   bySharedEndpoint: (collectiveSlug: string, sharedSlug?: string) =>
     [...billingSummaryKeys.all, collectiveSlug, sharedSlug ?? 'all'] as const,
-  readiness: (creditsUrls: readonly string[]) =>
-    [...billingSummaryKeys.all, 'readiness', creditsUrls] as const
+  readiness: (walletIdentities: readonly string[]) =>
+    [...billingSummaryKeys.all, 'readiness', walletIdentities] as const
 };

--- a/components/frontend/src/lib/xendit-client.ts
+++ b/components/frontend/src/lib/xendit-client.ts
@@ -17,6 +17,19 @@ import { syftClient } from '@/lib/sdk-client';
 
 export const POLL_INTERVAL_MS = 3000;
 
+/**
+ * Policy `type` values that bill via publisher-side prepaid credits. `cluster`
+ * is a station-hosted *shared* wallet — many spaces publish the same
+ * `wallet_id` under one wallet-owner account, so one balance backs them all.
+ * Keep in lockstep with the backend `PREPAID_POLICY_TYPES` in
+ * `schemas/endpoint.py`.
+ */
+export const PREPAID_POLICY_TYPES = new Set<string>(['xendit', 'stripe', 'cluster']);
+
+export function isPrepaidPolicyType(type: string): boolean {
+  return PREPAID_POLICY_TYPES.has(type.toLowerCase());
+}
+
 // Billing unit on a payment policy. Syft Space publishes the field as
 // `unit_type` in policy.config; legacy policies omit it and bill per request.
 export type PolicyUnit = 'request' | 'document';
@@ -48,6 +61,18 @@ export interface ParsedXenditConfig {
   pricePerUnit: number | null;
   unit: PolicyUnit;
   country: string | null;
+  /**
+   * Stable shared-wallet identifier (cluster policies). Preferred over
+   * `creditsUrl` as a grouping key: N spaces publish the URL independently,
+   * so string drift would split one wallet into several.
+   */
+  walletId: string | null;
+  /**
+   * Username of the wallet-hosting Hub account, injected server-side at
+   * publish time (cluster policies). This is the satellite-token audience;
+   * `null` means self-hosted → the endpoint owner is the audience.
+   */
+  walletOwnerUsername: string | null;
 }
 
 export function isValidUrl(value: unknown): value is string {
@@ -96,7 +121,40 @@ export function parseXenditConfig(config: Record<string, unknown>): ParsedXendit
       typeof (b as Record<string, unknown>).name === 'string' &&
       typeof (b as Record<string, unknown>).amount === 'number'
   );
-  return { paymentUrl, creditsUrl, invoicesUrl, bundles, currency, pricePerUnit, unit, country };
+  const walletId = pickConfigValue(config, 'wallet_id', 'walletId', isStringValue);
+  const walletOwnerUsername = pickConfigValue(
+    config,
+    'wallet_owner_username',
+    'walletOwnerUsername',
+    isStringValue
+  );
+  return {
+    paymentUrl,
+    creditsUrl,
+    invoicesUrl,
+    bundles,
+    currency,
+    pricePerUnit,
+    unit,
+    country,
+    walletId: walletId !== null && walletId !== '' ? walletId : null,
+    walletOwnerUsername:
+      walletOwnerUsername !== null && walletOwnerUsername !== '' ? walletOwnerUsername : null
+  };
+}
+
+/**
+ * The audience to mint a satellite token for when talking to this wallet's
+ * gateway: the wallet-hosting account (cluster) or the endpoint owner
+ * (self-hosted xendit/stripe). The station/space verifies `aud` against its
+ * own account, so minting for the wrong party yields `audience_mismatch`
+ * rejections that surface as permanently-null balances.
+ */
+export function resolveWalletAudience(
+  parsed: Pick<ParsedXenditConfig, 'walletOwnerUsername'>,
+  endpointOwner: string
+): string {
+  return parsed.walletOwnerUsername ?? endpointOwner;
 }
 
 export function formatUnitEstimate(amount: number, pricePerUnit: number, unit: PolicyUnit): string {

--- a/components/frontend/src/lib/xendit-client.ts
+++ b/components/frontend/src/lib/xendit-client.ts
@@ -26,6 +26,9 @@ export const POLL_INTERVAL_MS = 3000;
  */
 export const PREPAID_POLICY_TYPES = new Set<string>(['xendit', 'stripe', 'cluster']);
 
+/** The one policy type whose wallet claims are verified at publish time. */
+export const CLUSTER_POLICY_TYPE = 'cluster';
+
 export function isPrepaidPolicyType(type: string): boolean {
   return PREPAID_POLICY_TYPES.has(type.toLowerCase());
 }
@@ -144,17 +147,53 @@ export function parseXenditConfig(config: Record<string, unknown>): ParsedXendit
 }
 
 /**
+ * Whether a policy may carry a wallet identity (`wallet_id`,
+ * `wallet_owner_username`) of its own.
+ *
+ * Only `cluster` may. Its `wallet_owner` and every wallet URL are verified
+ * against that owner's registered domain when it is published, so the claim
+ * has been proven. Self-hosted (`xendit` / `stripe`) policy URLs are never
+ * domain-verified, so the same fields on one are ignored: honoring them would
+ * let a publisher group their endpoint into somebody else's wallet, or have
+ * buyers mint satellite tokens for an account they don't own and collect
+ * those tokens at a host they do.
+ *
+ * Gating on read — rather than trusting publish-time stripping alone — also
+ * neutralizes rows stored before that stripping existed.
+ */
+function mayCarryWalletIdentity(policyType: string): boolean {
+  return policyType.toLowerCase() === CLUSTER_POLICY_TYPE;
+}
+
+/**
  * The audience to mint a satellite token for when talking to this wallet's
- * gateway: the wallet-hosting account (cluster) or the endpoint owner
- * (self-hosted xendit/stripe). The station/space verifies `aud` against its
- * own account, so minting for the wrong party yields `audience_mismatch`
- * rejections that surface as permanently-null balances.
+ * gateway: the wallet-hosting account (verified cluster) or the endpoint
+ * owner. The station/space verifies `aud` against its own account, so minting
+ * for the wrong party yields `audience_mismatch` rejections that surface as
+ * permanently-null balances.
  */
 export function resolveWalletAudience(
   parsed: Pick<ParsedXenditConfig, 'walletOwnerUsername'>,
+  policyType: string,
   endpointOwner: string
 ): string {
+  if (!mayCarryWalletIdentity(policyType)) return endpointOwner;
   return parsed.walletOwnerUsername ?? endpointOwner;
+}
+
+/**
+ * Stable grouping key for a wallet: the published `wallet_id` (verified
+ * cluster) or the wallet's `credits_url`. Rows sharing a key share a balance
+ * — one payment funds them all — so an unverified `wallet_id` must never
+ * join a wallet the publisher does not own.
+ */
+export function resolveWalletKey(
+  parsed: Pick<ParsedXenditConfig, 'walletId'>,
+  policyType: string,
+  creditsUrl: string
+): string {
+  if (!mayCarryWalletIdentity(policyType)) return creditsUrl;
+  return parsed.walletId ?? creditsUrl;
 }
 
 export function formatUnitEstimate(amount: number, pricePerUnit: number, unit: PolicyUnit): string {

--- a/components/frontend/vite.config.ts
+++ b/components/frontend/vite.config.ts
@@ -23,6 +23,21 @@ function rewriteHiRoute(
   next();
 }
 
+// crypto.randomUUID only exists in secure contexts, so it is missing when the
+// dev server is reached over plain http on a non-localhost host (docker
+// hostname, LAN IP, tunnel). Polyfill it in dev only — production is https.
+const DEV_RANDOM_UUID_POLYFILL = `
+if (globalThis.crypto && !crypto.randomUUID) {
+  crypto.randomUUID = () => {
+    const b = crypto.getRandomValues(new Uint8Array(16));
+    b[6] = (b[6] & 15) | 64;
+    b[8] = (b[8] & 63) | 128;
+    const h = [...b].map((x) => x.toString(16).padStart(2, '0')).join('');
+    return h.slice(0, 8) + '-' + h.slice(8, 12) + '-' + h.slice(12, 16) + '-' + h.slice(16, 20) + '-' + h.slice(20);
+  };
+}
+`;
+
 // https://vitejs.dev/config/
 export default defineConfig({
   resolve: {
@@ -42,6 +57,19 @@ export default defineConfig({
       },
     },
     {
+      name: 'dev-crypto-randomuuid-polyfill',
+      apply: 'serve',
+      transformIndexHtml() {
+        return [
+          {
+            tag: 'script',
+            injectTo: 'head-prepend',
+            children: DEV_RANDOM_UUID_POLYFILL,
+          },
+        ];
+      },
+    },
+    {
       name: 'dynamic-html',
       transformIndexHtml(html) {
         return html
@@ -55,6 +83,7 @@ export default defineConfig({
   server: {
     host: config.server.host,
     port: config.server.port,
+    allowedHosts: true,
     watch: {
       // Use polling for Docker bind mounts where inotify events may not propagate
       usePolling: true,

--- a/components/frontend/vite.config.ts
+++ b/components/frontend/vite.config.ts
@@ -83,7 +83,10 @@ export default defineConfig({
   server: {
     host: config.server.host,
     port: config.server.port,
-    allowedHosts: true,
+    // Explicit allow-list (not `true`) keeps Vite's DNS-rebinding protection.
+    // `.localhost` covers every *.localhost dev hostname (station tenants,
+    // syfthub.localhost, …); host.k3d.internal is the hub as seen from k3d.
+    allowedHosts: ['.localhost', 'host.k3d.internal'],
     watch: {
       // Use polling for Docker bind mounts where inotify events may not propagate
       usePolling: true,

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -27,6 +27,48 @@ services:
       start_period: 10s
 
   # Backend API service (internal only)
+  # Wildcard DNS for backend/aggregator: answers every zone listed in
+  # DNS_WILDCARD_DOMAINS (apex + ALL subdomains) with the host-gateway IP, so
+  # new station tenant subdomains resolve without any extra_hosts edits. All
+  # other names are forwarded upstream via Docker's embedded DNS.
+  dns:
+    image: alpine:3.22
+    container_name: syfthub-dns-dev
+    restart: unless-stopped
+    environment:
+      # Space-separated zones to point at the host.
+      DNS_WILDCARD_DOMAINS: "station.localhost station.spaces.localhost"
+    extra_hosts:
+      # Injects the platform-correct host-gateway IP for the entrypoint to read.
+      - "host.docker.internal:host-gateway"
+    entrypoint:
+      - /bin/sh
+      - -ec
+      - |
+        apk add --no-cache dnsmasq >/dev/null
+        # ahostsv4, not hosts: the latter can return the gateway's IPv6 first,
+        # which would leave the zones without A records.
+        GATEWAY="$$(getent ahostsv4 host.docker.internal | awk 'NR==1{print $$1}')"
+        set -- --keep-in-foreground --log-facility=- --port=53 \
+          --bind-dynamic --except-interface=lo --no-hosts
+        for domain in $$DNS_WILDCARD_DOMAINS; do
+          set -- "$$@" --address="/$$domain/$$GATEWAY"
+        done
+        exec dnsmasq "$$@"
+    networks:
+      syfthub-network:
+        # Static IP: the `dns:` entries on backend/aggregator only accept
+        # literal IPs. Requires the fixed subnet declared on the network.
+        ipv4_address: 172.28.0.53
+    healthcheck:
+      # Query via the container IP — dnsmasq deliberately doesn't bind lo
+      # (binding loopback would make it reject 127.0.0.11 as upstream).
+      test: ["CMD", "nslookup", "station.localhost", "172.28.0.53"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
   backend:
     build:
       context: ../components/backend
@@ -49,6 +91,10 @@ services:
       # Named volume for RSA keys so the syfthub user (uid 1000) has write access
       # (bind-mounted parent dirs are created by Docker as root, blocking auto-generation)
       - rsa_keys_data:/app/data/rsa_keys
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    # Wildcard *.station.localhost etc. — see the dns service.
+    dns: 172.28.0.53
     environment:
       - ENVIRONMENT=development
       - DATABASE_URL=postgresql://syfthub:syfthub_dev_password@db:5432/syfthub_dev
@@ -83,6 +129,8 @@ services:
       - syfthub-network
     depends_on:
       db:
+        condition: service_healthy
+      dns:
         condition: service_healthy
       meilisearch:
         condition: service_healthy
@@ -222,10 +270,14 @@ services:
     # Enable host.docker.internal on Linux/WSL2 (required for connecting to host services)
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    # Wildcard *.station.localhost etc. — see the dns service.
+    dns: 172.28.0.53
     networks:
       - syfthub-network
     depends_on:
       backend:
+        condition: service_healthy
+      dns:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/health', timeout=5)"]
@@ -307,6 +359,10 @@ services:
 networks:
   syfthub-network:
     driver: bridge
+    ipam:
+      config:
+        # Fixed subnet so the dns service can hold a static IP.
+        - subnet: 172.28.0.0/16
 
 volumes:
   postgres_data:


### PR DESCRIPTION
This pull request introduces support for a new "cluster" prepaid billing policy, which allows multiple endpoints to share a single station-hosted wallet. The changes add validation, enrichment, and classification logic for this new policy type, ensure secure association between endpoints and wallet owners, and update schemas, services, and tests accordingly.

**Cluster prepaid wallet support**

* Added the `"cluster"` policy type to the set of prepaid billing providers (`PREPAID_POLICY_TYPES`) and documented its shared-wallet semantics (`schemas/endpoint.py`).
* Updated the `MemberBillingDetail` schema to include `wallet_id` and `wallet_owner_username` fields, which are used to group endpoints by wallet and to specify the wallet-hosting account (`schemas/collective.py`).
* The `_parse_prepaid_config` function now extracts and returns the new wallet fields, making them available to the frontend and billing logic (`services/collective_service.py`). [[1]](diffhunk://#diff-47e35e59b39440f4cf870ac78c03562288bcfbfe120f98ff62633ea9140bef29R146-R153) [[2]](diffhunk://#diff-47e35e59b39440f4cf870ac78c03562288bcfbfe120f98ff62633ea9140bef29R162-R167)
* The endpoint model and documentation clarify the meaning of `endpoint_owner` for both cluster and self-hosted wallets (`models/xendit_subscription.py`).

**Validation and enrichment**

* Implemented `_process_cluster_policies` to validate cluster wallet policies on creation, update, and sync. This ensures that wallet IDs are present, wallet owners are valid and active, and wallet URLs are securely hosted under the owner's registered domain. The function also enriches configs with the current wallet owner's username (`services/endpoint_service.py`).
* Integrated cluster policy validation into endpoint creation, update, and sync flows, raising errors when validation fails (`services/endpoint_service.py`). [[1]](diffhunk://#diff-cb1517ade0e21ae10b15e258625efc6f60545c56a47498e81ddd967e489029f8R343-R349) [[2]](diffhunk://#diff-cb1517ade0e21ae10b15e258625efc6f60545c56a47498e81ddd967e489029f8R481-R486) [[3]](diffhunk://#diff-cb1517ade0e21ae10b15e258625efc6f60545c56a47498e81ddd967e489029f8R1237-R1246)

**Classification and tagging**

* Updated billing classification and tag injection logic to recognize the new "cluster" provider as a prepaid policy, ensuring consistent behavior across the platform (`schemas/collective.py`, `services/endpoint_service.py`). [[1]](diffhunk://#diff-d16f8ac560b198f7a4bfb1b7290062e6445fbd7bfdf06c8c13ee1f7bca60252bL563-R563) [[2]](diffhunk://#diff-cb1517ade0e21ae10b15e258625efc6f60545c56a47498e81ddd967e489029f8L172-R327)

**Testing**

* Added test cases to verify extraction, enrichment, and classification of cluster wallet fields, and to ensure that self-hosted policies do not expose these fields (`tests/test_collective_billing.py`).

**Refactoring and single source of truth**

* Refactored the definition of prepaid providers to use a single source of truth, reducing duplication and potential for drift (`services/collective_service.py`). [[1]](diffhunk://#diff-47e35e59b39440f4cf870ac78c03562288bcfbfe120f98ff62633ea9140bef29L72-R75) [[2]](diffhunk://#diff-47e35e59b39440f4cf870ac78c03562288bcfbfe120f98ff62633ea9140bef29R49) [[3]](diffhunk://#diff-cb1517ade0e21ae10b15e258625efc6f60545c56a47498e81ddd967e489029f8R18-R19)

These changes ensure that cluster wallets are securely and consistently handled as a new type of prepaid billing policy across the backend.