### PR TITLE
Enhance OTP handling, email verification, and user management features

### DIFF
--- a/components/backend/alembic/versions/20260818_000000_add_user_public_id.py
+++ b/components/backend/alembic/versions/20260818_000000_add_user_public_id.py
@@ -1,0 +1,117 @@
+"""Add users.public_id — a stable, opaque external user identifier.
+
+``users.id`` is a sequential integer primary key. It must never become an
+external, permanently-bound reference: doing so hands every relying party
+SyftHub's internal id space (approximate user count, relative signup order) and
+a shared join key with which two unrelated relying parties can correlate the
+same person. The codebase already declines to expose it (see the privacy notes
+on ``EndpointPublicResponse`` and ``PublicUserProfile``).
+
+``public_id`` is that external reference instead — a random UUID, unique and
+immutable, which will back the OIDC ``sub`` claim.
+
+Migration shape, and why:
+
+1. Add the column **nullable with no default**. That is a catalogue-only change
+   on PostgreSQL: no table rewrite, so the ACCESS EXCLUSIVE lock is held only
+   momentarily rather than for the length of a rewrite.
+2. Backfill every existing row with a distinct value.
+3. Add the unique index.
+4. Constrain to NOT NULL and attach a ``gen_random_uuid()`` server default.
+
+Step 4's server default is load-bearing, not decoration. ``deploy.sh``'s
+``run_migrations()`` runs *before* ``deploy_services()`` and only brings up the
+database — the **previous release keeps serving traffic throughout**. That code
+has no ``public_id`` in its ORM model, so its signup INSERTs omit the column
+entirely. Without a database-side default, every registration between this
+migration committing and the new release rolling in would fail on a NOT NULL
+violation. A Python-side default cannot cover that window, because it exists
+only in the new code.
+
+``gen_random_uuid()`` is built into PostgreSQL 13+ (deployments run
+``postgres:16-alpine``). SQLite has no equivalent and cannot ``ALTER COLUMN``,
+so there the column stays nullable; the ORM-side ``default=uuid.uuid4`` covers
+inserts, and a freshly created dev database gets NOT NULL from ``create_all()``.
+
+Revision ID: 022_user_public_id
+Revises: 021_drop_user_heartbeat_fields
+Create Date: 2026-08-18 00:00:00.000000+00:00
+"""
+
+import uuid
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "022_user_public_id"
+down_revision: str | None = "021_drop_user_heartbeat_fields"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_users = sa.table(
+    "users",
+    sa.column("id", sa.Integer),
+    sa.column("public_id", sa.Uuid()),
+)
+
+
+def _backfill_public_ids(bind: sa.engine.Connection) -> None:
+    """Assign a distinct UUID to every row that lacks one, from Python.
+
+    Used on dialects without a UUID-generating SQL function. Runs inside the
+    migration transaction, so it is atomic with the schema change.
+    """
+    rows = bind.execute(
+        sa.select(_users.c.id).where(_users.c.public_id.is_(None))
+    ).fetchall()
+    for (user_id,) in rows:
+        bind.execute(
+            _users.update()
+            .where(_users.c.id == user_id)
+            .values(public_id=uuid.uuid4())
+        )
+
+
+def upgrade() -> None:
+    """Add, backfill, and constrain users.public_id."""
+    bind = op.get_bind()
+    is_postgresql = bind.dialect.name == "postgresql"
+
+    # 1. Nullable, no default — catalogue-only on PostgreSQL, no rewrite.
+    op.add_column("users", sa.Column("public_id", sa.Uuid(), nullable=True))
+
+    # 2. Backfill. One statement on PostgreSQL; gen_random_uuid() is volatile,
+    #    so each row receives a distinct value.
+    if is_postgresql:
+        op.execute(
+            sa.text(
+                "UPDATE users SET public_id = gen_random_uuid() "
+                "WHERE public_id IS NULL"
+            )
+        )
+    else:
+        _backfill_public_ids(bind)
+
+    # 3. Uniqueness.
+    op.create_index("idx_users_public_id", "users", ["public_id"], unique=True)
+
+    # 4. Constrain, and hand the still-running previous release a default it
+    #    can rely on. SQLite supports neither statement.
+    if is_postgresql:
+        op.alter_column(
+            "users",
+            "public_id",
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        )
+
+
+def downgrade() -> None:
+    """Drop users.public_id.
+
+    Irreversible in effect: any relying party that has bound accounts to these
+    values loses them, and re-running the upgrade mints different UUIDs.
+    """
+    op.drop_index("idx_users_public_id", table_name="users")
+    op.drop_column("users", "public_id")

--- a/components/backend/alembic/versions/20260818_000100_add_user_pending_email.py
+++ b/components/backend/alembic/versions/20260818_000100_add_user_pending_email.py
@@ -1,0 +1,38 @@
+"""Add users.pending_email for verified email changes.
+
+``PUT /api/v1/users/me`` previously wrote ``users.email`` directly and left
+``is_email_verified`` untouched, so a user could move to an address they had
+never proven control of while the row still claimed the address was verified.
+That is harmless while the flag is only read internally to gate login, but it
+becomes an account-takeover vector the moment it is exported as an OIDC
+``email_verified`` claim: a relying party that links accounts by verified email
+would accept the new address as proven.
+
+``pending_email`` holds the requested address until an OTP sent to it verifies.
+Only then does ``email`` move and ``is_email_verified`` become true, so the flag
+never describes an unproven address. See ``EmailChangeService``.
+
+Revision ID: 023_user_pending_email
+Revises: 022_user_public_id
+Create Date: 2026-08-18 01:00:00.000000+00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "023_user_pending_email"
+down_revision: str | None = "022_user_public_id"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the nullable pending_email column."""
+    op.add_column("users", sa.Column("pending_email", sa.String(255), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop pending_email, discarding any in-flight email changes."""
+    op.drop_column("users", "pending_email")

--- a/components/backend/src/syfthub/api/endpoints/users.py
+++ b/components/backend/src/syfthub/api/endpoints/users.py
@@ -4,23 +4,41 @@ import logging
 from typing import Annotated, Union
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Request,
+    status,
+)
 
 from syfthub.auth.db_dependencies import (
     OwnershipChecker,
     get_current_active_user,
     require_admin,
 )
+from syfthub.core.client_ip import get_client_ip
 from syfthub.core.config import settings
-from syfthub.database.dependencies import get_user_service
+from syfthub.database.dependencies import (
+    get_email_change_service,
+    get_user_service,
+)
 from syfthub.schemas.auth import UserRole
 from syfthub.schemas.user import (
+    AdminEmailUpdateResponse,
+    EmailUpdate,
     PublicUserProfile,
     TunnelCredentialsResponse,
     User,
     UserResponse,
     UserUpdate,
 )
+from syfthub.services.email_change_service import (
+    ADMIN_SET_EMAIL_TEMPLATE,
+    EmailChangeService,
+)
+from syfthub.services.email_service import send_otp_email
 from syfthub.services.user_service import UserService
 
 logger = logging.getLogger(__name__)
@@ -178,7 +196,12 @@ def update_current_user_profile(
     current_user: Annotated[User, Depends(get_current_active_user)],
     user_service: Annotated[UserService, Depends(get_user_service)],
 ) -> UserResponse:
-    """Update current user's profile."""
+    """Update current user's profile.
+
+    Does not accept `email`; changing an address requires proving control of it.
+    Use `PUT /auth/me/email`. The response still reports `pending_email` so a
+    client can render an in-flight change from any profile read.
+    """
     return user_service.update_user_profile(current_user.id, user_data, current_user)
 
 
@@ -189,8 +212,63 @@ def update_user(
     current_user: Annotated[User, Depends(get_current_active_user)],
     user_service: Annotated[UserService, Depends(get_user_service)],
 ) -> UserResponse:
-    """Update a user by ID (admin or self only)."""
+    """Update a user by ID (admin or self only).
+
+    Does not accept `email` — see `PUT /users/{user_id}/email` for the admin
+    path, or `PUT /auth/me/email` for a user changing their own.
+    """
     return user_service.update_user_profile(user_id, user_data, current_user)
+
+
+@router.put("/{user_id}/email", response_model=AdminEmailUpdateResponse)
+def set_user_email(
+    user_id: int,
+    body: EmailUpdate,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    email_change_service: Annotated[
+        EmailChangeService, Depends(get_email_change_service)
+    ],
+) -> AdminEmailUpdateResponse:
+    """Set a user's email address outright (admin only).
+
+    Applies immediately and **clears `is_email_verified`**: an administrator has
+    not proven the new address belongs to its owner, so the verified flag must not
+    carry over from the old one.
+
+    A verification code is sent to the new address in the same request. That
+    email is what tells the user their address moved — the previous address stops
+    resolving, so without it the change would be silent. On their next sign-in
+    they are prompted for the code, and entering it both verifies the address and
+    completes the login; no session is needed at any point, which matters because
+    a never-verified user has none.
+
+    Refuses when the target is the caller: this path clears the verified flag and
+    login is refused while that is false, so an admin aiming it at their own
+    account would lock themselves out. Use `PUT /auth/me/email` for that, which
+    keeps the current address working until the new one is verified.
+    """
+    updated, address, code = email_change_service.admin_set_email(
+        user_id, body.email, current_user, requester_ip=get_client_ip(request)
+    )
+
+    if not code:
+        return AdminEmailUpdateResponse(
+            user=updated,
+            verification_sent_to=None,
+            message="Address unchanged; nothing was sent.",
+        )
+
+    background_tasks.add_task(send_otp_email, address, code, ADMIN_SET_EMAIL_TEMPLATE)
+    return AdminEmailUpdateResponse(
+        user=updated,
+        verification_sent_to=address,
+        message=(
+            f"Address set to {address} and a verification code sent there. "
+            "The user must enter it at next sign-in before they can log in again."
+        ),
+    )
 
 
 @router.patch("/{user_id}/deactivate", response_model=UserResponse)

--- a/components/backend/src/syfthub/auth/router.py
+++ b/components/backend/src/syfthub/auth/router.py
@@ -22,6 +22,7 @@ from syfthub.core.rate_limit import per_ip_rate_limit
 from syfthub.database.dependencies import (
     get_api_token_service,
     get_auth_service,
+    get_email_change_service,
     get_otp_service,
 )
 from syfthub.domain.exceptions import (
@@ -42,6 +43,7 @@ from syfthub.schemas.api_token import (
 from syfthub.schemas.auth import (
     AuthConfigResponse,
     AuthResponse,
+    EmailChangeVerifyRequest,
     GoogleAuthRequest,
     PasswordChange,
     PasswordResetConfirm,
@@ -53,9 +55,13 @@ from syfthub.schemas.auth import (
     UserRegister,
     VerifyOTPRequest,
 )
-from syfthub.schemas.user import User, UserResponse
+from syfthub.schemas.user import EmailUpdate, User, UserResponse
 from syfthub.services.api_token_service import APITokenService
 from syfthub.services.auth_service import AuthService
+from syfthub.services.email_change_service import (
+    EMAIL_CHANGE_PURPOSE,
+    EmailChangeService,
+)
 from syfthub.services.email_service import send_otp_email
 from syfthub.services.otp_service import OTPService
 
@@ -433,6 +439,127 @@ def confirm_password_reset(
         user_repo.set_email_verified(user.id)
 
     return {"message": "Password has been reset successfully."}
+
+
+# =============================================================================
+# Email Address (credential) — mirrors PUT /auth/me/password
+# =============================================================================
+# An email address is a credential here, not a profile field: it is a login
+# identifier, the password-reset delivery channel, and an identity claim that
+# relying parties consume. Changing one therefore requires proving control of
+# the new address, which a profile PUT cannot express — so it lives beside
+# /auth/me/password rather than on /users/me.
+
+
+@router.put(
+    "/me/email",
+    status_code=status.HTTP_202_ACCEPTED,
+    dependencies=[_auth_rate_limit],
+    responses={
+        202: {"description": "Change accepted; a code was sent to the new address"},
+        409: {"description": "Another account already holds that address"},
+        422: {"description": "That is already your address"},
+        429: {"description": "Too many codes requested"},
+    },
+)
+def request_email_change(
+    body: EmailUpdate,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    email_change_service: Annotated[
+        EmailChangeService, Depends(get_email_change_service)
+    ],
+) -> dict[str, str]:
+    """Start a verified change of the current user's email address.
+
+    Returns **202**, not 200: nothing has changed yet. The address is held as
+    ``pending_email`` and a code is sent to it; the account keeps its current,
+    verified address — and keeps signing in with it — until
+    ``POST /auth/me/email/verify`` succeeds. A mistyped address therefore cannot
+    lock anyone out.
+    """
+    code = email_change_service.request_change(
+        current_user, body.email, requester_ip=get_client_ip(request)
+    )
+    pending = body.email.strip().lower()
+    background_tasks.add_task(send_otp_email, pending, code, EMAIL_CHANGE_PURPOSE)
+    return {
+        "message": f"A verification code was sent to {pending}.",
+        "pending_email": pending,
+    }
+
+
+@router.post(
+    "/me/email/verify",
+    response_model=UserResponse,
+    dependencies=[_auth_rate_limit],
+    responses={
+        400: {"description": "Invalid or expired verification code"},
+        409: {"description": "Another account claimed the address meanwhile"},
+        422: {"description": "No email change is pending"},
+    },
+)
+def verify_email_change(
+    body: EmailChangeVerifyRequest,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    email_change_service: Annotated[
+        EmailChangeService, Depends(get_email_change_service)
+    ],
+) -> UserResponse:
+    """Confirm a pending email change with the code sent to the new address.
+
+    The address is not taken from the request body — it is read from the
+    authenticated user's ``pending_email``, so a caller can only ever confirm
+    their own in-flight change. A wrong code leaves the change pending so the
+    user can retry.
+    """
+    return email_change_service.confirm_change(current_user, body.code)
+
+
+@router.post(
+    "/me/email/resend",
+    status_code=status.HTTP_202_ACCEPTED,
+    dependencies=[_auth_rate_limit],
+    responses={
+        422: {"description": "No email change is pending"},
+        429: {"description": "Too many codes requested"},
+    },
+)
+def resend_email_change_code(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    email_change_service: Annotated[
+        EmailChangeService, Depends(get_email_change_service)
+    ],
+) -> dict[str, str]:
+    """Send a fresh code to the address already pending.
+
+    Unlike the registration resend, this need not guard against email
+    enumeration: the caller is authenticated and the address is one they
+    nominated themselves, so a 422 or 429 reveals nothing new to them.
+    """
+    pending, code = email_change_service.resend_code(
+        current_user, requester_ip=get_client_ip(request)
+    )
+    background_tasks.add_task(send_otp_email, pending, code, EMAIL_CHANGE_PURPOSE)
+    return {"message": f"A new verification code was sent to {pending}."}
+
+
+@router.delete("/me/email", status_code=status.HTTP_204_NO_CONTENT)
+def cancel_email_change(
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    email_change_service: Annotated[
+        EmailChangeService, Depends(get_email_change_service)
+    ],
+) -> None:
+    """Abandon a pending email change. Idempotent.
+
+    Deletes the *pending* change, never the address on the account — there is no
+    operation here that can leave a user without an email.
+    """
+    email_change_service.cancel_change(current_user)
 
 
 # =============================================================================

--- a/components/backend/src/syfthub/database/dependencies.py
+++ b/components/backend/src/syfthub/database/dependencies.py
@@ -19,6 +19,7 @@ from syfthub.services.admin_stats_service import AdminStatsService
 from syfthub.services.api_token_service import APITokenService
 from syfthub.services.auth_service import AuthService
 from syfthub.services.collective_service import CollectiveService
+from syfthub.services.email_change_service import EmailChangeService
 from syfthub.services.endpoint_service import EndpointService
 from syfthub.services.otp_service import OTPService
 from syfthub.services.user_service import UserService
@@ -102,6 +103,13 @@ def get_collective_service(
 ) -> CollectiveService:
     """Get CollectiveService dependency."""
     return CollectiveService(session)
+
+
+def get_email_change_service(
+    session: Annotated[Session, Depends(get_db_session)],
+) -> EmailChangeService:
+    """Get EmailChangeService dependency."""
+    return EmailChangeService(session)
 
 
 def get_otp_service(

--- a/components/backend/src/syfthub/domain/exceptions.py
+++ b/components/backend/src/syfthub/domain/exceptions.py
@@ -21,6 +21,25 @@ class ValidationError(DomainException):
         super().__init__(message, "VALIDATION_ERROR")
 
 
+class EmailNotUpdatableHereError(ValidationError):
+    """Raised when a profile update tries to set ``email``.
+
+    An email change needs proof that the new address belongs to the user, so it
+    cannot be a plain profile field. Subclasses ``ValidationError`` purely to
+    inherit its 422 status mapping, while reporting its own error code so a
+    client can branch on it and follow the pointer.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with a pointer to the endpoint that does support this."""
+        DomainException.__init__(
+            self,
+            "Email changes require verification of the new address. "
+            "Use PUT /api/v1/auth/me/email.",
+            "EMAIL_NOT_UPDATABLE_HERE",
+        )
+
+
 # ===========================================
 # IDENTITY PROVIDER (IdP) EXCEPTIONS
 # ===========================================

--- a/components/backend/src/syfthub/domain/exceptions.py
+++ b/components/backend/src/syfthub/domain/exceptions.py
@@ -32,12 +32,11 @@ class EmailNotUpdatableHereError(ValidationError):
 
     def __init__(self) -> None:
         """Initialize with a pointer to the endpoint that does support this."""
-        DomainException.__init__(
-            self,
+        super().__init__(
             "Email changes require verification of the new address. "
-            "Use PUT /api/v1/auth/me/email.",
-            "EMAIL_NOT_UPDATABLE_HERE",
+            "Use PUT /api/v1/auth/me/email."
         )
+        self.error_code = "EMAIL_NOT_UPDATABLE_HERE"
 
 
 # ===========================================

--- a/components/backend/src/syfthub/models/user.py
+++ b/components/backend/src/syfthub/models/user.py
@@ -1,9 +1,10 @@
 """User database model."""
 
+import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional
 
-from sqlalchemy import Boolean, DateTime, Index, String, Text
+from sqlalchemy import Boolean, DateTime, Index, String, Text, Uuid
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from syfthub.models.base import BaseModel, TimestampMixin
@@ -19,6 +20,21 @@ class UserModel(BaseModel, TimestampMixin):
 
     __tablename__ = "users"
 
+    # Stable, opaque public identifier. This — never ``id`` — is what leaves the
+    # backend as an external reference to a user (the OIDC ``sub`` claim), so
+    # relying parties never learn SyftHub's internal, sequential primary keys
+    # (see the privacy notes on EndpointPublicResponse). Immutable once assigned.
+    #
+    # The Python-side default covers ORM inserts, including SQLite in dev/tests.
+    # PostgreSQL additionally carries a ``gen_random_uuid()`` server default,
+    # applied in migration 022 rather than declared here: SQLite has no such
+    # function and would choke on it during ``create_all()``. The server default
+    # is what keeps signups working during a deploy, while the previous release
+    # — which knows nothing about this column — is still serving traffic.
+    public_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(), unique=True, nullable=False, default=uuid.uuid4
+    )
+
     # User fields
     username: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
@@ -29,6 +45,14 @@ class UserModel(BaseModel, TimestampMixin):
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     is_email_verified: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=True, server_default="1"
+    )
+
+    # Address the user has asked to move to but has not yet proven control of.
+    # ``email`` is only overwritten once an OTP sent to this address verifies, so
+    # ``is_email_verified`` never ends up describing an unproven address. See
+    # EmailChangeService.
+    pending_email: Mapped[Optional[str]] = mapped_column(
+        String(255), nullable=True, default=None
     )
 
     # OAuth fields

--- a/components/backend/src/syfthub/repositories/otp.py
+++ b/components/backend/src/syfthub/repositories/otp.py
@@ -92,8 +92,12 @@ class OTPRepository(BaseRepository[OTPCodeModel]):
                 .returning(OTPCodeModel.attempts)
             )
             result = self.session.execute(stmt)
-            self.session.commit()
+            # Consume RETURNING before committing. Reading the cursor after the
+            # commit leaves it open, which on SQLite keeps a lock on the table.
+            # If the commit then fails, the except branch rolls back and returns
+            # 0 exactly as before, so nothing is lost by reading first.
             new_count = result.scalar()
+            self.session.commit()
             return new_count if new_count is not None else 0
         except Exception:
             self.session.rollback()

--- a/components/backend/src/syfthub/repositories/user.py
+++ b/components/backend/src/syfthub/repositories/user.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional
 
 from sqlalchemy import case, func, or_, select
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from syfthub.models.user import UserModel
 from syfthub.repositories.base import BaseRepository
 from syfthub.schemas.auth import UserRole
 from syfthub.schemas.user import User, UserCreate, UserUpdate
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -133,8 +136,11 @@ class UserRepository(BaseRepository[UserModel]):
             # Update fields if provided
             if user_data.username is not None:
                 user_model.username = user_data.username.lower()
-            if user_data.email is not None:
-                user_model.email = user_data.email.lower()
+            # `email` is deliberately NOT written here. Overwriting it while
+            # leaving `is_email_verified` alone is what let a user hold a
+            # "verified" address they never proved control of. Email changes go
+            # through set_pending_email/confirm_pending_email (self-service, OTP
+            # proven) or set_email (admin, which clears the verified flag).
             if user_data.full_name is not None:
                 user_model.full_name = user_data.full_name
             if user_data.avatar_url is not None:
@@ -159,6 +165,104 @@ class UserRepository(BaseRepository[UserModel]):
             return User.model_validate(user_model)
         except Exception:
             self.session.rollback()
+            return None
+
+    def set_pending_email(self, user_id: int, email: str) -> bool:
+        """Record an email change awaiting verification.
+
+        Writes only ``pending_email``; ``email`` and ``is_email_verified`` are
+        left alone, so the user keeps their current verified address until they
+        prove control of the new one. Overwrites any earlier pending address.
+        """
+        try:
+            user_model = self.session.get(self.model, user_id)
+            if not user_model:
+                return False
+
+            user_model.pending_email = email.lower()
+            self.session.commit()
+            return True
+        except SQLAlchemyError as e:
+            self.session.rollback()
+            logger.error(f"Failed to set pending email for user {user_id}: {e}")
+            return False
+
+    def clear_pending_email(self, user_id: int) -> bool:
+        """Discard an in-flight email change."""
+        try:
+            user_model = self.session.get(self.model, user_id)
+            if not user_model:
+                return False
+
+            user_model.pending_email = None
+            self.session.commit()
+            return True
+        except SQLAlchemyError as e:
+            self.session.rollback()
+            logger.error(f"Failed to clear pending email for user {user_id}: {e}")
+            return False
+
+    def confirm_pending_email(self, user_id: int) -> Optional[User]:
+        """Promote ``pending_email`` to ``email`` and mark it verified.
+
+        Call only once the OTP sent to the pending address has been verified —
+        this method does no proving of its own, it records the outcome.
+
+        Returns None if there is no pending address, or if the address was
+        claimed by another account between the request and the confirmation
+        (the unique constraint on ``email`` is the arbiter, so two users racing
+        for the same address cannot both win).
+        """
+        try:
+            user_model = self.session.get(self.model, user_id)
+            if not user_model or not user_model.pending_email:
+                return None
+
+            user_model.email = user_model.pending_email
+            user_model.pending_email = None
+            user_model.is_email_verified = True
+            self.session.commit()
+            self.session.refresh(user_model)
+            return User.model_validate(user_model)
+        except IntegrityError as e:
+            self.session.rollback()
+            logger.warning(
+                f"Pending email for user {user_id} was claimed by another "
+                f"account before confirmation: {e}"
+            )
+            return None
+        except SQLAlchemyError as e:
+            self.session.rollback()
+            logger.error(f"Failed to confirm pending email for user {user_id}: {e}")
+            return None
+
+    def set_email(self, user_id: int, email: str, *, verified: bool) -> Optional[User]:
+        """Set a user's email address directly.
+
+        For the admin path only. ``verified`` is explicit and callers should pass
+        False: an administrator changing someone else's address has not proven
+        that the new owner controls it, so the flag must not carry over from the
+        old address. Also clears any pending change, which the new address
+        supersedes.
+        """
+        try:
+            user_model = self.session.get(self.model, user_id)
+            if not user_model:
+                return None
+
+            user_model.email = email.lower()
+            user_model.pending_email = None
+            user_model.is_email_verified = verified
+            self.session.commit()
+            self.session.refresh(user_model)
+            return User.model_validate(user_model)
+        except IntegrityError as e:
+            self.session.rollback()
+            logger.warning(f"Email {email} already in use (user {user_id}): {e}")
+            return None
+        except SQLAlchemyError as e:
+            self.session.rollback()
+            logger.error(f"Failed to set email for user {user_id}: {e}")
             return None
 
     def update_password(self, user_id: int, new_password_hash: str) -> bool:

--- a/components/backend/src/syfthub/schemas/auth.py
+++ b/components/backend/src/syfthub/schemas/auth.py
@@ -161,6 +161,23 @@ class VerifyOTPRequest(BaseModel):
     )
 
 
+class EmailChangeVerifyRequest(BaseModel):
+    """Request to confirm a pending email change with its OTP code.
+
+    The address is not carried in the body: it is read from the authenticated
+    user's ``pending_email``, so a caller can only ever confirm their own
+    in-flight change.
+    """
+
+    code: str = Field(
+        ...,
+        min_length=6,
+        max_length=6,
+        pattern=r"^\d{6}$",
+        description="6-digit OTP code sent to the pending address",
+    )
+
+
 class ResendOTPRequest(BaseModel):
     """Request to resend an OTP code."""
 

--- a/components/backend/src/syfthub/schemas/user.py
+++ b/components/backend/src/syfthub/schemas/user.py
@@ -6,6 +6,7 @@ import re
 from datetime import datetime, timezone
 from typing import Optional
 from urllib.parse import urlparse
+from uuid import UUID, uuid4
 
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
@@ -43,7 +44,17 @@ class UserCreate(UserBase):
 class User(UserBase):
     """User model."""
 
-    id: int = Field(..., description="User's unique identifier")
+    id: int = Field(
+        ..., description="User's internal identifier — never exposed externally"
+    )
+    # Stable, opaque external identifier. Backs the OIDC ``sub`` claim; ``id``
+    # must never be used for that. ``default_factory`` keeps this constructible
+    # without an explicit value (tests, in-memory fixtures) while
+    # ``model_validate`` picks up the real column for DB-backed users.
+    public_id: UUID = Field(
+        default_factory=uuid4,
+        description="Stable, opaque public identifier for external references",
+    )
     avatar_url: Optional[str] = Field(
         None, max_length=500, description="URL to user's avatar image"
     )
@@ -91,6 +102,10 @@ class User(UserBase):
     )
     is_email_public: bool = Field(
         False, description="Whether the user's email is visible on their public profile"
+    )
+    # Address requested but not yet proven; see EmailChangeService.
+    pending_email: Optional[EmailStr] = Field(
+        None, description="Email change awaiting OTP verification, if any"
     )
 
     model_config = {"from_attributes": True}
@@ -140,8 +155,43 @@ class UserResponse(BaseModel):
     is_email_public: bool = Field(
         False, description="Whether the user's email is visible on their public profile"
     )
+    # Non-null while an email change is awaiting OTP verification. `email` still
+    # holds the current, verified address until the code is confirmed.
+    pending_email: Optional[EmailStr] = Field(
+        None, description="Email change awaiting OTP verification, if any"
+    )
 
     model_config = {"from_attributes": True}
+
+
+class EmailUpdate(BaseModel):
+    """A new email address.
+
+    Used by ``PUT /auth/me/email`` to start a verified change, and by
+    ``PUT /users/{user_id}/email`` for an administrator to set one outright.
+    """
+
+    email: EmailStr = Field(..., description="The new email address")
+
+
+class AdminEmailUpdateResponse(BaseModel):
+    """Result of an administrator setting a user's email address.
+
+    Reports the consequence alongside the user, because the consequence is not
+    obvious from the record: the address is now unverified, which blocks the
+    user's password login until they enter the code sent to
+    ``verification_sent_to``.
+    """
+
+    user: UserResponse = Field(..., description="The updated user")
+    verification_sent_to: Optional[EmailStr] = Field(
+        None,
+        description=(
+            "Address a verification code was sent to, or null when the request "
+            "did not change anything"
+        ),
+    )
+    message: str = Field(..., description="Human-readable summary for the admin")
 
 
 class UserUpdate(BaseModel):
@@ -150,7 +200,20 @@ class UserUpdate(BaseModel):
     username: Optional[str] = Field(
         None, min_length=3, max_length=50, description="Unique username"
     )
-    email: Optional[EmailStr] = Field(None, description="User's email address")
+    # Kept in the schema, but always rejected, so the field is discoverable in
+    # OpenAPI with a pointer rather than being silently ignored as an unknown
+    # key. Changing an address requires proving control of it, which a profile
+    # PUT cannot express: use PUT /auth/me/email (self) or
+    # PUT /users/{user_id}/email (admin).
+    email: Optional[EmailStr] = Field(
+        None,
+        description=(
+            "Not updatable here — rejected with 422. Email changes require "
+            "verification: use PUT /api/v1/auth/me/email. Admins use "
+            "PUT /api/v1/users/{user_id}/email."
+        ),
+        deprecated=True,
+    )
     full_name: Optional[str] = Field(
         None, min_length=1, max_length=100, description="User's full name"
     )

--- a/components/backend/src/syfthub/services/email_change_service.py
+++ b/components/backend/src/syfthub/services/email_change_service.py
@@ -1,0 +1,251 @@
+"""Verified email-change business logic.
+
+An email address is an identity claim, not a profile field. Once SyftHub asserts
+it to a third party — as the OIDC ``email`` claim alongside ``email_verified`` —
+a relying party may link accounts by it, so SyftHub must only ever present an
+address whose owner has actually proven control of it.
+
+That rules out writing ``users.email`` on request. Instead the requested address
+is parked in ``users.pending_email`` and an OTP is sent to it; ``email`` moves
+only when that code is verified. Until then the user keeps their current,
+genuinely verified address, which means:
+
+- ``is_email_verified`` never describes an unproven address, and
+- a typo'd address cannot lock anyone out, because their working address and
+  login are untouched while the change is pending.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from syfthub.domain.exceptions import (
+    ConflictError,
+    NotFoundError,
+    PermissionDeniedError,
+    ValidationError,
+)
+from syfthub.repositories.user import UserRepository
+from syfthub.schemas.user import User, UserResponse
+from syfthub.services.base import BaseService
+from syfthub.services.otp_service import OTPService
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# OTP purpose discriminator. `otp_codes.purpose` is a free String(20), so this
+# needs no migration; `send_otp_email` resolves subjects via SUBJECTS.get() with
+# a fallback, so an unknown purpose degrades to a generic subject line rather
+# than raising.
+EMAIL_CHANGE_PURPOSE = "email_change"
+
+# The purpose used for a code minted by an administrator's change.
+#
+# Deliberately "registration", not EMAIL_CHANGE_PURPOSE. A user whose address an
+# admin just changed may have no session at all — a never-verified signup never
+# receives tokens — so they must be able to finish without one. The only
+# session-less completion endpoints are POST /auth/register/{resend-otp,verify-otp},
+# and those accept the "registration" purpose exclusively. Using it means the
+# user completes with the machinery that already exists, and verify-otp hands
+# back tokens, so confirming the code *is* their login.
+ADMIN_SET_PURPOSE = "registration"
+
+# Copy variant for the email that carries an admin-set code.
+#
+# Separate from ADMIN_SET_PURPOSE because the stored OTP purpose and the wording
+# of the message are independent: `send_otp_email` only renders, it never reads
+# the OTP store. Reusing "registration" for the copy would tell a long-standing
+# user to "complete your SyftHub registration", which is both confusing and
+# fails to explain that their address was changed by an administrator.
+ADMIN_SET_EMAIL_TEMPLATE = "admin_email_change"
+
+
+class EmailChangeService(BaseService):
+    """Drives the request → verify → swap lifecycle of an email change."""
+
+    def __init__(self, session: Session):
+        """Initialize the email-change service."""
+        super().__init__(session)
+        self.user_repository = UserRepository(session)
+        self.otp_service = OTPService(session)
+
+    def request_change(
+        self,
+        current_user: User,
+        new_email: str,
+        *,
+        requester_ip: Optional[str] = None,
+    ) -> str:
+        """Park a requested address and mint the OTP proving it.
+
+        Returns the plain OTP code so the caller can hand delivery to a
+        background task — this service does not send mail itself, keeping it
+        free of any transport dependency.
+
+        Raises:
+            ValidationError: If the address matches the user's current one.
+            ConflictError: If another account already holds the address.
+            OTPRateLimitedError: If too many codes were requested recently.
+            NotFoundError: If the user no longer exists.
+        """
+        normalized = new_email.strip().lower()
+
+        if normalized == current_user.email.lower():
+            raise ValidationError("That is already your email address")
+
+        # Fail early on a taken address rather than letting the user complete an
+        # OTP round-trip that can only fail at the unique constraint. This is a
+        # courtesy check, not the guarantee — confirm_pending_email re-checks
+        # under the constraint, which is what actually settles a race.
+        existing = self.user_repository.get_by_email(normalized)
+        if existing and existing.id != current_user.id:
+            raise ConflictError("user", "email")
+
+        if not self.user_repository.set_pending_email(current_user.id, normalized):
+            raise NotFoundError("User")
+
+        code = self.otp_service.generate_otp(
+            normalized, EMAIL_CHANGE_PURPOSE, requester_ip=requester_ip
+        )
+        logger.info(
+            "Email change requested for user %s → %s (pending verification)",
+            current_user.id,
+            normalized,
+        )
+        return code
+
+    def resend_code(
+        self, current_user: User, *, requester_ip: Optional[str] = None
+    ) -> tuple[str, str]:
+        """Mint a fresh OTP for the address already pending.
+
+        Returns ``(pending_email, code)``.
+
+        Raises:
+            ValidationError: If no change is pending.
+            OTPRateLimitedError: If too many codes were requested recently.
+        """
+        pending = self._require_pending(current_user)
+        code = self.otp_service.generate_otp(
+            pending, EMAIL_CHANGE_PURPOSE, requester_ip=requester_ip
+        )
+        return pending, code
+
+    def confirm_change(self, current_user: User, code: str) -> UserResponse:
+        """Verify the OTP and promote the pending address.
+
+        Raises:
+            ValidationError: If no change is pending.
+            InvalidOTPError: If the code is wrong or expired.
+            OTPMaxAttemptsError: If too many attempts were made.
+            ConflictError: If another account claimed the address meanwhile.
+        """
+        pending = self._require_pending(current_user)
+
+        # Verify before mutating anything: a failed code must leave the pending
+        # change intact so the user can retry.
+        self.otp_service.verify_otp(pending, code, EMAIL_CHANGE_PURPOSE)
+
+        updated = self.user_repository.confirm_pending_email(current_user.id)
+        if updated is None:
+            raise ConflictError("user", "email")
+
+        logger.info("Email change confirmed for user %s → %s", current_user.id, pending)
+        return UserResponse.model_validate(updated)
+
+    def cancel_change(self, current_user: User) -> None:
+        """Discard an in-flight change. Idempotent."""
+        self.user_repository.clear_pending_email(current_user.id)
+
+    def _require_pending(self, current_user: User) -> str:
+        """Return the user's pending address, re-read from the database.
+
+        ``current_user`` comes from an auth dependency and may predate a change
+        made in this request, so the pending address is re-read rather than
+        trusted from the passed-in snapshot.
+        """
+        user = self.user_repository.get_by_id(current_user.id)
+        if user is None:
+            raise NotFoundError("User")
+        if not user.pending_email:
+            raise ValidationError("No email change is pending")
+        return user.pending_email
+
+    def admin_set_email(
+        self,
+        target_user_id: int,
+        new_email: str,
+        actor: User,
+        *,
+        requester_ip: Optional[str] = None,
+    ) -> tuple[UserResponse, str, str]:
+        """Set another user's address outright, and mint the code to prove it.
+
+        Admin-only, and deliberately different from ``request_change``: it
+        applies at once rather than parking the address. An administrator cannot
+        prove the new address belongs to its owner, so ``is_email_verified`` is
+        cleared rather than carried over from the old address.
+
+        The code is minted here rather than left to the user to request, because
+        otherwise the change is silent: the previous address stops resolving, and
+        the user is given no signal at all. The email carrying this code is what
+        tells them their address moved and what it moved to.
+
+        Returns ``(user, pending_verification_address, code)`` so the caller can
+        hand delivery to a background task; this service sends no mail itself.
+
+        Raises:
+            PermissionDeniedError: If the actor is not an admin.
+            ValidationError: If the actor is targeting their own account.
+            NotFoundError: If the target user does not exist.
+            ConflictError: If another account already holds the address.
+        """
+        if actor.role != "admin":
+            raise PermissionDeniedError(
+                "Admin role required to change another user's email"
+            )
+
+        # Prevent self-lockout, mirroring the self-deactivation guard in
+        # UserService. This path clears `is_email_verified`, and login is refused
+        # while that is false, so an admin aiming it at their own account would
+        # lock themselves out. PUT /auth/me/email keeps the current address
+        # working throughout, so route them there instead.
+        if actor.id == target_user_id:
+            raise ValidationError(
+                "Use PUT /api/v1/auth/me/email to change your own address — it "
+                "keeps your current address working until the new one is verified"
+            )
+
+        target = self.user_repository.get_by_id(target_user_id)
+        if target is None:
+            raise NotFoundError("User")
+
+        normalized = new_email.strip().lower()
+        if normalized == target.email.lower():
+            # Not a change. Returning the existing state keeps the endpoint
+            # idempotent, and mints no code for an address already verified.
+            return UserResponse.model_validate(target), normalized, ""
+
+        existing = self.user_repository.get_by_email(normalized)
+        if existing and existing.id != target_user_id:
+            raise ConflictError("user", "email")
+
+        updated = self.user_repository.set_email(
+            target_user_id, normalized, verified=False
+        )
+        if updated is None:
+            raise ConflictError("user", "email")
+
+        code = self.otp_service.generate_otp(
+            normalized, ADMIN_SET_PURPOSE, requester_ip=requester_ip
+        )
+        logger.info(
+            "Admin %s set the email of user %s to %s (verification pending)",
+            actor.id,
+            target_user_id,
+            normalized,
+        )
+        return UserResponse.model_validate(updated), normalized, code

--- a/components/backend/src/syfthub/services/email_service.py
+++ b/components/backend/src/syfthub/services/email_service.py
@@ -28,6 +28,8 @@ _jinja_env = Environment(
 SUBJECTS = {
     "registration": "Your SyftHub verification code",
     "password_reset": "Your SyftHub password reset code",
+    "email_change": "Confirm your new SyftHub email address",
+    "admin_email_change": "Your SyftHub email address was changed",
 }
 
 _otp_template = _jinja_env.get_template("otp_email.html")
@@ -60,7 +62,9 @@ async def send_otp_email(to_email: str, code: str, purpose: str) -> None:
     Args:
         to_email: Recipient email address.
         code: The plain-text 6-digit OTP code.
-        purpose: "registration" or "password_reset".
+        purpose: Selects subject line and body copy — "registration",
+            "password_reset", "email_change", or "admin_email_change".
+            Independent of the purpose an OTP is *stored* under.
     """
     if not settings.smtp_configured:
         logger.warning("Email not configured — skipping OTP email to %s", to_email)

--- a/components/backend/src/syfthub/services/user_service.py
+++ b/components/backend/src/syfthub/services/user_service.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, List, Optional
 
 from syfthub.domain.exceptions import (
     ConflictError,
+    EmailNotUpdatableHereError,
     NotFoundError,
     PermissionDeniedError,
     ValidationError,
@@ -100,11 +101,19 @@ class UserService(BaseService):
             if existing_user and existing_user.id != user_id:
                 raise ConflictError("user", "username")
 
-        # Validate email uniqueness if being updated
-        if user_data.email and self.user_repository.email_exists(user_data.email):
-            existing_user = self.user_repository.get_by_email(user_data.email)
-            if existing_user and existing_user.id != user_id:
-                raise ConflictError("user", "email")
+        # A profile PUT cannot *change* an address: that would either apply an
+        # unproven one or accept a field it silently declines to write. Reject a
+        # change and point at the endpoints that can perform it.
+        #
+        # An address equal to the one already on the account is not a change, so
+        # it is allowed through as a no-op. Clients that round-trip a whole user
+        # object would otherwise be unable to update any field at all.
+        if user_data.email is not None:
+            target = self.user_repository.get_by_id(user_id)
+            if target is None:
+                raise NotFoundError("User")
+            if user_data.email.strip().lower() != target.email.lower():
+                raise EmailNotUpdatableHereError()
 
         # Update user
         updated_user = self.user_repository.update_user(user_id, user_data)

--- a/components/backend/src/syfthub/templates/otp_email.html
+++ b/components/backend/src/syfthub/templates/otp_email.html
@@ -22,6 +22,10 @@
                             <p style="margin:0 0 16px;color:#3f3f46;font-size:15px;line-height:1.6;">
                                 {% if purpose == "registration" %}
                                     Use the code below to verify your email and complete your SyftHub registration.
+                                {% elif purpose == "admin_email_change" %}
+                                    An administrator changed the email address on your SyftHub account to this one. Enter the code below the next time you sign in to confirm it — you'll need to do this before you can sign in again, and your previous address will no longer work.
+                                {% elif purpose == "email_change" %}
+                                    Use the code below to confirm this address as your new SyftHub email. Your account keeps its current address until you do.
                                 {% else %}
                                     Use the code below to reset your SyftHub password.
                                 {% endif %}

--- a/components/backend/tests/test_auth_users.py
+++ b/components/backend/tests/test_auth_users.py
@@ -477,18 +477,38 @@ def test_update_profile_duplicate_username(
     assert detail["field"] == "username"
 
 
-def test_update_profile_duplicate_email(
+def test_update_profile_cannot_change_email(
     client: TestClient, regular_user_token: str, admin_user_token: str
 ) -> None:
-    """Test that updating profile with existing email fails."""
-    # Regular user tries to change email to admin's email
+    """A profile PUT cannot change an email address, taken or not.
+
+    Changing an address requires proving control of it, which this endpoint has
+    no way to do — so it rejects the attempt and points at the endpoint that
+    can. Whether the target address is already in use is beside the point here;
+    that is checked by PUT /auth/me/email (see test_email_change_endpoints.py).
+    """
     headers = {"Authorization": f"Bearer {regular_user_token}"}
-    update_data = {"email": "admin@example.com"}  # This email exists
-    response = client.put("/api/v1/users/me", json=update_data, headers=headers)
-    assert response.status_code == 409
+    response = client.put(
+        "/api/v1/users/me", json={"email": "admin@example.com"}, headers=headers
+    )
+    assert response.status_code == 422
     detail = response.json()["detail"]
-    assert detail["code"] == "CONFLICT"
-    assert detail["field"] == "email"
+    assert detail["code"] == "EMAIL_NOT_UPDATABLE_HERE"
+    assert "/auth/me/email" in detail["message"]
+
+
+def test_update_profile_rejects_unused_email_too(
+    client: TestClient, regular_user_token: str
+) -> None:
+    """The rejection is about the operation, not about availability."""
+    headers = {"Authorization": f"Bearer {regular_user_token}"}
+    response = client.put(
+        "/api/v1/users/me",
+        json={"email": "nobody-has-this@example.com"},
+        headers=headers,
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "EMAIL_NOT_UPDATABLE_HERE"
 
 
 def test_update_profile_with_own_username(
@@ -508,7 +528,12 @@ def test_update_profile_with_own_username(
 def test_update_profile_with_own_email(
     client: TestClient, regular_user_token: str
 ) -> None:
-    """Test that updating profile with own email is allowed."""
+    """Echoing the address already on the account is not a change.
+
+    Clients that round-trip a whole user object must still be able to update
+    other fields, so an unchanged `email` passes through as a no-op rather than
+    being rejected alongside real changes.
+    """
     headers = {"Authorization": f"Bearer {regular_user_token}"}
     # Update with current email should not fail
     update_data = {"email": "regular@example.com", "full_name": "Updated Name"}

--- a/components/backend/tests/test_email_change_endpoints.py
+++ b/components/backend/tests/test_email_change_endpoints.py
@@ -310,10 +310,8 @@ class TestCancellingAChange:
         token = _register(client, "alice")
 
         for _ in range(2):
-            assert (
-                client.delete("/api/v1/auth/me/email", headers=_auth(token)).status_code
-                == 204
-            )
+            response = client.delete("/api/v1/auth/me/email", headers=_auth(token))
+            assert response.status_code == 204
 
 
 class TestResendingTheCode:

--- a/components/backend/tests/test_email_change_endpoints.py
+++ b/components/backend/tests/test_email_change_endpoints.py
@@ -1,0 +1,445 @@
+"""End-to-end tests for the verified email-change flow.
+
+An email address is a credential here, so changing one lives beside
+``PUT /auth/me/password`` rather than on ``PUT /users/me``. These tests pin both
+halves of that contract: the profile endpoint refuses to change an address, and
+``/auth/me/email`` only moves it once a code sent to the new address is verified.
+"""
+
+from __future__ import annotations
+
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from syfthub.auth.security import token_blacklist
+from syfthub.main import app
+from syfthub.services.email_change_service import EMAIL_CHANGE_PURPOSE
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    """Test client against a clean database."""
+    from syfthub.database.connection import create_tables, drop_tables
+
+    drop_tables()
+    create_tables()
+    yield TestClient(app)
+    drop_tables()
+
+
+@pytest.fixture(autouse=True)
+def reset_auth_data() -> None:
+    """Clear the token blacklist between tests."""
+    token_blacklist.clear()
+
+
+def _register(client: TestClient, username: str, *, role: str | None = None) -> str:
+    """Register a user and return their access token."""
+    response = client.post(
+        "/api/v1/auth/register",
+        json={
+            "username": username,
+            "email": f"{username}@example.com",
+            "full_name": f"{username.title()} User",
+            "password": "testpass123",
+        },
+    )
+    assert response.status_code == 201, response.text
+
+    if role == "admin":
+        from syfthub.database.connection import SessionLocal
+        from syfthub.models.user import UserModel
+
+        session = SessionLocal()
+        try:
+            user = session.query(UserModel).filter(UserModel.username == username).one()
+            user.role = "admin"
+            session.commit()
+        finally:
+            session.close()
+
+    return response.json()["access_token"]
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _user_id(client: TestClient, token: str) -> int:
+    return int(client.get("/api/v1/auth/me", headers=_auth(token)).json()["id"])
+
+
+def _registration_code(email: str) -> str:
+    """Recover the registration-purpose code minted by an admin's change."""
+    return _code_for(email, "registration")
+
+
+def _pending_code(pending_email: str) -> str:
+    """Recover the OTP minted for a pending address.
+
+    The code only ever leaves by email, so a test has to reach into the OTP
+    store. Codes are hashed at rest, so brute-force the 6-digit space against
+    the stored hash rather than trying to read a plaintext that does not exist.
+    """
+
+    return _code_for(pending_email, EMAIL_CHANGE_PURPOSE)
+
+
+def _code_for(email: str, purpose: str) -> str:
+    """Brute-force a hashed OTP back out of the store for the given purpose."""
+    from syfthub.database.connection import SessionLocal
+    from syfthub.repositories.otp import OTPRepository
+    from syfthub.services.otp_service import _hash_code
+
+    session = SessionLocal()
+    try:
+        otp = OTPRepository(session).get_active_otp(email, purpose)
+        assert otp is not None, f"no active {purpose} OTP for {email}"
+        for candidate in range(1_000_000):
+            code = f"{candidate:06d}"
+            if _hash_code(code) == otp.code_hash:
+                return code
+        raise AssertionError("could not recover the OTP code")
+    finally:
+        session.close()
+
+
+class TestProfileEndpointRefusesEmailChanges:
+    """PUT /users/me cannot change an address, and says where to go instead."""
+
+    def test_a_different_address_is_rejected(self, client: TestClient) -> None:
+        token = _register(client, "alice")
+
+        response = client.put(
+            "/api/v1/users/me",
+            json={"email": "new@example.com"},
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert detail["code"] == "EMAIL_NOT_UPDATABLE_HERE"
+        assert "/auth/me/email" in detail["message"]
+
+    def test_nothing_changes_on_the_account(self, client: TestClient) -> None:
+        token = _register(client, "alice")
+        client.put(
+            "/api/v1/users/me",
+            json={"email": "new@example.com"},
+            headers=_auth(token),
+        )
+
+        me = client.get("/api/v1/auth/me", headers=_auth(token)).json()
+        assert me["email"] == "alice@example.com"
+        assert me["pending_email"] is None
+        assert me["is_email_verified"] is True
+
+    def test_the_unchanged_address_passes_through(self, client: TestClient) -> None:
+        """A client round-tripping a whole user object must still work."""
+        token = _register(client, "alice")
+
+        response = client.put(
+            "/api/v1/users/me",
+            json={"email": "ALICE@example.com", "full_name": "Alice Renamed"},
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 200
+        assert response.json()["full_name"] == "Alice Renamed"
+
+
+class TestRequestingAChange:
+    """PUT /auth/me/email parks the address; it does not apply it."""
+
+    def test_returns_202_and_does_not_move_the_address(
+        self, client: TestClient
+    ) -> None:
+        token = _register(client, "alice")
+
+        response = client.put(
+            "/api/v1/auth/me/email",
+            json={"email": "New@Example.com"},
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 202, response.text
+        assert response.json()["pending_email"] == "new@example.com"
+
+        me = client.get("/api/v1/auth/me", headers=_auth(token)).json()
+        assert me["email"] == "alice@example.com"
+        assert me["pending_email"] == "new@example.com"
+        assert me["is_email_verified"] is True
+
+    def test_pending_survives_a_fresh_request(self, client: TestClient) -> None:
+        """Pending is server state, which is what lets a second device see it."""
+        token = _register(client, "alice")
+        client.put(
+            "/api/v1/auth/me/email",
+            json={"email": "new@example.com"},
+            headers=_auth(token),
+        )
+
+        me = client.get("/api/v1/auth/me", headers=_auth(token)).json()
+        assert me["pending_email"] == "new@example.com"
+
+    def test_the_current_address_is_refused(self, client: TestClient) -> None:
+        token = _register(client, "alice")
+
+        response = client.put(
+            "/api/v1/auth/me/email",
+            json={"email": "alice@example.com"},
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 422
+
+    def test_an_address_held_by_another_account_is_refused(
+        self, client: TestClient
+    ) -> None:
+        _register(client, "bob")
+        token = _register(client, "alice")
+
+        response = client.put(
+            "/api/v1/auth/me/email",
+            json={"email": "bob@example.com"},
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 409
+
+    def test_requires_authentication(self, client: TestClient) -> None:
+        response = client.put(
+            "/api/v1/auth/me/email", json={"email": "new@example.com"}
+        )
+        assert response.status_code in (401, 403)
+
+
+class TestConfirmingAChange:
+    """The address moves only once the code sent to it is verified."""
+
+    def test_verifying_the_code_moves_the_address(self, client: TestClient) -> None:
+        token = _register(client, "alice")
+        client.put(
+            "/api/v1/auth/me/email",
+            json={"email": "new@example.com"},
+            headers=_auth(token),
+        )
+
+        response = client.post(
+            "/api/v1/auth/me/email/verify",
+            json={"code": _pending_code("new@example.com")},
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["email"] == "new@example.com"
+        assert body["pending_email"] is None
+        assert body["is_email_verified"] is True
+
+    def test_a_wrong_code_leaves_everything_alone(self, client: TestClient) -> None:
+        token = _register(client, "alice")
+        client.put(
+            "/api/v1/auth/me/email",
+            json={"email": "new@example.com"},
+            headers=_auth(token),
+        )
+
+        response = client.post(
+            "/api/v1/auth/me/email/verify",
+            json={"code": "000000"},
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 400
+        me = client.get("/api/v1/auth/me", headers=_auth(token)).json()
+        assert me["email"] == "alice@example.com"
+        assert me["pending_email"] == "new@example.com"
+
+    def test_verifying_without_a_pending_change_is_rejected(
+        self, client: TestClient
+    ) -> None:
+        token = _register(client, "alice")
+
+        response = client.post(
+            "/api/v1/auth/me/email/verify",
+            json={"code": "123456"},
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 422
+
+    def test_requires_authentication(self, client: TestClient) -> None:
+        response = client.post("/api/v1/auth/me/email/verify", json={"code": "123456"})
+        assert response.status_code in (401, 403)
+
+    def test_malformed_codes_are_rejected_by_validation(
+        self, client: TestClient
+    ) -> None:
+        token = _register(client, "alice")
+
+        response = client.post(
+            "/api/v1/auth/me/email/verify",
+            json={"code": "abc"},
+            headers=_auth(token),
+        )
+        assert response.status_code == 422
+
+
+class TestCancellingAChange:
+    """DELETE /auth/me/email abandons the pending change, never the address."""
+
+    def test_clears_the_pending_address_only(self, client: TestClient) -> None:
+        token = _register(client, "alice")
+        client.put(
+            "/api/v1/auth/me/email",
+            json={"email": "new@example.com"},
+            headers=_auth(token),
+        )
+
+        response = client.delete("/api/v1/auth/me/email", headers=_auth(token))
+
+        assert response.status_code == 204
+        me = client.get("/api/v1/auth/me", headers=_auth(token)).json()
+        assert me["pending_email"] is None
+        assert me["email"] == "alice@example.com"
+
+    def test_is_idempotent(self, client: TestClient) -> None:
+        token = _register(client, "alice")
+
+        for _ in range(2):
+            assert (
+                client.delete("/api/v1/auth/me/email", headers=_auth(token)).status_code
+                == 204
+            )
+
+
+class TestResendingTheCode:
+    """POST /auth/me/email/resend mints a fresh code for the pending address."""
+
+    def test_accepted_when_a_change_is_pending(self, client: TestClient) -> None:
+        token = _register(client, "alice")
+        client.put(
+            "/api/v1/auth/me/email",
+            json={"email": "new@example.com"},
+            headers=_auth(token),
+        )
+
+        response = client.post("/api/v1/auth/me/email/resend", headers=_auth(token))
+
+        assert response.status_code == 202
+
+    def test_rejected_when_nothing_is_pending(self, client: TestClient) -> None:
+        token = _register(client, "alice")
+
+        response = client.post("/api/v1/auth/me/email/resend", headers=_auth(token))
+
+        assert response.status_code == 422
+
+
+class TestAdminSetsAnEmail:
+    """PUT /users/{id}/email applies immediately and clears the verified flag."""
+
+    def test_admin_can_set_another_users_email(self, client: TestClient) -> None:
+        alice_token = _register(client, "alice")
+        alice_id = _user_id(client, alice_token)
+        admin_token = _register(client, "root", role="admin")
+
+        response = client.put(
+            f"/api/v1/users/{alice_id}/email",
+            json={"email": "Moved@Example.com"},
+            headers=_auth(admin_token),
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["user"]["email"] == "moved@example.com"
+        # The admin proved nothing about the new address, so it is not verified.
+        assert body["user"]["is_email_verified"] is False
+        # A code goes out in the same request; otherwise the change is silent,
+        # because the previous address stops resolving.
+        assert body["verification_sent_to"] == "moved@example.com"
+
+    def test_the_user_can_then_verify_and_log_in_without_a_session(
+        self, client: TestClient
+    ) -> None:
+        """The whole point of the registration purpose: no session is needed."""
+        alice_token = _register(client, "alice")
+        alice_id = _user_id(client, alice_token)
+        admin_token = _register(client, "root", role="admin")
+        client.put(
+            f"/api/v1/users/{alice_id}/email",
+            json={"email": "moved@example.com"},
+            headers=_auth(admin_token),
+        )
+
+        # No Authorization header on either call.
+        code = _registration_code("moved@example.com")
+        response = client.post(
+            "/api/v1/auth/register/verify-otp",
+            json={"email": "moved@example.com", "code": code},
+        )
+
+        assert response.status_code == 200, response.text
+        # Verifying hands back tokens, so entering the code *is* the login.
+        assert response.json()["access_token"]
+        me = client.get("/api/v1/auth/me", headers=_auth(alice_token)).json()
+        assert me["email"] == "moved@example.com"
+        assert me["is_email_verified"] is True
+
+    def test_a_non_admin_is_refused(self, client: TestClient) -> None:
+        alice_token = _register(client, "alice")
+        alice_id = _user_id(client, alice_token)
+        bob_token = _register(client, "bob")
+
+        response = client.put(
+            f"/api/v1/users/{alice_id}/email",
+            json={"email": "hijack@example.com"},
+            headers=_auth(bob_token),
+        )
+
+        assert response.status_code == 403
+        me = client.get("/api/v1/auth/me", headers=_auth(alice_token)).json()
+        assert me["email"] == "alice@example.com"
+        assert me["is_email_verified"] is True
+
+    def test_an_admin_cannot_target_their_own_account(self, client: TestClient) -> None:
+        """This path clears the verified flag, and login is refused while that is
+        false — so aiming it at yourself is self-lockout. Mirrors the existing
+        guard against self-deactivation."""
+        admin_token = _register(client, "root", role="admin")
+        admin_id = _user_id(client, admin_token)
+
+        response = client.put(
+            f"/api/v1/users/{admin_id}/email",
+            json={"email": "newroot@example.com"},
+            headers=_auth(admin_token),
+        )
+
+        assert response.status_code == 422
+        assert "/auth/me/email" in response.json()["detail"]["message"]
+        me = client.get("/api/v1/auth/me", headers=_auth(admin_token)).json()
+        assert me["email"] == "root@example.com"
+        assert me["is_email_verified"] is True
+
+    def test_it_supersedes_a_users_own_pending_change(self, client: TestClient) -> None:
+        alice_token = _register(client, "alice")
+        alice_id = _user_id(client, alice_token)
+        admin_token = _register(client, "root", role="admin")
+        client.put(
+            "/api/v1/auth/me/email",
+            json={"email": "self-chosen@example.com"},
+            headers=_auth(alice_token),
+        )
+
+        client.put(
+            f"/api/v1/users/{alice_id}/email",
+            json={"email": "admin-chosen@example.com"},
+            headers=_auth(admin_token),
+        )
+
+        me = client.get("/api/v1/auth/me", headers=_auth(alice_token)).json()
+        assert me["email"] == "admin-chosen@example.com"
+        assert me["pending_email"] is None

--- a/components/backend/tests/test_services/test_email_change_service.py
+++ b/components/backend/tests/test_services/test_email_change_service.py
@@ -1,0 +1,474 @@
+"""Tests for EmailChangeService and the public_id external identifier.
+
+The property under test throughout is the invariant that made this work
+necessary: ``is_email_verified`` must never describe an address whose owner has
+not proven control of it, because that flag is about to be exported as an OIDC
+``email_verified`` claim that relying parties link accounts by.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy.orm import Session
+
+from syfthub.domain.exceptions import (
+    ConflictError,
+    InvalidOTPError,
+    NotFoundError,
+    PermissionDeniedError,
+    ValidationError,
+)
+from syfthub.models.user import UserModel
+from syfthub.repositories.user import UserRepository
+from syfthub.schemas.user import User, UserUpdate
+from syfthub.services.email_change_service import (
+    ADMIN_SET_PURPOSE,
+    EMAIL_CHANGE_PURPOSE,
+    EmailChangeService,
+)
+from syfthub.services.user_service import UserService
+
+
+def _make_user(username: str, **overrides) -> UserModel:
+    """Build a UserModel with sensible defaults."""
+    data = {
+        "username": username,
+        "email": f"{username}@example.com",
+        "full_name": f"{username.title()} User",
+        "role": "user",
+        "is_active": True,
+        "is_email_verified": True,
+        "auth_provider": "local",
+        "password_hash": "x",
+    }
+    data.update(overrides)
+    return UserModel(**data)
+
+
+@pytest.fixture
+def persisted_user(test_session: Session) -> UserModel:
+    """A committed user with a verified address."""
+    user = _make_user("alice")
+    test_session.add(user)
+    test_session.commit()
+    test_session.refresh(user)
+    return user
+
+
+def _as_schema(model: UserModel) -> User:
+    return User.model_validate(model)
+
+
+class TestPublicId:
+    """users.public_id — the opaque external identifier backing OIDC `sub`."""
+
+    def test_assigned_automatically(self, persisted_user: UserModel) -> None:
+        assert isinstance(persisted_user.public_id, uuid.UUID)
+
+    def test_distinct_per_user(self, test_session: Session) -> None:
+        first = _make_user("bob")
+        second = _make_user("carol")
+        test_session.add_all([first, second])
+        test_session.commit()
+
+        assert first.public_id != second.public_id
+
+    def test_is_a_random_version_4_uuid(self, persisted_user: UserModel) -> None:
+        """Random, not derived from `id` — a derived value would leak the very
+        thing `public_id` exists to hide."""
+        assert persisted_user.public_id.version == 4
+
+    def test_survives_a_profile_update(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        """It is an identifier, so it must be immutable across ordinary edits."""
+        original = persisted_user.public_id
+        repo = UserRepository(test_session)
+
+        repo.update_user(persisted_user.id, UserUpdate(full_name="Renamed"))
+
+        test_session.refresh(persisted_user)
+        assert persisted_user.public_id == original
+
+    def test_absent_from_the_public_profile(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        profile = UserService(test_session).get_public_user_profile(
+            persisted_user.username
+        )
+        assert profile is not None
+        assert not hasattr(profile, "public_id")
+        assert not hasattr(profile, "id")
+
+
+class TestUpdateUserNoLongerWritesEmail:
+    """The repository-level half of the fix."""
+
+    def test_email_is_ignored(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        repo = UserRepository(test_session)
+
+        repo.update_user(
+            persisted_user.id, UserUpdate(email="attacker-target@example.com")
+        )
+
+        test_session.refresh(persisted_user)
+        assert persisted_user.email == "alice@example.com"
+        assert persisted_user.is_email_verified is True
+
+    def test_other_fields_still_apply(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        repo = UserRepository(test_session)
+
+        repo.update_user(
+            persisted_user.id,
+            UserUpdate(full_name="Alice Renamed", email="ignored@example.com"),
+        )
+
+        test_session.refresh(persisted_user)
+        assert persisted_user.full_name == "Alice Renamed"
+        assert persisted_user.email == "alice@example.com"
+
+
+class TestRequestChange:
+    """Requesting a change must not touch the current, verified address."""
+
+    def test_parks_the_address_without_moving_email(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        service = EmailChangeService(test_session)
+
+        code = service.request_change(_as_schema(persisted_user), "New@Example.com")
+
+        test_session.refresh(persisted_user)
+        assert persisted_user.pending_email == "new@example.com"
+        assert persisted_user.email == "alice@example.com"
+        assert persisted_user.is_email_verified is True
+        assert len(code) == 6
+
+    def test_otp_is_keyed_to_the_new_address(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        """The code must prove the *new* address, not the old one."""
+        service = EmailChangeService(test_session)
+
+        service.request_change(_as_schema(persisted_user), "new@example.com")
+
+        assert (
+            service.otp_service.otp_repo.get_active_otp(
+                "new@example.com", EMAIL_CHANGE_PURPOSE
+            )
+            is not None
+        )
+        assert (
+            service.otp_service.otp_repo.get_active_otp(
+                "alice@example.com", EMAIL_CHANGE_PURPOSE
+            )
+            is None
+        )
+
+    def test_rejects_the_current_address(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        service = EmailChangeService(test_session)
+
+        with pytest.raises(ValidationError):
+            service.request_change(_as_schema(persisted_user), "ALICE@example.com")
+
+    def test_rejects_an_address_held_by_another_account(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        test_session.add(_make_user("bob"))
+        test_session.commit()
+        service = EmailChangeService(test_session)
+
+        with pytest.raises(ConflictError):
+            service.request_change(_as_schema(persisted_user), "bob@example.com")
+
+        test_session.refresh(persisted_user)
+        assert persisted_user.pending_email is None
+
+    def test_a_second_request_replaces_the_first(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        service = EmailChangeService(test_session)
+
+        service.request_change(_as_schema(persisted_user), "first@example.com")
+        service.request_change(_as_schema(persisted_user), "second@example.com")
+
+        test_session.refresh(persisted_user)
+        assert persisted_user.pending_email == "second@example.com"
+
+
+class TestConfirmChange:
+    """Only a verified code moves the address."""
+
+    def test_promotes_the_pending_address(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        service = EmailChangeService(test_session)
+        code = service.request_change(_as_schema(persisted_user), "new@example.com")
+
+        result = service.confirm_change(_as_schema(persisted_user), code)
+
+        test_session.refresh(persisted_user)
+        assert persisted_user.email == "new@example.com"
+        assert persisted_user.pending_email is None
+        assert persisted_user.is_email_verified is True
+        assert result.email == "new@example.com"
+
+    def test_a_wrong_code_changes_nothing_and_keeps_the_change_pending(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        service = EmailChangeService(test_session)
+        service.request_change(_as_schema(persisted_user), "new@example.com")
+
+        with pytest.raises(InvalidOTPError):
+            service.confirm_change(_as_schema(persisted_user), "000000")
+
+        # verify_otp increments the attempt counter without committing before it
+        # raises, so the session carries a pending write. Roll it back so the
+        # assertions read committed state and SQLite is not left holding a write
+        # lock that would block table teardown.
+        test_session.rollback()
+        reread = UserRepository(test_session).get_by_id(persisted_user.id)
+        assert reread is not None
+        assert reread.email == "alice@example.com"
+        assert reread.pending_email == "new@example.com"
+        test_session.rollback()
+
+    def test_rejects_when_nothing_is_pending(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        service = EmailChangeService(test_session)
+
+        with pytest.raises(ValidationError):
+            service.confirm_change(_as_schema(persisted_user), "123456")
+
+    def test_loses_a_race_for_the_same_address(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        """If someone else takes the address before confirmation, we must not
+        clobber the unique constraint — the other account keeps it."""
+        service = EmailChangeService(test_session)
+        code = service.request_change(_as_schema(persisted_user), "taken@example.com")
+
+        test_session.add(_make_user("bob", email="taken@example.com"))
+        test_session.commit()
+
+        with pytest.raises(ConflictError):
+            service.confirm_change(_as_schema(persisted_user), code)
+
+        # The service rolled the failed UPDATE back, so re-read rather than
+        # trusting the identity map, then close the read transaction — SQLite
+        # holds a shared lock on an open one, which would block table teardown.
+        test_session.rollback()
+        reread = UserRepository(test_session).get_by_id(persisted_user.id)
+        assert reread is not None
+        assert reread.email == "alice@example.com"
+        assert reread.pending_email == "taken@example.com"
+        test_session.rollback()
+
+    def test_cannot_confirm_another_users_change(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        """The pending address is read from the caller's own row, so a code
+        minted for someone else's change is useless."""
+        other = _make_user("bob")
+        test_session.add(other)
+        test_session.commit()
+        test_session.refresh(other)
+
+        service = EmailChangeService(test_session)
+        code = service.request_change(_as_schema(other), "bobs-new@example.com")
+
+        with pytest.raises(ValidationError):
+            service.confirm_change(_as_schema(persisted_user), code)
+
+        test_session.refresh(persisted_user)
+        assert persisted_user.email == "alice@example.com"
+
+
+class TestResendAndCancel:
+    """Lifecycle management for an in-flight change."""
+
+    def test_resend_returns_the_pending_address_and_a_fresh_code(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        service = EmailChangeService(test_session)
+        service.request_change(_as_schema(persisted_user), "new@example.com")
+
+        pending, code = service.resend_code(_as_schema(persisted_user))
+
+        assert pending == "new@example.com"
+        assert len(code) == 6
+
+    def test_resend_requires_a_pending_change(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        service = EmailChangeService(test_session)
+
+        with pytest.raises(ValidationError):
+            service.resend_code(_as_schema(persisted_user))
+
+    def test_cancel_clears_the_pending_address(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        service = EmailChangeService(test_session)
+        service.request_change(_as_schema(persisted_user), "new@example.com")
+
+        service.cancel_change(_as_schema(persisted_user))
+
+        test_session.refresh(persisted_user)
+        assert persisted_user.pending_email is None
+        assert persisted_user.email == "alice@example.com"
+
+    def test_cancel_is_idempotent(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        service = EmailChangeService(test_session)
+        service.cancel_change(_as_schema(persisted_user))
+        service.cancel_change(_as_schema(persisted_user))
+
+    def test_missing_user_raises_not_found(self, test_session: Session) -> None:
+        service = EmailChangeService(test_session)
+        ghost = User(
+            id=999999, username="ghost", email="ghost@example.com", full_name="Ghost"
+        )
+
+        with pytest.raises(NotFoundError):
+            service.resend_code(ghost)
+
+
+class TestAdminSetEmail:
+    """An admin changing someone else's address has proven nothing."""
+
+    def test_applies_immediately_and_clears_the_verified_flag(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        admin = _make_user("root", role="admin")
+        test_session.add(admin)
+        test_session.commit()
+
+        _, address, code = EmailChangeService(test_session).admin_set_email(
+            persisted_user.id, "Moved@Example.com", _as_schema(admin)
+        )
+
+        test_session.refresh(persisted_user)
+        assert persisted_user.email == "moved@example.com"
+        assert persisted_user.is_email_verified is False
+        assert address == "moved@example.com"
+        assert len(code) == 6
+
+    def test_mints_the_code_under_the_registration_purpose(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        """The target may have no session, and only the registration-purpose
+        endpoints can be completed without one."""
+        admin = _make_user("root", role="admin")
+        test_session.add(admin)
+        test_session.commit()
+        service = EmailChangeService(test_session)
+
+        service.admin_set_email(
+            persisted_user.id, "moved@example.com", _as_schema(admin)
+        )
+
+        assert (
+            service.otp_service.otp_repo.get_active_otp(
+                "moved@example.com", ADMIN_SET_PURPOSE
+            )
+            is not None
+        )
+        assert ADMIN_SET_PURPOSE == "registration"
+
+    def test_an_unchanged_address_mints_nothing(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        admin = _make_user("root", role="admin")
+        test_session.add(admin)
+        test_session.commit()
+
+        _, _, code = EmailChangeService(test_session).admin_set_email(
+            persisted_user.id, "ALICE@example.com", _as_schema(admin)
+        )
+
+        assert code == ""
+        test_session.refresh(persisted_user)
+        assert persisted_user.is_email_verified is True
+
+    def test_clears_any_pending_change(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        admin = _make_user("root", role="admin")
+        test_session.add(admin)
+        test_session.commit()
+        EmailChangeService(test_session).request_change(
+            _as_schema(persisted_user), "self-chosen@example.com"
+        )
+
+        EmailChangeService(test_session).admin_set_email(
+            persisted_user.id, "admin-chosen@example.com", _as_schema(admin)
+        )
+
+        test_session.refresh(persisted_user)
+        assert persisted_user.pending_email is None
+        assert persisted_user.email == "admin-chosen@example.com"
+
+    def test_non_admin_is_refused(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        other = _make_user("bob")
+        test_session.add(other)
+        test_session.commit()
+        test_session.refresh(other)
+
+        with pytest.raises(PermissionDeniedError):
+            EmailChangeService(test_session).admin_set_email(
+                persisted_user.id, "hijack@example.com", _as_schema(other)
+            )
+
+        test_session.refresh(persisted_user)
+        assert persisted_user.email == "alice@example.com"
+
+    def test_rejects_an_address_held_by_another_account(
+        self, test_session: Session, persisted_user: UserModel
+    ) -> None:
+        admin = _make_user("root", role="admin")
+        test_session.add_all([admin, _make_user("bob")])
+        test_session.commit()
+
+        with pytest.raises(ConflictError):
+            EmailChangeService(test_session).admin_set_email(
+                persisted_user.id, "bob@example.com", _as_schema(admin)
+            )
+
+    def test_refuses_to_target_the_caller(self, test_session: Session) -> None:
+        """Clearing your own verified flag is self-lockout; PUT /auth/me/email
+        is the path that keeps the current address working."""
+        admin = _make_user("root", role="admin")
+        test_session.add(admin)
+        test_session.commit()
+        test_session.refresh(admin)
+
+        with pytest.raises(ValidationError) as exc_info:
+            EmailChangeService(test_session).admin_set_email(
+                admin.id, "newroot@example.com", _as_schema(admin)
+            )
+
+        assert "/auth/me/email" in exc_info.value.message
+        test_session.refresh(admin)
+        assert admin.email == "root@example.com"
+        assert admin.is_email_verified is True
+
+    def test_missing_target_raises_not_found(self, test_session: Session) -> None:
+        admin = _make_user("root", role="admin")
+        test_session.add(admin)
+        test_session.commit()
+
+        with pytest.raises(NotFoundError):
+            EmailChangeService(test_session).admin_set_email(
+                999999, "nobody@example.com", _as_schema(admin)
+            )

--- a/components/backend/tests/test_services/test_user_service.py
+++ b/components/backend/tests/test_services/test_user_service.py
@@ -7,7 +7,7 @@ import pytest
 
 from syfthub.database.connection import get_db_session
 from syfthub.domain.exceptions import (
-    ConflictError,
+    EmailNotUpdatableHereError,
     NotFoundError,
     PermissionDeniedError,
     ValidationError,
@@ -212,26 +212,39 @@ class TestUserServiceUpdateProfile:
 
         assert exc_info.value.error_code == "PERMISSION_DENIED"
 
-    def test_update_user_profile_email_exists(self, user_service, sample_user):
-        """Test updating with existing email."""
-        update_data = UserUpdate(email="existing@example.com")
-        user_dict = sample_user.model_dump()
-        user_dict.update({"id": 3, "email": "existing@example.com"})
-        existing_user = User(**user_dict)
+    def test_update_user_profile_rejects_an_email_change(
+        self, user_service, sample_user
+    ):
+        """A different address is rejected, with a pointer to the right endpoint."""
+        update_data = UserUpdate(email="somewhere-else@example.com")
+
+        with patch.object(
+            user_service.user_repository, "get_by_id", return_value=sample_user
+        ):
+            with pytest.raises(EmailNotUpdatableHereError) as exc_info:
+                user_service.update_user_profile(1, update_data, sample_user)
+
+            assert exc_info.value.error_code == "EMAIL_NOT_UPDATABLE_HERE"
+            assert "/auth/me/email" in exc_info.value.message
+
+    def test_update_user_profile_allows_the_unchanged_email(
+        self, user_service, sample_user
+    ):
+        """An echo of the current address is a no-op, not a change."""
+        update_data = UserUpdate(email=sample_user.email.upper(), full_name="Renamed")
 
         with (
             patch.object(
-                user_service.user_repository, "email_exists", return_value=True
+                user_service.user_repository, "get_by_id", return_value=sample_user
             ),
             patch.object(
-                user_service.user_repository, "get_by_email", return_value=existing_user
+                user_service.user_repository, "update_user", return_value=sample_user
             ),
         ):
-            with pytest.raises(ConflictError) as exc_info:
-                user_service.update_user_profile(1, update_data, sample_user)
+            # Must not raise.
+            result = user_service.update_user_profile(1, update_data, sample_user)
 
-            assert exc_info.value.error_code == "CONFLICT"
-            assert exc_info.value.field == "email"
+        assert result.email == sample_user.email
 
     def test_update_user_profile_user_not_found(self, user_service, admin_user):
         """Test updating non-existent user."""

--- a/components/frontend/src/components/__tests__/pending-email-card.test.tsx
+++ b/components/frontend/src/components/__tests__/pending-email-card.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PendingEmailCard } from '@/components/settings/pending-email-card';
+
+vi.mock('framer-motion', () => import('@/test/mocks/framer-motion'));
+
+const { mockVerify, mockResend, mockCancel } = vi.hoisted(() => ({
+  mockVerify: vi.fn(),
+  mockResend: vi.fn(),
+  mockCancel: vi.fn()
+}));
+
+vi.mock('@/lib/sdk-client', () => ({
+  verifyEmailChangeAPI: (code: string): unknown => mockVerify(code),
+  resendEmailChangeCodeAPI: (): unknown => mockResend(),
+  cancelEmailChangeAPI: (): unknown => mockCancel()
+}));
+
+const updatedUser = {
+  id: '1',
+  username: 'alice',
+  email: 'new@example.com',
+  name: 'Alice',
+  full_name: 'Alice',
+  role: 'user',
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  pending_email: undefined
+};
+
+function renderCard(onResolved = vi.fn()) {
+  render(
+    <PendingEmailCard
+      pendingEmail='new@example.com'
+      currentEmail='alice@example.com'
+      onResolved={onResolved}
+    />
+  );
+  return { onResolved };
+}
+
+describe('PendingEmailCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVerify.mockResolvedValue(updatedUser);
+    mockResend.mockResolvedValue(null);
+    mockCancel.mockResolvedValue(null);
+  });
+
+  it('names the pending address and reassures about the current one', () => {
+    renderCard();
+
+    expect(screen.getByText('new@example.com')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    expect(screen.getByText(/stays your address/i)).toBeInTheDocument();
+  });
+
+  it('keeps Confirm disabled until a full 6-digit code is entered', async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    const confirm = screen.getByRole('button', { name: 'Confirm' });
+    expect(confirm).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/verification code/i), '123');
+    expect(confirm).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/verification code/i), '456');
+    expect(confirm).toBeEnabled();
+  });
+
+  it('strips non-digits from the code input', async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    const input = screen.getByLabelText(/verification code/i);
+    await user.type(input, '12ab34cd56');
+
+    expect(input).toHaveValue('123456');
+  });
+
+  it('hands the updated user back on a successful confirmation', async () => {
+    const user = userEvent.setup();
+    const { onResolved } = renderCard();
+
+    await user.type(screen.getByLabelText(/verification code/i), '123456');
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(mockVerify).toHaveBeenCalledWith('123456');
+    });
+    expect(onResolved).toHaveBeenCalledWith(updatedUser);
+  });
+
+  it('shows the error and clears the code on a rejected one, without resolving', async () => {
+    const user = userEvent.setup();
+    mockVerify.mockRejectedValue(new Error('Invalid or expired verification code'));
+    const { onResolved } = renderCard();
+
+    await user.type(screen.getByLabelText(/verification code/i), '000000');
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid or expired verification code')).toBeInTheDocument();
+    });
+    // The change is still pending server-side, so the card must stay put.
+    expect(onResolved).not.toHaveBeenCalled();
+    expect(screen.getByLabelText(/verification code/i)).toHaveValue('');
+  });
+
+  it('resends a code and then blocks resending during the cooldown', async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    await user.click(screen.getByRole('button', { name: 'Resend code' }));
+
+    await waitFor(() => {
+      expect(mockResend).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Resend in \d+s/ })).toBeDisabled();
+    });
+  });
+
+  it('resolves with null when the change is cancelled', async () => {
+    const user = userEvent.setup();
+    const { onResolved } = renderCard();
+
+    await user.click(screen.getByRole('button', { name: 'Cancel change' }));
+
+    await waitFor(() => {
+      expect(mockCancel).toHaveBeenCalledTimes(1);
+    });
+    expect(onResolved).toHaveBeenCalledWith(null);
+  });
+
+  it('surfaces a failure to cancel instead of resolving', async () => {
+    const user = userEvent.setup();
+    mockCancel.mockRejectedValue(new Error('Could not cancel the change'));
+    const { onResolved } = renderCard();
+
+    await user.click(screen.getByRole('button', { name: 'Cancel change' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Could not cancel the change')).toBeInTheDocument();
+    });
+    expect(onResolved).not.toHaveBeenCalled();
+  });
+});

--- a/components/frontend/src/components/auth/verify-otp-modal.tsx
+++ b/components/frontend/src/components/auth/verify-otp-modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 
 import type { VerifyOtpFormValues } from '@/lib/schemas';
 
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Modal } from '@/components/ui/modal';
 import { useAuth } from '@/context/auth-context';
+import { useResendCooldown } from '@/hooks/use-resend-cooldown';
 import { verifyOtpSchema } from '@/lib/schemas';
 
 import { AuthErrorAlert, AuthLoadingOverlay } from './auth-utils';
@@ -28,8 +29,7 @@ export function VerifyOtpModal({
   onSwitchToLogin
 }: Readonly<VerifyOtpModalProperties>) {
   const { verifyOtp, resendOtp, isLoading, error, clearError } = useAuth();
-  const [resendCooldown, setResendCooldown] = useState(0);
-  const timerReference = useRef<ReturnType<typeof setTimeout>>(null);
+  const cooldown = useResendCooldown();
 
   const {
     register,
@@ -51,36 +51,24 @@ export function VerifyOtpModal({
   };
 
   const handleResend = async () => {
-    if (resendCooldown > 0) return;
+    if (cooldown.isCoolingDown) return;
     try {
       clearError();
       await resendOtp(email);
-      // Start cooldown timer (60 seconds)
-      setResendCooldown(60);
+      cooldown.start();
     } catch {
       // Error displayed by auth context
     }
   };
-
-  // Cooldown timer — uses setTimeout chain to avoid re-running the effect on every tick
-  useEffect(() => {
-    if (resendCooldown <= 0) return;
-    timerReference.current = setTimeout(() => {
-      setResendCooldown((previous) => previous - 1);
-    }, 1000);
-    return () => {
-      if (timerReference.current) clearTimeout(timerReference.current);
-    };
-  }, [resendCooldown]);
 
   // Reset when modal closes
   useEffect(() => {
     if (!isOpen) {
       reset();
       clearError();
-      setResendCooldown(0);
+      cooldown.reset();
     }
-  }, [isOpen, reset, clearError]);
+  }, [isOpen, reset, clearError, cooldown]);
 
   const handleInputChange = () => {
     if (error) clearError();
@@ -131,10 +119,10 @@ export function VerifyOtpModal({
             <button
               type='button'
               onClick={() => void handleResend()}
-              disabled={resendCooldown > 0 || isLoading}
+              disabled={cooldown.isCoolingDown || isLoading}
               className='text-foreground hover:text-secondary font-medium underline disabled:no-underline disabled:opacity-50'
             >
-              {resendCooldown > 0 ? `Resend in ${String(resendCooldown)}s` : 'Resend code'}
+              {cooldown.isCoolingDown ? `Resend in ${String(cooldown.remaining)}s` : 'Resend code'}
             </button>
           </p>
         </div>

--- a/components/frontend/src/components/settings/pending-email-card.tsx
+++ b/components/frontend/src/components/settings/pending-email-card.tsx
@@ -1,0 +1,185 @@
+import { useState } from 'react';
+
+import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
+import Mail from 'lucide-react/dist/esm/icons/mail';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useResendCooldown } from '@/hooks/use-resend-cooldown';
+import {
+  cancelEmailChangeAPI,
+  resendEmailChangeCodeAPI,
+  verifyEmailChangeAPI
+} from '@/lib/sdk-client';
+
+import { StatusMessage } from './status-message';
+
+interface PendingEmailCardProps {
+  /** The address awaiting verification, from `user.pending_email`. */
+  readonly pendingEmail: string;
+  /** The address still on the account, which stays active until confirmation. */
+  readonly currentEmail: string;
+  /** Called with the updated user once the change is confirmed or cancelled. */
+  readonly onResolved: (updated: Awaited<ReturnType<typeof verifyEmailChangeAPI>> | null) => void;
+}
+
+const CODE_LENGTH = 6;
+
+/**
+ * Inline card for an email change awaiting verification.
+ *
+ * Rendered whenever the server reports a `pending_email`, which means it
+ * survives a reload, a new session, and a different device — the pending state
+ * lives in the database, not here. That is why this is an inline card rather
+ * than a modal: a dismissed modal would leave a real pending change with no
+ * route back to the code entry.
+ *
+ * Deliberately non-blocking. Unlike registration OTP, the account's current
+ * address still works and still logs the user in while a change is pending, so
+ * nothing here demands immediate attention.
+ */
+export function PendingEmailCard({
+  pendingEmail,
+  currentEmail,
+  onResolved
+}: PendingEmailCardProps) {
+  const [code, setCode] = useState('');
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [isResending, setIsResending] = useState(false);
+  const [isCancelling, setIsCancelling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const cooldown = useResendCooldown();
+
+  const busy = isVerifying || isResending || isCancelling;
+
+  const handleCodeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    // Codes are always 6 digits; drop anything else rather than letting the
+    // server reject it.
+    setCode(event.target.value.replaceAll(/\D/g, '').slice(0, CODE_LENGTH));
+    if (error) setError(null);
+  };
+
+  const handleVerify = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (code.length !== CODE_LENGTH || busy) return;
+
+    setIsVerifying(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const updated = await verifyEmailChangeAPI(code);
+      onResolved(updated);
+    } catch (error_) {
+      // A rejected code leaves the pending change intact server-side, so the
+      // card stays put and the user can retry.
+      setError(error_ instanceof Error ? error_.message : 'Could not confirm that code');
+      setCode('');
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  const handleResend = async () => {
+    if (cooldown.isCoolingDown || busy) return;
+
+    setIsResending(true);
+    setError(null);
+    try {
+      await resendEmailChangeCodeAPI();
+      cooldown.start();
+      setNotice(`A new code is on its way to ${pendingEmail}.`);
+    } catch (error_) {
+      setError(error_ instanceof Error ? error_.message : 'Could not send a new code');
+    } finally {
+      setIsResending(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    if (busy) return;
+
+    setIsCancelling(true);
+    setError(null);
+    try {
+      await cancelEmailChangeAPI();
+      onResolved(null);
+    } catch (error_) {
+      setError(error_ instanceof Error ? error_.message : 'Could not cancel the change');
+    } finally {
+      setIsCancelling(false);
+    }
+  };
+
+  return (
+    <div
+      className='space-y-3 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950'
+      data-testid='pending-email-card'
+    >
+      <div className='flex items-start gap-2'>
+        <Mail
+          className='mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600 dark:text-amber-400'
+          aria-hidden='true'
+        />
+        <div className='space-y-1'>
+          <p className='font-inter text-sm font-medium text-amber-900 dark:text-amber-100'>
+            Confirm your new email address
+          </p>
+          <p className='font-inter text-xs text-amber-800 dark:text-amber-200'>
+            We sent a {CODE_LENGTH}-digit code to <strong>{pendingEmail}</strong>. Until you confirm
+            it, <strong>{currentEmail}</strong> stays your address and you can keep signing in with
+            it.
+          </p>
+        </div>
+      </div>
+
+      <StatusMessage type='error' message={error} />
+      <StatusMessage type='success' message={notice} />
+
+      <form onSubmit={(event) => void handleVerify(event)} className='flex items-end gap-2'>
+        <div className='w-40'>
+          <Input
+            label='Verification code'
+            value={code}
+            onChange={handleCodeChange}
+            placeholder='123456'
+            disabled={busy}
+            autoComplete='one-time-code'
+            inputMode='numeric'
+            maxLength={CODE_LENGTH}
+            aria-label='Verification code for your new email address'
+          />
+        </div>
+        <Button type='submit' disabled={busy || code.length !== CODE_LENGTH}>
+          {isVerifying ? (
+            <>
+              <Loader2 className='h-4 w-4 animate-spin' aria-hidden='true' />
+              Confirming…
+            </>
+          ) : (
+            'Confirm'
+          )}
+        </Button>
+      </form>
+
+      <div className='font-inter flex items-center gap-4 text-xs'>
+        <button
+          type='button'
+          onClick={() => void handleResend()}
+          disabled={cooldown.isCoolingDown || busy}
+          className='font-medium text-amber-900 underline underline-offset-2 disabled:no-underline disabled:opacity-50 dark:text-amber-100'
+        >
+          {cooldown.isCoolingDown ? `Resend in ${String(cooldown.remaining)}s` : 'Resend code'}
+        </button>
+        <button
+          type='button'
+          onClick={() => void handleCancel()}
+          disabled={busy}
+          className='text-amber-800 underline underline-offset-2 disabled:no-underline disabled:opacity-50 dark:text-amber-200'
+        >
+          {isCancelling ? 'Cancelling…' : 'Cancel change'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/frontend/src/components/settings/profile-settings-tab.tsx
+++ b/components/frontend/src/components/settings/profile-settings-tab.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
+import type { User as FrontendUser } from '@/lib/types';
 import type { AvailabilityState } from './username-field';
 
 import AlertCircle from 'lucide-react/dist/esm/icons/alert-circle';
@@ -18,12 +19,14 @@ import { useAuth } from '@/context/auth-context';
 import {
   checkEmailAvailability,
   checkUsernameAvailability,
+  requestEmailChangeAPI,
   updateUserProfileAPI
 } from '@/lib/sdk-client';
 import { useSettingsModalStore } from '@/stores/settings-modal-store';
 
 import { AvatarSection } from './avatar-section';
 import { DisplayNameField } from './display-name-field';
+import { PendingEmailCard } from './pending-email-card';
 import { StatusMessage } from './status-message';
 import { UsernameField } from './username-field';
 
@@ -51,8 +54,40 @@ function normalizeDomainInput(value: string): string {
   return scheme.toLowerCase() + trimmed.slice(scheme.length);
 }
 
+/**
+ * Collect only the profile fields that actually changed.
+ *
+ * `email` is deliberately absent: it is not a profile field, and the endpoint
+ * rejects it. An email change is dispatched separately by handleSubmit.
+ */
+function buildProfileUpdates(
+  formData: ProfileFormData,
+  user: FrontendUser | null
+): Record<string, string | boolean> {
+  const updates: Record<string, string | boolean> = {};
+  if (formData.username !== user?.username) {
+    updates.username = formData.username.trim().toLowerCase();
+  }
+  if (formData.full_name !== user?.full_name) {
+    updates.full_name = formData.full_name.trim();
+  }
+  if (formData.avatar_url !== (user?.avatar_url ?? '')) {
+    updates.avatar_url = formData.avatar_url.trim();
+  }
+  if (formData.domain !== (user?.domain ?? '')) {
+    updates.domain = normalizeDomainInput(formData.domain);
+  }
+  if (formData.bio !== (user?.bio ?? '')) {
+    updates.bio = formData.bio;
+  }
+  if (formData.is_email_public !== (user?.is_email_public ?? false)) {
+    updates.is_email_public = formData.is_email_public;
+  }
+  return updates;
+}
+
 export function ProfileSettingsTab() {
-  const { user, updateUser } = useAuth();
+  const { user, updateUser, refreshUser } = useAuth();
   const { closeSettings } = useSettingsModalStore();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -232,32 +267,18 @@ export function ProfileSettingsTab() {
       return;
     }
 
-    // Build update payload (only changed fields)
-    const updates: Record<string, string | boolean> = {};
-    if (formData.username !== user?.username) {
-      updates.username = formData.username.trim().toLowerCase();
-    }
-    if (formData.email !== user?.email) {
-      updates.email = formData.email.trim().toLowerCase();
-    }
-    if (formData.full_name !== user?.full_name) {
-      updates.full_name = formData.full_name.trim();
-    }
-    if (formData.avatar_url !== (user?.avatar_url ?? '')) {
-      updates.avatar_url = formData.avatar_url.trim();
-    }
-    if (formData.domain !== (user?.domain ?? '')) {
-      updates.domain = normalizeDomainInput(formData.domain);
-    }
-    if (formData.bio !== (user?.bio ?? '')) {
-      updates.bio = formData.bio;
-    }
-    if (formData.is_email_public !== (user?.is_email_public ?? false)) {
-      updates.is_email_public = formData.is_email_public;
-    }
+    const updates = buildProfileUpdates(formData, user);
+
+    // An email change is a separate operation against a separate endpoint: it
+    // needs proof of the new address, so it cannot ride along with fields that
+    // apply immediately.
+    const newEmail =
+      formData.email.trim().toLowerCase() === (user?.email ?? '').toLowerCase()
+        ? null
+        : formData.email.trim().toLowerCase();
 
     // If nothing changed, show message
-    if (Object.keys(updates).length === 0) {
+    if (Object.keys(updates).length === 0 && newEmail === null) {
       setSuccess('No changes to save');
       return;
     }
@@ -265,13 +286,20 @@ export function ProfileSettingsTab() {
     setIsLoading(true);
 
     try {
-      // Update profile and get the updated user directly from the response
-      const updatedUser = await updateUserProfileAPI(updates);
+      let updatedUser = user;
+      if (Object.keys(updates).length > 0) {
+        updatedUser = await updateUserProfileAPI(updates);
+        updateUser(updatedUser);
+      }
 
-      // Update auth context directly with the response data (no need for separate API call)
-      updateUser(updatedUser);
-
-      setSuccess('Profile updated successfully!');
+      if (newEmail === null) {
+        setSuccess('Profile updated successfully!');
+      } else {
+        const pending = await requestEmailChangeAPI(newEmail);
+        // Re-read so `pending_email` lands in the session and the card appears.
+        await refreshUser();
+        setSuccess(`Check ${pending} for a code to confirm your new address.`);
+      }
 
       // Clear success message after 3 seconds
       setTimeout(() => {
@@ -282,6 +310,25 @@ export function ProfileSettingsTab() {
     } finally {
       setIsLoading(false);
     }
+  };
+
+  /**
+   * Fold the outcome of a pending email change back into the session.
+   *
+   * A confirmed change hands back the updated user; a cancellation returns no
+   * body, so the user is re-read to drop the stale `pending_email`.
+   */
+  const handlePendingEmailResolved = async (updatedUser: FrontendUser | null) => {
+    if (updatedUser) {
+      updateUser(updatedUser);
+      setSuccess(`Your email address is now ${updatedUser.email}.`);
+    } else {
+      await refreshUser();
+      setSuccess('Email change cancelled.');
+    }
+    setTimeout(() => {
+      setSuccess(null);
+    }, 3000);
   };
 
   /* eslint-disable @typescript-eslint/no-unnecessary-condition -- Defensive null checks */
@@ -380,6 +427,16 @@ export function ProfileSettingsTab() {
             </p>
           ) : null}
         </div>
+
+        {/* Email change awaiting verification. Driven by server state, so it is
+            here on reload, on a new session, and on another device. */}
+        {user?.pending_email ? (
+          <PendingEmailCard
+            pendingEmail={user.pending_email}
+            currentEmail={user.email}
+            onResolved={(updatedUser) => void handlePendingEmailResolved(updatedUser)}
+          />
+        ) : null}
 
         {/* Full Name */}
         <DisplayNameField

--- a/components/frontend/src/components/settings/profile-settings-tab.tsx
+++ b/components/frontend/src/components/settings/profile-settings-tab.tsx
@@ -286,9 +286,8 @@ export function ProfileSettingsTab() {
     setIsLoading(true);
 
     try {
-      let updatedUser = user;
       if (Object.keys(updates).length > 0) {
-        updatedUser = await updateUserProfileAPI(updates);
+        const updatedUser = await updateUserProfileAPI(updates);
         updateUser(updatedUser);
       }
 

--- a/components/frontend/src/context/auth-context.tsx
+++ b/components/frontend/src/context/auth-context.tsx
@@ -147,7 +147,8 @@ export function mapSdkUserToFrontend(sdkUser: SdkUser): User {
     domain: sdkUser.domain ?? undefined,
     aggregator_url: sdkUser.aggregatorUrl ?? undefined,
     bio: sdkUser.bio ?? undefined,
-    is_email_public: sdkUser.isEmailPublic ?? false
+    is_email_public: sdkUser.isEmailPublic ?? false,
+    pending_email: sdkUser.pendingEmail ?? undefined
   };
 }
 

--- a/components/frontend/src/hooks/use-resend-cooldown.ts
+++ b/components/frontend/src/hooks/use-resend-cooldown.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Countdown that throttles "resend code" buttons.
+ *
+ * Extracted so every OTP surface (registration, email change) shares one
+ * implementation rather than each keeping its own timer.
+ *
+ * Uses a setTimeout chain rather than setInterval so the effect is not
+ * re-registered on every tick.
+ *
+ * @param seconds - How long to block resending after each send. Default 60.
+ */
+export function useResendCooldown(seconds = 60) {
+  const [remaining, setRemaining] = useState(0);
+  const timerReference = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (remaining <= 0) return;
+    timerReference.current = setTimeout(() => {
+      setRemaining((previous) => previous - 1);
+    }, 1000);
+    return () => {
+      if (timerReference.current) clearTimeout(timerReference.current);
+    };
+  }, [remaining]);
+
+  const start = useCallback(() => {
+    setRemaining(seconds);
+  }, [seconds]);
+
+  const reset = useCallback(() => {
+    setRemaining(0);
+  }, []);
+
+  return {
+    /** Seconds left before another send is allowed; 0 when ready. */
+    remaining,
+    /** True while a resend must be blocked. */
+    isCoolingDown: remaining > 0,
+    /** Begin the countdown — call after a successful send. */
+    start,
+    /** Clear the countdown, e.g. when the surface is dismissed. */
+    reset
+  };
+}

--- a/components/frontend/src/lib/sdk-client.ts
+++ b/components/frontend/src/lib/sdk-client.ts
@@ -2,6 +2,7 @@
 // User Profile Utilities
 // ============================================================================
 
+import type { User as SdkUser } from '@syfthub/sdk';
 import type {
   AvailabilityResponse,
   User as FrontendUser,
@@ -269,8 +270,9 @@ function generateAvatarUrl(name: string): string {
  */
 export async function updateUserProfileAPI(profileData: UserUpdate): Promise<FrontendUser> {
   const sdkUser = await syftClient.users.update({
+    // `email` is deliberately not forwarded: the profile endpoint rejects it
+    // with 422. Email changes go through requestEmailChangeAPI below.
     username: profileData.username,
-    email: profileData.email,
     fullName: profileData.full_name,
     avatarUrl: profileData.avatar_url,
     domain: profileData.domain,
@@ -279,7 +281,16 @@ export async function updateUserProfileAPI(profileData: UserUpdate): Promise<Fro
     isEmailPublic: profileData.is_email_public
   });
 
-  // Convert SDK User to frontend User format
+  return mapSdkUser(sdkUser);
+}
+
+/**
+ * Convert an SDK User into the frontend User shape.
+ *
+ * Shared by every call here that returns a user, so a newly added field only
+ * has to be mapped once.
+ */
+function mapSdkUser(sdkUser: SdkUser): FrontendUser {
   return {
     id: String(sdkUser.id),
     username: sdkUser.username,
@@ -294,8 +305,41 @@ export async function updateUserProfileAPI(profileData: UserUpdate): Promise<Fro
     domain: sdkUser.domain ?? undefined,
     aggregator_url: sdkUser.aggregatorUrl ?? undefined,
     bio: sdkUser.bio ?? undefined,
-    is_email_public: sdkUser.isEmailPublic ?? false
+    is_email_public: sdkUser.isEmailPublic ?? false,
+    pending_email: sdkUser.pendingEmail ?? undefined
   };
+}
+
+/**
+ * Start a verified change of the current user's email address.
+ *
+ * Nothing changes on the account yet — the address is held as `pending_email`
+ * and a code is sent to it. Returns the address as the server normalised it.
+ */
+export async function requestEmailChangeAPI(email: string): Promise<string> {
+  const { pendingEmail } = await syftClient.auth.requestEmailChange(email);
+  return pendingEmail;
+}
+
+/**
+ * Confirm a pending email change with the code sent to the new address.
+ *
+ * Only on success does the address actually move; a wrong code leaves the
+ * pending change in place so the user can retry.
+ */
+export async function verifyEmailChangeAPI(code: string): Promise<FrontendUser> {
+  const sdkUser = await syftClient.auth.verifyEmailChange(code);
+  return mapSdkUser(sdkUser);
+}
+
+/** Send a fresh code to the address already pending. */
+export async function resendEmailChangeCodeAPI(): Promise<void> {
+  await syftClient.auth.resendEmailChangeCode();
+}
+
+/** Abandon a pending email change. Idempotent. */
+export async function cancelEmailChangeAPI(): Promise<void> {
+  await syftClient.auth.cancelEmailChange();
 }
 
 /**

--- a/components/frontend/src/lib/types.ts
+++ b/components/frontend/src/lib/types.ts
@@ -53,6 +53,12 @@ export interface User {
   is_email_public?: boolean;
   /** Timestamp of the user's last successful login (null/undefined if never) */
   last_login_at?: string;
+  /**
+   * An email change awaiting verification, or undefined when none is in flight.
+   * `email` stays the current, verified address until a code sent to this one
+   * is confirmed.
+   */
+  pending_email?: string;
 }
 
 // Authentication request schemas

--- a/sdk/typescript/src/models/user.ts
+++ b/sdk/typescript/src/models/user.ts
@@ -21,6 +21,15 @@ export interface User {
   readonly bio?: string | null;
   /** Whether the user's email is shown on their public profile */
   readonly isEmailPublic?: boolean;
+  /**
+   * An email change awaiting verification, or null when none is in flight.
+   *
+   * Setting `email` via `users.update()` does not move the address: it is held
+   * here until a code sent to it is confirmed with
+   * `auth.verifyEmailChange()`. `email` remains the current, verified address
+   * throughout, so the account never presents an unproven address.
+   */
+  readonly pendingEmail?: string | null;
 }
 
 /**
@@ -61,7 +70,14 @@ export interface UserRegisterInput {
  */
 export interface UserUpdateInput {
   username?: string;
-  email?: string;
+  /**
+   * Not a profile field. Changing an address requires proving control of it, so
+   * `users.update()` rejects it with 422 — use `auth.requestEmailChange()`
+   * (self) or `users.setEmail()` (admin).
+   *
+   * @deprecated Use `auth.requestEmailChange()`.
+   */
+  email?: never;
   fullName?: string;
   avatarUrl?: string;
   /** Domain for endpoint URL construction (no protocol, e.g., "api.example.com:8080") */

--- a/sdk/typescript/src/resources/auth.ts
+++ b/sdk/typescript/src/resources/auth.ts
@@ -269,6 +269,63 @@ export class AuthResource {
   }
 
   /**
+   * Start a verified change of the current user's email address.
+   *
+   * Nothing changes yet: the address is held as `pendingEmail` and a code is
+   * sent to it. The account keeps its current, verified address — and keeps
+   * signing in with it — until `verifyEmailChange()` succeeds, so a mistyped
+   * address cannot lock anyone out.
+   *
+   * Sits beside `changePassword()` because an address is a credential here: a
+   * login identifier, the password-reset channel, and an exported identity
+   * claim. `users.update()` will not change it.
+   *
+   * @param email - The new email address
+   * @returns The pending address, as normalised by the server
+   * @throws {ValidationError} If it is already the account's address
+   * @throws {ConflictError} If another account already holds it
+   */
+  async requestEmailChange(email: string): Promise<{ pendingEmail: string }> {
+    return this.http.put<{ pendingEmail: string }>('/api/v1/auth/me/email', { email });
+  }
+
+  /**
+   * Confirm a pending email change with the code sent to the new address.
+   *
+   * On success the pending address becomes the account's email and is marked
+   * verified. A wrong code leaves the pending change intact so the user can
+   * retry, and the current address stays usable throughout.
+   *
+   * The address is not passed in: the server reads it from the authenticated
+   * user's pending change, so a caller can only ever confirm their own.
+   *
+   * @param code - The 6-digit code sent to the pending address
+   * @returns The updated User, with `email` moved and `pendingEmail` cleared
+   * @throws {ValidationError} If no change is pending, or the code is malformed
+   */
+  async verifyEmailChange(code: string): Promise<User> {
+    return this.http.post<User>('/api/v1/auth/me/email/verify', { code });
+  }
+
+  /**
+   * Send a fresh code to the address already pending.
+   *
+   * @throws {ValidationError} If no email change is pending
+   */
+  async resendEmailChangeCode(): Promise<void> {
+    await this.http.post<void>('/api/v1/auth/me/email/resend');
+  }
+
+  /**
+   * Abandon a pending email change. Idempotent.
+   *
+   * Deletes the pending change, never the address on the account.
+   */
+  async cancelEmailChange(): Promise<void> {
+    await this.http.delete<void>('/api/v1/auth/me/email');
+  }
+
+  /**
    * Request a password reset OTP.
    *
    * Always returns successfully to prevent email enumeration.

--- a/sdk/typescript/src/resources/users.ts
+++ b/sdk/typescript/src/resources/users.ts
@@ -62,14 +62,36 @@ export class UsersResource {
   }
 
   /**
+   * Set a user's email address outright (admin only).
+   *
+   * Applies immediately and clears the verified flag: an administrator has not
+   * proven the new address belongs to its owner, so it cannot inherit the old
+   * address's verified status. The account holder re-proves it through the
+   * normal OTP flow.
+   *
+   * Admins changing their *own* address should use `auth.requestEmailChange()`,
+   * which keeps the current address working until the new one is verified.
+   *
+   * @param userId - The user whose address to set
+   * @param email - The new email address
+   * @returns The updated User
+   * @throws {ValidationError} If the caller is not an admin
+   * @throws {ConflictError} If another account already holds the address
+   */
+  async setEmail(userId: number, email: string): Promise<User> {
+    return this.http.put<User>(`/api/v1/users/${String(userId)}/email`, { email });
+  }
+
+  /**
    * Update the current user's profile.
    *
-   * Only provided fields will be updated.
+   * Only provided fields will be updated. `email` is not updatable here and is
+   * rejected with 422 — see `auth.requestEmailChange()`.
    *
    * @param input - Fields to update
    * @returns The updated User
    * @throws {AuthenticationError} If not authenticated
-   * @throws {ValidationError} If input validation fails
+   * @throws {ValidationError} If input validation fails, or `email` is supplied
    */
   async update(input: UserUpdateInput): Promise<User> {
     return this.http.put<User>('/api/v1/users/me', input);


### PR DESCRIPTION
This pull request introduces a robust, privacy-preserving, and secure mechanism for managing user email addresses and public identifiers. It adds a stable, opaque `public_id` field to the `users` table for external references, and implements a verified email change workflow that prevents unverified email addresses from being marked as verified. The API and models are updated to support these features, and new endpoints and services are introduced for email change management.

**Database Schema Changes:**

- **User public identifier:**
  - Adds a `public_id` (UUID) column to `users`, backfills existing users, enforces uniqueness, and sets a server-side default for PostgreSQL to ensure stable, opaque external references. This prevents exposing internal user IDs and supports OIDC `sub` claims. [[1]](diffhunk://#diff-eb425f785113ccc93f4344759feb238b921e16cb68e59a10970cb699e4795caeR1-R117) [[2]](diffhunk://#diff-50414e758ca6f3b6d66c9ab71b2622c13b2b4a8f607438bb40101eedc809309fR23-R37)
- **Verified email change flow:**
  - Adds a `pending_email` column to `users` for storing requested but unverified email addresses, ensuring `is_email_verified` never describes an unproven address. [[1]](diffhunk://#diff-1e0e5a55602bef44dcbf5cc056dec37d44b870e90ab062bc1c4d71d933155b83R1-R38) [[2]](diffhunk://#diff-50414e758ca6f3b6d66c9ab71b2622c13b2b4a8f607438bb40101eedc809309fR50-R57)

**API and Endpoint Changes:**

- **User profile updates:**
  - Disallows direct modification of `email` via profile endpoints. Instead, email changes require verification through dedicated endpoints. [[1]](diffhunk://#diff-b0ab1187117d7db77896d7dc66390c3c8060a8080166456406d956123ece39abL181-R204) [[2]](diffhunk://#diff-b0ab1187117d7db77896d7dc66390c3c8060a8080166456406d956123ece39abL192-R273)
- **New endpoints for email change:**
  - Implements `/auth/me/email` endpoints for requesting, verifying, resending, and cancelling email changes, requiring OTP verification before updating the address.
  - Adds an admin endpoint (`PUT /users/{user_id}/email`) for administrators to set a user's email, which clears the verified flag and sends a notification and verification code to the new address.

**Service and Dependency Updates:**

- **Email change service:**
  - Introduces `EmailChangeService` and its dependency injection for handling the email change flow, including code generation and verification. [[1]](diffhunk://#diff-1fe28ad525d26645f139a03c50fd2cd0d6bdcb1816029c91d848504fb5a9ac57R22) [[2]](diffhunk://#diff-1fe28ad525d26645f139a03c50fd2cd0d6bdcb1816029c91d848504fb5a9ac57R108-R114)

**Validation and Exceptions:**

- **Error handling:**
  - Adds a specific exception (`EmailNotUpdatableHereError`) for attempts to update email via unsupported endpoints, guiding clients to the correct workflow.

These changes collectively ensure user privacy, prevent account takeover via unverified email changes, and provide a clear, secure, and auditable process for managing user email addresses and identifiers.