### PR TITLE
Pin MCP version to <2.0 to resolve production image issues

### DIFF
--- a/components/mcp/Dockerfile
+++ b/components/mcp/Dockerfile
@@ -98,6 +98,12 @@ RUN uv venv .venv && \
     sed -i '/\[tool.uv.sources\]/,/^$/d' pyproject.toml && \
     uv pip install -e . -e /sdk/python --python .venv/bin/python
 
+# Fail the build on a bad dependency resolve. Deps here are resolved fresh from
+# PyPI (uv.lock is not used in this image), so an upstream release can silently
+# produce an image that builds clean and then dies on first import. Nothing else
+# in the build imports fastmcp, so without this the failure only surfaces in prod.
+RUN .venv/bin/python -c "from fastmcp import FastMCP"
+
 # Copy source code
 COPY --chown=syfthub:syfthub components/mcp/server.py ./
 COPY --chown=syfthub:syfthub components/mcp/syfthub_client.py ./

--- a/components/mcp/pyproject.toml
+++ b/components/mcp/pyproject.toml
@@ -8,7 +8,8 @@ dependencies = [
     # Note: auth extra deprecated in 2.14+, auth features now included by default
     "fastmcp>=2.14.3",
     # MCP SDK with DNS rebinding protection (CVE-2025-66416)
-    "mcp>=1.23.0",
+    # <2.0: fastmcp's server extra is incompatible with the mcp 2.x restructure.
+    "mcp>=1.24.0,<2.0",
     # HTTP libraries with security fixes
     "requests>=2.32.4",  # CVE-2024-47081: .netrc credentials leak
     "httpx>=0.27.0",
@@ -50,7 +51,11 @@ override-dependencies = [
     "werkzeug>=3.1.6",  # CVE-2025-66221, CVE-2026-21860, CVE-2026-27199
     "authlib>=1.6.12",  # CVE-2025-68158, CVE-2026-27962, CVE-2026-28490, CVE-2026-28498, CVE-2026-28802
     "aiohttp>=3.14.1",  # CVE-2025-69223
-    "mcp>=1.23.0",  # CVE-2025-66416
+    # CVE-2025-66416. The <2.0 ceiling is mandatory: this is an *override*, so it
+    # replaces (not intersects) fastmcp-slim[server]'s own "mcp<2.0,>=1.24.0".
+    # Without it the resolver takes mcp 2.0.0 and fastmcp's server layer fails to
+    # import at runtime ("FastMCP server support is not installed").
+    "mcp>=1.24.0,<2.0",
     "pydantic>=2.11.7",  # syft-accounting-sdk pins ==2.11.4; override for fastmcp compat
     "python-dotenv>=1.2.2",  # CVE-2025-67006: syft-accounting-sdk pins ==1.1.0 (vulnerable)
     "Pygments>=2.20.0",  # CVE-2025-68139: ReDoS via inefficient regex for GUID matching

--- a/components/mcp/uv.lock
+++ b/components/mcp/uv.lock
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 overrides = [
     { name = "aiohttp", specifier = ">=3.14.1" },
     { name = "authlib", specifier = ">=1.6.12" },
-    { name = "mcp", specifier = ">=1.23.0" },
+    { name = "mcp", specifier = ">=1.24.0,<2.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
@@ -1630,7 +1630,7 @@ requires-dist = [
     { name = "email-validator", specifier = ">=2.0.0" },
     { name = "fastmcp", specifier = ">=2.14.3" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "mcp", specifier = ">=1.23.0" },
+    { name = "mcp", specifier = ">=1.24.0,<2.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
@@ -1645,11 +1645,12 @@ requires-dist = [
 
 [[package]]
 name = "syfthub-sdk"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "../../sdk/python" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
+    { name = "websocket-client" },
 ]
 
 [package.metadata]
@@ -1663,6 +1664,7 @@ requires-dist = [
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0" },
+    { name = "websocket-client", specifier = ">=1.9.0" },
 ]
 provides-extras = ["dev"]
 
@@ -1786,6 +1788,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
     { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
     { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request addresses compatibility and reliability issues with the `mcp` dependency in the MCP component, ensuring that the build fails early if there are dependency resolution problems and preventing runtime errors due to incompatible package versions. The most important changes are as follows:

**Dependency version constraints and security:**

* Updated the `mcp` dependency in `pyproject.toml` to require `>=1.24.0,<2.0`, preventing installation of incompatible 2.x versions that break `fastmcp` server support. This ensures compatibility and avoids runtime import errors.
* Applied the same `<2.0` ceiling for `mcp` in the `override-dependencies` section, with detailed comments explaining the necessity due to override semantics and to address CVE-2025-66416.

**Build reliability:**

* Added a build step in the `Dockerfile` to explicitly import `fastmcp` after installation, causing the build to fail immediately if there is a dependency resolution issue, rather than letting the error surface at runtime in production.