### PR TITLE
Fix MCP image resolution to prevent deployment failures

### DIFF
--- a/components/mcp/Dockerfile
+++ b/components/mcp/Dockerfile
@@ -98,6 +98,10 @@ RUN uv venv .venv && \
     sed -i '/\[tool.uv.sources\]/,/^$/d' pyproject.toml && \
     uv pip install -e . -e /sdk/python --python .venv/bin/python
 
+# Deps resolve fresh from PyPI (no uv.lock in this image), so a bad resolve builds
+# clean and dies at runtime. Fail here instead.
+RUN .venv/bin/python -c "from fastmcp import FastMCP"
+
 # Copy source code
 COPY --chown=syfthub:syfthub components/mcp/server.py ./
 COPY --chown=syfthub:syfthub components/mcp/syfthub_client.py ./

--- a/components/mcp/pyproject.toml
+++ b/components/mcp/pyproject.toml
@@ -7,28 +7,27 @@ dependencies = [
     # Core MCP framework - pinned for security (CVE-2025-66416, GHSA-rj5c-58rq-j5g5, GHSA-fg6f-75jq-6523)
     # Note: auth extra deprecated in 2.14+, auth features now included by default
     "fastmcp>=2.14.3",
-    # MCP SDK with DNS rebinding protection (CVE-2025-66416)
-    "mcp>=1.23.0",
+    # MCP SDK with DNS rebinding protection (CVE-2025-66416).
+    # No ceiling: fastmcp declares the mcp range it supports.
+    "mcp>=1.24.0",
     # HTTP libraries with security fixes
-    "requests>=2.32.4",  # CVE-2024-47081: .netrc credentials leak
+    "requests>=2.32.4", # CVE-2024-47081: .netrc credentials leak
     "httpx>=0.27.0",
-    "aiohttp>=3.14.1",  # CVE-2025-69223 and related DoS vulnerabilities
-    "urllib3>=2.7.0",  # CVE-2025-66471, CVE-2026-21441: decompression bomb; GHSA-pq67-6m6q-mj2v: sensitive headers forwarded on cross-origin redirects
+    "aiohttp>=3.14.1", # CVE-2025-69223 and related DoS vulnerabilities
+    "urllib3>=2.7.0", # CVE-2025-66471, CVE-2026-21441: decompression bomb; GHSA-pq67-6m6q-mj2v: sensitive headers forwarded on cross-origin redirects
     # Web framework dependencies with security fixes
-    "starlette>=1.3.1",  # CVE-2025-62727: O(n^2) DoS via Range header
-    "werkzeug>=3.1.6",  # CVE-2025-66221, CVE-2026-21860, CVE-2026-27199: Windows device names
-    "authlib>=1.6.12",  # CVE-2025-68158, CVE-2026-28802, CVE-2026-27962, CVE-2026-28490, CVE-2026-28498
+    "starlette>=1.3.1", # CVE-2025-62727: O(n^2) DoS via Range header
+    "werkzeug>=3.1.6", # CVE-2025-66221, CVE-2026-21860, CVE-2026-27199: Windows device names
+    "authlib>=1.6.12", # CVE-2025-68158, CVE-2026-28802, CVE-2026-27962, CVE-2026-28490, CVE-2026-28498
     # Pydantic (compatible with fastmcp>=2.14.3)
     "pydantic>=2.11.7",
     # Authentication and crypto
     "cryptography>=48.0.1",
-    "pyjwt>=2.13.0",  # CVE-2026-32597: accepts unknown crit header extensions
+    "pyjwt>=2.13.0", # CVE-2026-32597: accepts unknown crit header extensions
     # Utilities
-    "python-dotenv>=1.2.2",  # CVE-2025-67006: symlink following allows arbitrary file overwrite
+    "python-dotenv>=1.2.2", # CVE-2025-67006: symlink following allows arbitrary file overwrite
     "python-multipart>=0.0.31",
     "email-validator>=2.0.0",
-    # SyftHub integration
-    "syft-accounting-sdk @ git+https://git@github.com/OpenMined/accounting-sdk.git",
     "syfthub-sdk",
 ]
 
@@ -39,19 +38,22 @@ py-modules = ["server", "syfthub_client"]
 syfthub-sdk = { path = "../../sdk/python", editable = true }
 
 [tool.uv]
-override-dependencies = [
-    # Security overrides - force minimum secure versions even when transitive deps pin older versions
-    # NOTE: diskcache 5.6.3 (CVE-2025-69872) is a transitive dep via fastmcp -> py-key-value-aio[disk].
-    # No upstream fix is available. The cache directory is hardened in Dockerfile (chmod 700, owned by
-    # syfthub user only). Monitor https://github.com/grantjenks/python-diskcache for a patched release.
-    "requests>=2.32.4",  # CVE-2024-47081: syft-accounting-sdk pins 2.32.3
+# Security floors, as constraints rather than overrides: a constraint INTERSECTS
+# with what our dependencies declare, so it can raise a floor without deleting an
+# upstream ceiling. An override REPLACES, which is how an unbounded "mcp>=1.23.0"
+# once erased fastmcp's "mcp<2.0" and shipped mcp 2.0.0 to prod.
+#
+# NOTE: diskcache 5.6.3 (CVE-2025-69872) has no upstream fix; its cache dir is
+# hardened in the Dockerfile (chmod 700, syfthub-owned).
+constraint-dependencies = [
+    "requests>=2.32.4",  # CVE-2024-47081
     "urllib3>=2.7.0",  # CVE-2025-66471, CVE-2026-21441, GHSA-pq67-6m6q-mj2v
     "starlette>=1.3.1",  # CVE-2025-62727
     "werkzeug>=3.1.6",  # CVE-2025-66221, CVE-2026-21860, CVE-2026-27199
     "authlib>=1.6.12",  # CVE-2025-68158, CVE-2026-27962, CVE-2026-28490, CVE-2026-28498, CVE-2026-28802
     "aiohttp>=3.14.1",  # CVE-2025-69223
-    "mcp>=1.23.0",  # CVE-2025-66416
-    "pydantic>=2.11.7",  # syft-accounting-sdk pins ==2.11.4; override for fastmcp compat
-    "python-dotenv>=1.2.2",  # CVE-2025-67006: syft-accounting-sdk pins ==1.1.0 (vulnerable)
-    "Pygments>=2.20.0",  # CVE-2025-68139: ReDoS via inefficient regex for GUID matching
+    "mcp>=1.24.0",  # CVE-2025-66416; ceiling comes from fastmcp
+    "pydantic>=2.11.7",
+    "python-dotenv>=1.2.2",  # CVE-2025-67006
+    "Pygments>=2.20.0",  # CVE-2025-68139
 ]

--- a/components/mcp/uv.lock
+++ b/components/mcp/uv.lock
@@ -3,10 +3,10 @@ revision = 3
 requires-python = ">=3.12"
 
 [manifest]
-overrides = [
+constraints = [
     { name = "aiohttp", specifier = ">=3.14.1" },
     { name = "authlib", specifier = ">=1.6.12" },
-    { name = "mcp", specifier = ">=1.23.0" },
+    { name = "mcp", specifier = ">=1.24.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
@@ -514,7 +514,7 @@ dependencies = [
     { name = "packaging" },
     { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pydantic" },
+    { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -1197,6 +1197,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
 ]
 
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
+]
+
 [[package]]
 name = "pydantic-core"
 version = "2.41.5"
@@ -1587,18 +1592,6 @@ wheels = [
 ]
 
 [[package]]
-name = "syft-accounting-sdk"
-version = "0.1.0"
-source = { git = "https://github.com/OpenMined/accounting-sdk.git#a4908263e9b8609cb9d28e79b3a1e6ab66b5ffb6" }
-dependencies = [
-    { name = "click" },
-    { name = "colorama" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "requests" },
-]
-
-[[package]]
 name = "syfthub-mcp"
 version = "0.1.0"
 source = { virtual = "." }
@@ -1616,7 +1609,6 @@ dependencies = [
     { name = "python-multipart" },
     { name = "requests" },
     { name = "starlette" },
-    { name = "syft-accounting-sdk" },
     { name = "syfthub-sdk" },
     { name = "urllib3" },
     { name = "werkzeug" },
@@ -1630,14 +1622,13 @@ requires-dist = [
     { name = "email-validator", specifier = ">=2.0.0" },
     { name = "fastmcp", specifier = ">=2.14.3" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "mcp", specifier = ">=1.23.0" },
+    { name = "mcp", specifier = ">=1.24.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = ">=0.0.31" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "starlette", specifier = ">=1.3.1" },
-    { name = "syft-accounting-sdk", git = "https://github.com/OpenMined/accounting-sdk.git" },
     { name = "syfthub-sdk", editable = "../../sdk/python" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "werkzeug", specifier = ">=3.1.6" },
@@ -1645,11 +1636,12 @@ requires-dist = [
 
 [[package]]
 name = "syfthub-sdk"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "../../sdk/python" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
+    { name = "websocket-client" },
 ]
 
 [package.metadata]
@@ -1663,6 +1655,7 @@ requires-dist = [
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0" },
+    { name = "websocket-client", specifier = ">=1.9.0" },
 ]
 provides-extras = ["dev"]
 
@@ -1786,6 +1779,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
     { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
     { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request strengthens dependency management and security for the MCP component, focusing on ensuring secure and compatible package versions. The changes clarify how dependency overrides and constraints are handled, update minimum package versions to address known vulnerabilities, and add a runtime check to catch dependency resolution issues early.

**Dependency and Security Improvements:**

* Raised the minimum required version of the `mcp` package to `1.24.0` in both the main dependencies and security constraints, ensuring protection against CVE-2025-66416 and aligning with `fastmcp` compatibility. [[1]](diffhunk://#diff-c5d31ee97c6b6865de1e5d434b57576850c1b2fd2e434dab0adac9298086ecf2L10-R12) [[2]](diffhunk://#diff-c5d31ee97c6b6865de1e5d434b57576850c1b2fd2e434dab0adac9298086ecf2R43-R64)
* Updated and clarified dependency overrides and constraints in `pyproject.toml`, including new overrides for `pydantic` and `python-dotenv` to enforce secure versions and prevent vulnerable pins from transitive dependencies.
* Improved documentation in the dependency management section to explain the difference between overrides and constraints, and to warn about potential issues if upstream packages declare new version ceilings.

**Build Process Hardening:**

* Added a runtime import check for `fastmcp` in the Docker build (`Dockerfile`) to ensure that dependency resolution failures are detected during the build rather than at runtime.