### PR TITLE
feat(auth): add allow_signup flag to Google sign-in (login-only mode)

### DIFF
--- a/components/backend/src/syfthub/auth/router.py
+++ b/components/backend/src/syfthub/auth/router.py
@@ -213,17 +213,20 @@ def google_login(
     google_data: GoogleAuthRequest,
     auth_service: Annotated[AuthService, Depends(get_auth_service)],
 ) -> AuthResponse:
-    """Authenticate or register user via Google OAuth.
+    """Authenticate (and, by default, register) a user via Google OAuth.
 
-    This endpoint handles both login and registration for Google OAuth:
-    - If the user exists (by Google ID or email), they are logged in
-    - If the user doesn't exist, a new account is created
-    - If email matches an existing account, the Google account is linked
-
-    The credential should be the Google ID token (JWT) received from
-    Google Sign-In on the frontend.
+    Given the Google ID token (JWT) from Google Sign-In on the frontend:
+    - Existing user (matched by Google ID) → logged in.
+    - Email already on an account not linked to Google → 409 (never
+      auto-linked; the user must link Google from account settings).
+    - Unknown email → a new account is created, UNLESS the request sets
+      ``allow_signup: false``, in which case it is rejected with 401
+      (``code: account_not_found``) — for relying services that admit
+      existing users only.
     """
-    return auth_service.google_login(google_data.credential)
+    return auth_service.google_login(
+        google_data.credential, allow_signup=google_data.allow_signup
+    )
 
 
 @router.post("/refresh", response_model=Token, dependencies=[_refresh_rate_limit])

--- a/components/backend/src/syfthub/schemas/auth.py
+++ b/components/backend/src/syfthub/schemas/auth.py
@@ -225,3 +225,12 @@ class GoogleAuthRequest(BaseModel):
         min_length=1,
         description="Google ID token (JWT) received from Google Sign-In",
     )
+    allow_signup: bool = Field(
+        default=True,
+        description=(
+            "When false, an unknown email is rejected (401) instead of creating "
+            "a new account. For relying services that sign in existing users "
+            "only. Defaults true — the Hub's own web login "
+            "signs up on first Google sign-in."
+        ),
+    )

--- a/components/backend/src/syfthub/services/auth_service.py
+++ b/components/backend/src/syfthub/services/auth_service.py
@@ -432,18 +432,24 @@ class AuthService(BaseService):
         suffix = secrets.randbelow(9000) + 1000  # 1000-9999
         return f"{base_username}{suffix}"
 
-    def google_login(self, credential: str) -> AuthResponse:
-        """Authenticate or register user via Google OAuth.
+    def google_login(
+        self, credential: str, *, allow_signup: bool = True
+    ) -> AuthResponse:
+        """Authenticate (and, by default, register) a user via Google OAuth.
 
         This method handles both login and registration for Google OAuth:
         1. Verify the Google ID token
         2. Check if user exists by google_id
         3. If not, check if email belongs to an existing account (reject with 409)
-        4. If no user found, create a new account
+        4. If no user found, create a new account — unless ``allow_signup`` is
+           False, in which case reject with 401 (``code: account_not_found``)
         5. Return authentication tokens
 
         Args:
             credential: Google ID token from Google Sign-In
+            allow_signup: When False, an unknown email is rejected instead of
+                being signed up. For relying services that admit existing
+                users only; defaults True to preserve the Hub's own web login.
 
         Returns:
             AuthResponse with user info and tokens
@@ -483,6 +489,17 @@ class AuthService(BaseService):
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail="An account with this email already exists. Please log in with your original method and link Google from account settings.",
+                )
+            elif not allow_signup:
+                # Login-only caller: an unknown email is not signed up — the
+                # relying service admits existing users only.
+                logger.info("Rejected Google sign-in for unknown email: %s", email)
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail={
+                        "code": "account_not_found",
+                        "message": "No SyftHub account for this Google email.",
+                    },
                 )
             else:
                 # Create new user

--- a/components/backend/tests/test_services/test_auth_service.py
+++ b/components/backend/tests/test_services/test_auth_service.py
@@ -780,3 +780,89 @@ class TestGoogleLogin:
 
         assert exc_info.value.status_code == 401
         assert "missing user information" in exc_info.value.detail
+
+    def test_rejects_unknown_email_when_signup_disallowed(self, auth_service):
+        """allow_signup=False: an unknown email is rejected, never signed up."""
+        mock_idinfo = {
+            "sub": "gid-unknown",
+            "email": "stranger@example.com",
+            "name": "Stranger",
+        }
+
+        with (
+            patch.object(
+                auth_service, "_verify_google_token", return_value=mock_idinfo
+            ),
+            patch.object(
+                auth_service.user_repository, "get_by_google_id", return_value=None
+            ),
+            patch.object(
+                auth_service.user_repository, "get_by_email", return_value=None
+            ),
+            patch.object(auth_service.user_repository, "create_user") as mock_create,
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            auth_service.google_login("google_credential", allow_signup=False)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail["code"] == "account_not_found"
+        mock_create.assert_not_called()
+
+    def test_existing_user_signs_in_when_signup_disallowed(self, auth_service):
+        """allow_signup=False still admits an existing google-linked user."""
+        mock_idinfo = {
+            "sub": "gid-123",
+            "email": "guser@example.com",
+            "name": "Google User",
+        }
+        existing_user = self._make_user()
+
+        with (
+            patch.object(
+                auth_service, "_verify_google_token", return_value=mock_idinfo
+            ),
+            patch.object(
+                auth_service.user_repository,
+                "get_by_google_id",
+                return_value=existing_user,
+            ),
+            patch(
+                "syfthub.services.auth_service.create_access_token",
+                return_value="access",
+            ),
+            patch(
+                "syfthub.services.auth_service.create_refresh_token",
+                return_value="refresh",
+            ),
+        ):
+            result = auth_service.google_login("google_credential", allow_signup=False)
+
+        assert result.access_token == "access"
+        assert result.user["username"] == "guser"
+
+    def test_email_exists_still_409_when_signup_disallowed(self, auth_service):
+        """allow_signup=False does not bypass the unlinked-email 409 guard."""
+        mock_idinfo = {
+            "sub": "gid-new",
+            "email": "existing@example.com",
+            "name": "Existing User",
+        }
+        existing_by_email = self._make_user(email="existing@example.com")
+
+        with (
+            patch.object(
+                auth_service, "_verify_google_token", return_value=mock_idinfo
+            ),
+            patch.object(
+                auth_service.user_repository, "get_by_google_id", return_value=None
+            ),
+            patch.object(
+                auth_service.user_repository,
+                "get_by_email",
+                return_value=existing_by_email,
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            auth_service.google_login("fake-credential", allow_signup=False)
+
+        assert exc_info.value.status_code == 409


### PR DESCRIPTION
## What

Adds an optional `allow_signup` field (default `true`) to `POST /api/v1/auth/google`.

- **`allow_signup: true`** (default) — unchanged behavior: an unknown email creates a new account (signup-on-first-Google-login).
- **`allow_signup: false`** — an unknown email is **rejected with `401 {code: account_not_found}`** instead of being signed up.

## Why

**Syft Station** wants to let users sign in with Google (the same Google account they use on the Hub) instead of a username/password — but Station must admit **existing SyftHub users only, no new signups**. The Hub is the identity authority, so enforcement belongs here. Station will call this endpoint with `allow_signup: false`; the Hub's own web login keeps the default and is unaffected.

This also corrects the handler docstring, which previously *claimed* unknown emails were rejected — the code actually created them.

## Changes

- `schemas/auth.py` — `GoogleAuthRequest.allow_signup: bool = True`
- `services/auth_service.py` — `google_login(..., *, allow_signup=True)`; new guard rejects unknown emails before the create branch when the flag is off
- `auth/router.py` — threads the flag through; docstring fixed
- `tests/test_services/test_auth_service.py` — 3 new tests: reject-unknown-when-off, existing-user-still-admitted-when-off, and unlinked-email-409-not-bypassed

## Backward compatibility

Default `true` ⇒ every existing caller (the Hub frontend, internal callers) behaves identically. No migration.

## Reviewer notes / caveats

- **The unlinked-email `409` is intentionally unchanged.** A password-only account that shares the Google email still gets `409` (never auto-linked, to avoid takeover). So Google sign-in only works for **already-Google-linked** users; relying services should keep a password fallback for the rest.
- **Deploy this before the Station-side change.** Pydantic ignores unknown fields, so if Station sends `allow_signup: false` to a Hub that predates this PR, the field is silently dropped and the unknown email would be **signed up**. Ship the Hub first; smoke-test with an unknown-email token + `allow_signup: false` → expect `401 account_not_found`.
- **Google client_id / `aud` (config, not code):** the id_token's `aud` must equal the Hub's `google_client_id`, so Station's frontend must use the **Hub's** Google client and that client's Authorized JavaScript origins must include the Station origin.

## Test

`uv run pytest tests/test_services/test_auth_service.py::TestGoogleLogin` → 8 passed. ruff + mypy clean (pre-commit).