### PR TITLE
Refactor email verification and improve UI prompts

### DIFF
--- a/components/backend/alembic/versions/20260818_000000_add_user_public_id.py
+++ b/components/backend/alembic/versions/20260818_000000_add_user_public_id.py
@@ -67,9 +67,7 @@ def _backfill_public_ids(bind: sa.engine.Connection) -> None:
     ).fetchall()
     for (user_id,) in rows:
         bind.execute(
-            _users.update()
-            .where(_users.c.id == user_id)
-            .values(public_id=uuid.uuid4())
+            _users.update().where(_users.c.id == user_id).values(public_id=uuid.uuid4())
         )
 
 
@@ -86,8 +84,7 @@ def upgrade() -> None:
     if is_postgresql:
         op.execute(
             sa.text(
-                "UPDATE users SET public_id = gen_random_uuid() "
-                "WHERE public_id IS NULL"
+                "UPDATE users SET public_id = gen_random_uuid() WHERE public_id IS NULL"
             )
         )
     else:

--- a/components/backend/alembic/versions/20260818_000000_add_user_public_id.py
+++ b/components/backend/alembic/versions/20260818_000000_add_user_public_id.py
@@ -1,0 +1,117 @@
+"""Add users.public_id — a stable, opaque external user identifier.
+
+``users.id`` is a sequential integer primary key. It must never become an
+external, permanently-bound reference: doing so hands every relying party
+SyftHub's internal id space (approximate user count, relative signup order) and
+a shared join key with which two unrelated relying parties can correlate the
+same person. The codebase already declines to expose it (see the privacy notes
+on ``EndpointPublicResponse`` and ``PublicUserProfile``).
+
+``public_id`` is that external reference instead — a random UUID, unique and
+immutable, which will back the OIDC ``sub`` claim.
+
+Migration shape, and why:
+
+1. Add the column **nullable with no default**. That is a catalogue-only change
+   on PostgreSQL: no table rewrite, so the ACCESS EXCLUSIVE lock is held only
+   momentarily rather than for the length of a rewrite.
+2. Backfill every existing row with a distinct value.
+3. Add the unique index.
+4. Constrain to NOT NULL and attach a ``gen_random_uuid()`` server default.
+
+Step 4's server default is load-bearing, not decoration. ``deploy.sh``'s
+``run_migrations()`` runs *before* ``deploy_services()`` and only brings up the
+database — the **previous release keeps serving traffic throughout**. That code
+has no ``public_id`` in its ORM model, so its signup INSERTs omit the column
+entirely. Without a database-side default, every registration between this
+migration committing and the new release rolling in would fail on a NOT NULL
+violation. A Python-side default cannot cover that window, because it exists
+only in the new code.
+
+``gen_random_uuid()`` is built into PostgreSQL 13+ (deployments run
+``postgres:16-alpine``). SQLite has no equivalent and cannot ``ALTER COLUMN``,
+so there the column stays nullable; the ORM-side ``default=uuid.uuid4`` covers
+inserts, and a freshly created dev database gets NOT NULL from ``create_all()``.
+
+Revision ID: 022_user_public_id
+Revises: 021_drop_user_heartbeat_fields
+Create Date: 2026-08-18 00:00:00.000000+00:00
+"""
+
+import uuid
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "022_user_public_id"
+down_revision: str | None = "021_drop_user_heartbeat_fields"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_users = sa.table(
+    "users",
+    sa.column("id", sa.Integer),
+    sa.column("public_id", sa.Uuid()),
+)
+
+
+def _backfill_public_ids(bind: sa.engine.Connection) -> None:
+    """Assign a distinct UUID to every row that lacks one, from Python.
+
+    Used on dialects without a UUID-generating SQL function. Runs inside the
+    migration transaction, so it is atomic with the schema change.
+    """
+    rows = bind.execute(
+        sa.select(_users.c.id).where(_users.c.public_id.is_(None))
+    ).fetchall()
+    for (user_id,) in rows:
+        bind.execute(
+            _users.update()
+            .where(_users.c.id == user_id)
+            .values(public_id=uuid.uuid4())
+        )
+
+
+def upgrade() -> None:
+    """Add, backfill, and constrain users.public_id."""
+    bind = op.get_bind()
+    is_postgresql = bind.dialect.name == "postgresql"
+
+    # 1. Nullable, no default — catalogue-only on PostgreSQL, no rewrite.
+    op.add_column("users", sa.Column("public_id", sa.Uuid(), nullable=True))
+
+    # 2. Backfill. One statement on PostgreSQL; gen_random_uuid() is volatile,
+    #    so each row receives a distinct value.
+    if is_postgresql:
+        op.execute(
+            sa.text(
+                "UPDATE users SET public_id = gen_random_uuid() "
+                "WHERE public_id IS NULL"
+            )
+        )
+    else:
+        _backfill_public_ids(bind)
+
+    # 3. Uniqueness.
+    op.create_index("idx_users_public_id", "users", ["public_id"], unique=True)
+
+    # 4. Constrain, and hand the still-running previous release a default it
+    #    can rely on. SQLite supports neither statement.
+    if is_postgresql:
+        op.alter_column(
+            "users",
+            "public_id",
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        )
+
+
+def downgrade() -> None:
+    """Drop users.public_id.
+
+    Irreversible in effect: any relying party that has bound accounts to these
+    values loses them, and re-running the upgrade mints different UUIDs.
+    """
+    op.drop_index("idx_users_public_id", table_name="users")
+    op.drop_column("users", "public_id")

--- a/components/backend/alembic/versions/20260819_000000_replace_is_email_verified.py
+++ b/components/backend/alembic/versions/20260819_000000_replace_is_email_verified.py
@@ -1,0 +1,77 @@
+"""Replace users.is_email_verified with users.email_verified_at.
+
+``is_email_verified`` answered two unrelated questions with one boolean:
+
+1. "has this account ever proven an address?" — which gated login, and
+2. "is the address currently on file proven?" — which is what an OIDC
+   ``email_verified`` claim needs.
+
+Because a change to the address had to clear the flag, changing an email yanked
+the login gate as a side effect: users were locked out, admins could lock
+themselves out, and recovery needed a session the locked-out user did not have.
+Worse, registration set the flag ``True`` **without any proof** whenever email
+delivery was unconfigured, so ``True`` never actually meant "proven".
+
+``email_verified_at`` answers only the second question. It gates nothing; login
+no longer consults it. It is cleared whenever the address changes and set when a
+code sent to that address is confirmed, so it describes the address on file and
+nothing else — which makes it safe to export as a claim.
+
+**Backfill:** rows with ``is_email_verified`` true get ``email_verified_at =
+created_at``, preserving today's behaviour so nothing regresses for existing
+users and the admin dashboard's Verified/Unverified badges are unchanged. Those
+rows therefore inherit the old ambiguity: in a deployment that never had email
+configured, they claim a verified address that was never proven. Only the
+*forward* semantics are fixed here — new accounts and new changes record
+``email_verified_at`` solely on real proof. If strictness matters before this is
+exported anywhere, null the column in a one-off pass; that is a policy decision,
+not a migration one.
+
+Revision ID: 023_user_email_verified_at
+Revises: 022_user_public_id
+Create Date: 2026-08-19 00:00:00.000000+00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "023_user_email_verified_at"
+down_revision: str | None = "022_user_public_id"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add email_verified_at, backfill it, and drop is_email_verified."""
+    op.add_column(
+        "users",
+        sa.Column("email_verified_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.execute(
+        sa.text(
+            "UPDATE users SET email_verified_at = created_at WHERE is_email_verified"
+        )
+    )
+    op.drop_column("users", "is_email_verified")
+
+
+def downgrade() -> None:
+    """Restore the boolean, losing when verification happened."""
+    op.add_column(
+        "users",
+        sa.Column(
+            "is_email_verified",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.execute(
+        sa.text(
+            "UPDATE users SET is_email_verified = true "
+            "WHERE email_verified_at IS NOT NULL"
+        )
+    )
+    op.drop_column("users", "email_verified_at")

--- a/components/backend/src/syfthub/api/endpoints/users.py
+++ b/components/backend/src/syfthub/api/endpoints/users.py
@@ -1,18 +1,29 @@
 """User management endpoints."""
 
 import logging
-from typing import Annotated, Union
+from typing import Annotated, Optional, Union
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Request,
+    status,
+)
 
 from syfthub.auth.db_dependencies import (
     OwnershipChecker,
     get_current_active_user,
     require_admin,
 )
+from syfthub.core.client_ip import get_client_ip
 from syfthub.core.config import settings
-from syfthub.database.dependencies import get_user_service
+from syfthub.database.dependencies import (
+    get_email_verification_service,
+    get_user_service,
+)
 from syfthub.schemas.auth import UserRole
 from syfthub.schemas.user import (
     PublicUserProfile,
@@ -20,6 +31,11 @@ from syfthub.schemas.user import (
     User,
     UserResponse,
     UserUpdate,
+)
+from syfthub.services.email_service import send_email_changed_notice, send_otp_email
+from syfthub.services.email_verification_service import (
+    EMAIL_VERIFY_PURPOSE,
+    EmailVerificationService,
 )
 from syfthub.services.user_service import UserService
 
@@ -172,25 +188,95 @@ def get_user(
     return user_profile
 
 
+def _after_email_change(
+    updated: UserResponse,
+    previous_email: Optional[str],
+    request: Request,
+    background_tasks: BackgroundTasks,
+    verification: EmailVerificationService,
+) -> None:
+    """Send what an address change owes the user, if it changed at all.
+
+    Two messages, to two different inboxes, for two different reasons:
+
+    - a code to the **new** address, so the account can claim it is verified
+      again (the write cleared that state); and
+    - a notice to the **old** address, the only inbox the account holder is known
+      to control at this moment. Without it the change is silent, and a typo goes
+      unnoticed until a password reset can no longer reach them.
+
+    Both are best-effort background sends, and both are skipped when email
+    delivery is not configured — in that deployment the address simply stays
+    unverified, which is the honest state rather than a claimed proof.
+    """
+    if previous_email is None:
+        return
+
+    background_tasks.add_task(send_email_changed_notice, previous_email, updated.email)
+
+    if not settings.smtp_configured:
+        return
+
+    code = verification.otp_service.generate_otp(
+        updated.email, EMAIL_VERIFY_PURPOSE, requester_ip=get_client_ip(request)
+    )
+    background_tasks.add_task(send_otp_email, updated.email, code, EMAIL_VERIFY_PURPOSE)
+
+
 @router.put("/me", response_model=UserResponse)
 def update_current_user_profile(
     user_data: UserUpdate,
+    request: Request,
+    background_tasks: BackgroundTasks,
     current_user: Annotated[User, Depends(get_current_active_user)],
     user_service: Annotated[UserService, Depends(get_user_service)],
+    verification: Annotated[
+        EmailVerificationService, Depends(get_email_verification_service)
+    ],
 ) -> UserResponse:
-    """Update current user's profile."""
-    return user_service.update_user_profile(current_user.id, user_data, current_user)
+    """Update current user's profile.
+
+    `email` is an ordinary field here and applies immediately. Doing so clears
+    its verified state, sends a code to the new address, and tells the old
+    address it was replaced. Nothing is gated on being verified — the account
+    keeps working either way — so `is_email_verified` in the response is the
+    signal for a client to prompt.
+    """
+    updated, previous_email = user_service.update_user_profile(
+        current_user.id, user_data, current_user
+    )
+    _after_email_change(
+        updated, previous_email, request, background_tasks, verification
+    )
+    return updated
 
 
 @router.put("/{user_id}", response_model=UserResponse)
 def update_user(
     user_id: int,
     user_data: UserUpdate,
+    request: Request,
+    background_tasks: BackgroundTasks,
     current_user: Annotated[User, Depends(get_current_active_user)],
     user_service: Annotated[UserService, Depends(get_user_service)],
+    verification: Annotated[
+        EmailVerificationService, Depends(get_email_verification_service)
+    ],
 ) -> UserResponse:
-    """Update a user by ID (admin or self only)."""
-    return user_service.update_user_profile(user_id, user_data, current_user)
+    """Update a user by ID (admin or self only).
+
+    An admin changing someone else's `email` behaves exactly as a user changing
+    their own: it applies, the verified state is cleared, and the same two
+    messages go out. There is no separate admin mechanism, and no way for this to
+    lock the target out.
+    """
+    updated, previous_email = user_service.update_user_profile(
+        user_id, user_data, current_user
+    )
+    _after_email_change(
+        updated, previous_email, request, background_tasks, verification
+    )
+    return updated
 
 
 @router.patch("/{user_id}/deactivate", response_model=UserResponse)

--- a/components/backend/src/syfthub/auth/router.py
+++ b/components/backend/src/syfthub/auth/router.py
@@ -22,10 +22,10 @@ from syfthub.core.rate_limit import per_ip_rate_limit
 from syfthub.database.dependencies import (
     get_api_token_service,
     get_auth_service,
+    get_email_verification_service,
     get_otp_service,
 )
 from syfthub.domain.exceptions import (
-    EmailNotVerifiedError,
     InvalidOTPError,
     OTPMaxAttemptsError,
     OTPRateLimitedError,
@@ -42,6 +42,7 @@ from syfthub.schemas.api_token import (
 from syfthub.schemas.auth import (
     AuthConfigResponse,
     AuthResponse,
+    EmailVerifyRequest,
     GoogleAuthRequest,
     PasswordChange,
     PasswordResetConfirm,
@@ -57,6 +58,10 @@ from syfthub.schemas.user import User, UserResponse
 from syfthub.services.api_token_service import APITokenService
 from syfthub.services.auth_service import AuthService
 from syfthub.services.email_service import send_otp_email
+from syfthub.services.email_verification_service import (
+    EMAIL_VERIFY_PURPOSE,
+    EmailVerificationService,
+)
 from syfthub.services.otp_service import OTPService
 
 logger = logging.getLogger(__name__)
@@ -175,17 +180,14 @@ def login_for_access_token(
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
     auth_service: Annotated[AuthService, Depends(get_auth_service)],
 ) -> AuthResponse:
-    """OAuth2 compatible token login, get an access token for future requests."""
-    try:
-        return auth_service.login(form_data.username, form_data.password)
-    except EmailNotVerifiedError as e:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={
-                "code": e.error_code,
-                "message": e.message,
-            },
-        ) from e
+    """OAuth2 compatible token login, get an access token for future requests.
+
+    An unverified email address does not block sign-in. Whether the address on
+    file is proven is a claim about the address, not a permission on the account;
+    clients surface it as a prompt to verify. Gating login on it meant every
+    address change locked the user out.
+    """
+    return auth_service.login(form_data.username, form_data.password)
 
 
 @router.post(
@@ -433,6 +435,68 @@ def confirm_password_reset(
         user_repo.set_email_verified(user.id)
 
     return {"message": "Password has been reset successfully."}
+
+
+# =============================================================================
+# Email verification — proving the address on the account
+# =============================================================================
+# Changing an address is an ordinary profile write (PUT /users/me), which clears
+# its verified state. These endpoints set it again. Verification gates nothing:
+# an unverified address costs the user a tick in the UI, not access to their
+# account.
+#
+# A user who has never verified and has no session yet uses the unauthenticated
+# POST /auth/register/{resend-otp,verify-otp} pair above instead. Both share the
+# same OTP purpose, so they are two doors onto one mechanism, not two mechanisms.
+
+
+@router.post(
+    "/me/email/verify",
+    response_model=UserResponse,
+    dependencies=[_auth_rate_limit],
+    responses={
+        400: {"description": "Invalid or expired code"},
+        422: {"description": "The address is already verified"},
+    },
+)
+def verify_current_email(
+    body: EmailVerifyRequest,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    verification: Annotated[
+        EmailVerificationService, Depends(get_email_verification_service)
+    ],
+) -> UserResponse:
+    """Confirm the address on the account with the code sent to it.
+
+    The address comes from the authenticated user, never the request body, so a
+    caller can only verify their own. A wrong code changes nothing.
+    """
+    return verification.confirm(current_user, body.code)
+
+
+@router.post(
+    "/me/email/resend",
+    status_code=status.HTTP_202_ACCEPTED,
+    dependencies=[_auth_rate_limit],
+    responses={
+        422: {"description": "Already verified, or email delivery is not configured"},
+        429: {"description": "Too many codes requested"},
+    },
+)
+def resend_current_email_code(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    verification: Annotated[
+        EmailVerificationService, Depends(get_email_verification_service)
+    ],
+) -> dict[str, str]:
+    """Send a fresh code to the address on the account."""
+    address, code = verification.send_code(
+        current_user, requester_ip=get_client_ip(request)
+    )
+    background_tasks.add_task(send_otp_email, address, code, EMAIL_VERIFY_PURPOSE)
+    return {"message": f"A verification code was sent to {address}."}
 
 
 # =============================================================================

--- a/components/backend/src/syfthub/database/dependencies.py
+++ b/components/backend/src/syfthub/database/dependencies.py
@@ -19,6 +19,7 @@ from syfthub.services.admin_stats_service import AdminStatsService
 from syfthub.services.api_token_service import APITokenService
 from syfthub.services.auth_service import AuthService
 from syfthub.services.collective_service import CollectiveService
+from syfthub.services.email_verification_service import EmailVerificationService
 from syfthub.services.endpoint_service import EndpointService
 from syfthub.services.otp_service import OTPService
 from syfthub.services.user_service import UserService
@@ -102,6 +103,13 @@ def get_collective_service(
 ) -> CollectiveService:
     """Get CollectiveService dependency."""
     return CollectiveService(session)
+
+
+def get_email_verification_service(
+    session: Annotated[Session, Depends(get_db_session)],
+) -> EmailVerificationService:
+    """Get EmailVerificationService dependency."""
+    return EmailVerificationService(session)
 
 
 def get_otp_service(

--- a/components/backend/src/syfthub/domain/exceptions.py
+++ b/components/backend/src/syfthub/domain/exceptions.py
@@ -212,15 +212,3 @@ class OTPRateLimitedError(DomainException):
             "Too many code requests. Please wait before requesting a new code.",
             "OTP_RATE_LIMITED",
         )
-
-
-class EmailNotVerifiedError(DomainException):
-    """Raised when an unverified user attempts to log in."""
-
-    def __init__(self) -> None:
-        """Initialize email not verified error."""
-        super().__init__(
-            "Email address has not been verified. "
-            "Please check your inbox for a verification code.",
-            "EMAIL_NOT_VERIFIED",
-        )

--- a/components/backend/src/syfthub/models/user.py
+++ b/components/backend/src/syfthub/models/user.py
@@ -43,9 +43,28 @@ class UserModel(BaseModel, TimestampMixin):
     role: Mapped[str] = mapped_column(String(20), nullable=False, default="user")
     password_hash: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
-    is_email_verified: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=True, server_default="1"
+    # When the address currently in ``email`` was proven, or NULL if it has not
+    # been. Cleared on every change of address and set when a code sent to that
+    # address is confirmed, so it describes the address on file and nothing else.
+    #
+    # This gates nothing — login does not consult it. Its one job is to be a
+    # truthful answer to "is this address proven?", which is what an OIDC
+    # ``email_verified`` claim needs. The boolean it replaces also carried the
+    # login gate, which is why changing an address used to lock people out.
+    email_verified_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
     )
+
+    @property
+    def is_email_verified(self) -> bool:
+        """Whether the address on file has been proven.
+
+        Derived, not stored. Kept because it reads better at call sites and is
+        the shape the API and the admin dashboard already expose. Query filters
+        must use ``email_verified_at`` directly — a Python property is invisible
+        to SQL.
+        """
+        return self.email_verified_at is not None
 
     # OAuth fields
     auth_provider: Mapped[str] = mapped_column(

--- a/components/backend/src/syfthub/models/user.py
+++ b/components/backend/src/syfthub/models/user.py
@@ -1,9 +1,10 @@
 """User database model."""
 
+import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional
 
-from sqlalchemy import Boolean, DateTime, Index, String, Text
+from sqlalchemy import Boolean, DateTime, Index, String, Text, Uuid
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from syfthub.models.base import BaseModel, TimestampMixin
@@ -18,6 +19,21 @@ class UserModel(BaseModel, TimestampMixin):
     """User database model."""
 
     __tablename__ = "users"
+
+    # Stable, opaque public identifier. This — never ``id`` — is what leaves the
+    # backend as an external reference to a user (the OIDC ``sub`` claim), so
+    # relying parties never learn SyftHub's internal, sequential primary keys
+    # (see the privacy notes on EndpointPublicResponse). Immutable once assigned.
+    #
+    # The Python-side default covers ORM inserts, including SQLite in dev/tests.
+    # PostgreSQL additionally carries a ``gen_random_uuid()`` server default,
+    # applied in migration 022 rather than declared here: SQLite has no such
+    # function and would choke on it during ``create_all()``. The server default
+    # is what keeps signups working during a deploy, while the previous release
+    # — which knows nothing about this column — is still serving traffic.
+    public_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(), unique=True, nullable=False, default=uuid.uuid4
+    )
 
     # User fields
     username: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)

--- a/components/backend/src/syfthub/repositories/otp.py
+++ b/components/backend/src/syfthub/repositories/otp.py
@@ -92,8 +92,12 @@ class OTPRepository(BaseRepository[OTPCodeModel]):
                 .returning(OTPCodeModel.attempts)
             )
             result = self.session.execute(stmt)
-            self.session.commit()
+            # Consume RETURNING before committing. Reading the cursor after the
+            # commit leaves it open, which on SQLite keeps a lock on the table.
+            # If the commit then fails, the except branch rolls back and returns
+            # 0 exactly as before, so nothing is lost by reading first.
             new_count = result.scalar()
+            self.session.commit()
             return new_count if new_count is not None else 0
         except Exception:
             self.session.rollback()

--- a/components/backend/src/syfthub/repositories/user.py
+++ b/components/backend/src/syfthub/repositories/user.py
@@ -108,7 +108,9 @@ class UserRepository(BaseRepository[UserModel]):
                 full_name=user_data.full_name,
                 password_hash=password_hash,
                 is_active=True,
-                is_email_verified=user_data.is_email_verified,
+                email_verified_at=(
+                    datetime.now(timezone.utc) if user_data.is_email_verified else None
+                ),
                 auth_provider=auth_provider,
                 google_id=google_id,
                 avatar_url=avatar_url,
@@ -134,7 +136,15 @@ class UserRepository(BaseRepository[UserModel]):
             if user_data.username is not None:
                 user_model.username = user_data.username.lower()
             if user_data.email is not None:
-                user_model.email = user_data.email.lower()
+                normalized = user_data.email.lower()
+                if normalized != user_model.email:
+                    # A new address has proven nothing, so the timestamp is
+                    # cleared. Nothing gates on it, so this cannot lock
+                    # anyone out — it only stops the account claiming an
+                    # address nobody proved. Sending the code is the
+                    # service's job, not the repository's.
+                    user_model.email = normalized
+                    user_model.email_verified_at = None
             if user_data.full_name is not None:
                 user_model.full_name = user_data.full_name
             if user_data.avatar_url is not None:
@@ -196,7 +206,7 @@ class UserRepository(BaseRepository[UserModel]):
             if not user_model:
                 return False
 
-            user_model.is_email_verified = True
+            user_model.email_verified_at = datetime.now(timezone.utc)
             self.session.commit()
             return True
         except Exception:
@@ -343,10 +353,10 @@ class UserRepository(BaseRepository[UserModel]):
                 func.count(case((self.model.is_active.is_(False), 1))).label(
                     "inactive"
                 ),
-                func.count(case((self.model.is_email_verified.is_(True), 1))).label(
+                func.count(case((self.model.email_verified_at.is_not(None), 1))).label(
                     "verified"
                 ),
-                func.count(case((self.model.is_email_verified.is_(False), 1))).label(
+                func.count(case((self.model.email_verified_at.is_(None), 1))).label(
                     "unverified"
                 ),
                 func.count(case((self.model.role == UserRole.ADMIN.value, 1))).label(
@@ -385,7 +395,13 @@ class UserRepository(BaseRepository[UserModel]):
             if is_active is not None:
                 stmt = stmt.where(self.model.is_active == is_active)
             if is_email_verified is not None:
-                stmt = stmt.where(self.model.is_email_verified == is_email_verified)
+                # Filter on the column, not the derived property, which SQL
+                # cannot see.
+                stmt = stmt.where(
+                    self.model.email_verified_at.is_not(None)
+                    if is_email_verified
+                    else self.model.email_verified_at.is_(None)
+                )
             if role is not None:
                 stmt = stmt.where(self.model.role == role)
             result = self.session.execute(stmt)
@@ -503,7 +519,11 @@ class UserRepository(BaseRepository[UserModel]):
         if is_active is not None:
             conditions.append(self.model.is_active == is_active)
         if is_email_verified is not None:
-            conditions.append(self.model.is_email_verified == is_email_verified)
+            conditions.append(
+                self.model.email_verified_at.is_not(None)
+                if is_email_verified
+                else self.model.email_verified_at.is_(None)
+            )
         return conditions
 
     def list_users_for_export(

--- a/components/backend/src/syfthub/schemas/auth.py
+++ b/components/backend/src/syfthub/schemas/auth.py
@@ -161,6 +161,22 @@ class VerifyOTPRequest(BaseModel):
     )
 
 
+class EmailVerifyRequest(BaseModel):
+    """Request to confirm the address currently on the authenticated account.
+
+    The address is not in the body: it is read from the authenticated user, so a
+    caller can only ever verify their own.
+    """
+
+    code: str = Field(
+        ...,
+        min_length=6,
+        max_length=6,
+        pattern=r"^\d{6}$",
+        description="6-digit code sent to the address on the account",
+    )
+
+
 class ResendOTPRequest(BaseModel):
     """Request to resend an OTP code."""
 

--- a/components/backend/src/syfthub/schemas/user.py
+++ b/components/backend/src/syfthub/schemas/user.py
@@ -72,6 +72,12 @@ class User(UserBase):
         None,
         description="Timestamp of the user's last successful login (null if never)",
     )
+    # When the address in `email` was proven, or null if it has not been. The
+    # `is_email_verified` boolean on UserBase is derived from this; both are
+    # carried so a response can report either without a second read.
+    email_verified_at: Optional[datetime] = Field(
+        None, description="When the address on file was proven, or null"
+    )
     # MPP wallet fields (Tempo blockchain)
     wallet_address: Optional[str] = Field(
         None, description="Tempo wallet address (Ethereum-format)"
@@ -107,7 +113,14 @@ class UserResponse(BaseModel):
     role: UserRole = Field(..., description="User role")
     is_active: bool = Field(..., description="Whether the user is active")
     is_email_verified: bool = Field(
-        ..., description="Whether the user has verified their email"
+        ..., description="Whether the address on file has been proven"
+    )
+    email_verified_at: Optional[datetime] = Field(
+        None,
+        description=(
+            "When the address on file was proven, or null if it has not been. "
+            "Cleared whenever the address changes. Gates nothing."
+        ),
     )
     auth_provider: AuthProvider = Field(..., description="Authentication provider")
     created_at: datetime = Field(..., description="When the user was created")

--- a/components/backend/src/syfthub/services/auth_service.py
+++ b/components/backend/src/syfthub/services/auth_service.py
@@ -15,7 +15,6 @@ from syfthub.auth.security import (
 )
 from syfthub.core.config import settings
 from syfthub.domain.exceptions import (
-    EmailNotVerifiedError,
     UserAlreadyExistsError,
 )
 from syfthub.repositories.user import UserRepository
@@ -52,7 +51,7 @@ class AuthService(BaseService):
             user: The user model instance.
 
         Returns:
-            Dictionary with the 7 standard user fields.
+            Dictionary with the standard user fields.
         """
         return {
             "id": user.id,
@@ -62,6 +61,10 @@ class AuthService(BaseService):
             "role": user.role,
             "is_active": user.is_active,
             "created_at": user.created_at.isoformat(),
+            # Included so a client can decide whether to prompt for verification
+            # straight from the login or register response, without a follow-up
+            # call to /auth/me.
+            "is_email_verified": user.is_email_verified,
         }
 
     @staticmethod
@@ -136,16 +139,22 @@ class AuthService(BaseService):
         # Generate password hash for SyftHub
         password_hash = hash_password(register_data.password)
 
-        # Email verification is required when Resend is configured
-        require_verification = settings.smtp_configured
+        # A code is sent when email delivery is configured. It does not block
+        # anything: verification is a claim about the address, not a gate on the
+        # account, so registration always hands back tokens and the client nudges
+        # the user to verify. Blocking here would be the same gate login used to
+        # apply, and equally bypassable — the user could just log in instead.
+        verification_sent = settings.smtp_configured
 
-        # Create user data
+        # Never verified at creation: nothing has been proven yet. With no email
+        # delivery configured it simply stays unverified, which is the honest
+        # answer rather than claiming a proof that never happened.
         user_data = UserCreate(
             username=username,
             email=register_data.email,
             full_name=register_data.full_name,
             is_active=True,
-            is_email_verified=not require_verification,
+            is_email_verified=False,
         )
 
         # Create user in database
@@ -160,20 +169,6 @@ class AuthService(BaseService):
                 detail="Failed to create user account",
             )
 
-        if require_verification:
-            # Return response WITHOUT tokens — client must verify OTP first
-            logger.info(
-                f"Registered user {user.username} — email verification required"
-            )
-            return RegistrationResponse(
-                user=self._build_user_dict(user),
-                access_token=None,
-                refresh_token=None,
-                token_type="bearer",
-                requires_email_verification=True,
-            )
-
-        # No verification required — issue tokens immediately
         access_token = create_access_token(
             data={"sub": str(user.id), "username": user.username, "role": user.role}
         )
@@ -181,14 +176,19 @@ class AuthService(BaseService):
             data={"sub": str(user.id), "username": user.username}
         )
 
-        logger.info(f"Successfully registered user: {user.username} ({user.email})")
+        logger.info(
+            "Successfully registered user: %s (%s), verification email sent: %s",
+            user.username,
+            user.email,
+            verification_sent,
+        )
 
         return RegistrationResponse(
             user=self._build_user_dict(user),
             access_token=access_token,
             refresh_token=refresh_token,
             token_type="bearer",
-            requires_email_verification=False,
+            requires_email_verification=verification_sent,
         )
 
     def login_user(self, login_data: UserLogin) -> AuthResponse:
@@ -227,9 +227,10 @@ class AuthService(BaseService):
                 detail="Account is deactivated",
             )
 
-        # Check email verification when Resend is configured
-        if settings.smtp_configured and not user.is_email_verified:
-            raise EmailNotVerifiedError()
+        # Deliberately no email-verification gate. Whether the address on file
+        # is proven says nothing about whether this person may use their own
+        # account, and tying the two together meant any address change locked
+        # the user out. `email_verified_at` is a claim, not a permission.
 
         # Best-effort: stamp last successful login. Never breaks the login flow
         # (update_last_login swallows its own errors and returns a bool).

--- a/components/backend/src/syfthub/services/email_service.py
+++ b/components/backend/src/syfthub/services/email_service.py
@@ -30,7 +30,10 @@ SUBJECTS = {
     "password_reset": "Your SyftHub password reset code",
 }
 
+EMAIL_CHANGED_SUBJECT = "The email address on your SyftHub account was changed"
+
 _otp_template = _jinja_env.get_template("otp_email.html")
+_email_changed_template = _jinja_env.get_template("email_changed_notice.html")
 _invitation_template = _jinja_env.get_template("collective_invitation_email.html")
 
 
@@ -190,3 +193,46 @@ async def send_collective_invitation_email(ctx: InvitationEmailContext) -> None:
         plain_text,
         context="collective_invitation",
     )
+
+
+def _mask_address(address: str) -> str:
+    """Partially hide an address for a notice sent to a different inbox.
+
+    The old address is told *that* it was replaced without being handed the new
+    address in full: if the change was not authorised, the person reading this
+    should not also learn the attacker's inbox.
+    """
+    local, _, domain = address.partition("@")
+    if not domain:
+        return "***"
+    shown = local[:1] if local else ""
+    return f"{shown}{'*' * max(len(local) - 1, 1)}@{domain}"
+
+
+async def send_email_changed_notice(to_email: str, new_email: str) -> None:
+    """Tell a former address that it is no longer on the account.
+
+    Sent to the address being replaced, which is the only inbox the account
+    holder is known to control at that moment. Without it an address change is
+    silent, and a typo — or someone else's change — goes unnoticed until the user
+    needs a password reset that can no longer reach them.
+
+    Designed for FastAPI BackgroundTasks; failures are logged, never raised.
+    """
+    if not settings.smtp_configured:
+        logger.warning("Email not configured — skipping change notice to %s", to_email)
+        return
+
+    html_body = _email_changed_template.render(
+        masked_new_email=_mask_address(new_email),
+        old_email=to_email,
+    )
+    plain_text = (
+        f"The email address on your SyftHub account was changed from {to_email} "
+        f"to {_mask_address(new_email)}.\n"
+        "If you did not make this change, contact support immediately."
+    )
+    try:
+        await _send_via_resend(to_email, EMAIL_CHANGED_SUBJECT, html_body, plain_text)
+    except Exception:
+        logger.exception("Failed to send email-changed notice to %s", to_email)

--- a/components/backend/src/syfthub/services/email_service.py
+++ b/components/backend/src/syfthub/services/email_service.py
@@ -25,8 +25,20 @@ _jinja_env = Environment(
 )
 
 
+# Subject templates per purpose. ``{code}`` is substituted where the code is
+# safe to expose in a subject line.
+#
+# Leading with the code lets Gmail and iOS surface it in the notification and the
+# inbox list, so the common case never involves opening the message — the closest
+# thing to a "copy" affordance an email can have, since mail clients strip all
+# scripting and a real clipboard button would be inert.
+#
+# Deliberately NOT done for password reset: a subject line is visible on a locked
+# screen, and proving you own an address is a much smaller thing to leak that way
+# than a credential-reset code.
 SUBJECTS = {
-    "registration": "Your SyftHub verification code",
+    "registration": "{code} is your SyftHub verification code",
+    "email_change": "{code} is your SyftHub verification code",
     "password_reset": "Your SyftHub password reset code",
 }
 
@@ -74,7 +86,7 @@ async def send_otp_email(to_email: str, code: str, purpose: str) -> None:
         purpose=purpose,
         expiry_minutes=settings.otp_expiry_minutes,
     )
-    subject = SUBJECTS.get(purpose, "Your SyftHub verification code")
+    subject = SUBJECTS.get(purpose, "Your SyftHub verification code").format(code=code)
     plain_text = (
         f"Your SyftHub verification code is: {code}\n"
         f"This code expires in {settings.otp_expiry_minutes} minutes."

--- a/components/backend/src/syfthub/services/email_verification_service.py
+++ b/components/backend/src/syfthub/services/email_verification_service.py
@@ -1,0 +1,119 @@
+"""Proving that the address on a user's account is real.
+
+An email address is a claim SyftHub makes about a user, and one that relying
+parties act on — an OIDC ``email_verified`` claim is what lets an app link an
+account by email. So the claim must only ever be true of an address whose owner
+actually proved control of it.
+
+That is the *only* job here. Verification gates nothing: an unverified address
+does not block sign-in or anything else, because whether an address is proven
+says nothing about whether the account holder may use their own account. Tying
+the two together is what previously locked users out whenever their address
+changed.
+
+Changing an address is therefore an ordinary profile write (see
+``UserService.update_user_profile``), which clears ``email_verified_at``. This
+service exists to set it again.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from syfthub.core.config import settings
+from syfthub.domain.exceptions import NotFoundError, ValidationError
+from syfthub.repositories.user import UserRepository
+from syfthub.schemas.user import User, UserResponse
+from syfthub.services.base import BaseService
+from syfthub.services.otp_service import OTPService
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# Purpose the verification codes are stored under.
+#
+# Shared with registration on purpose: both prove "the address on this account is
+# real", and sharing it means the existing unauthenticated
+# POST /auth/register/{resend-otp,verify-otp} pair keeps working for a user who
+# has no session yet. One concept, one purpose, no third code path.
+EMAIL_VERIFY_PURPOSE = "registration"
+
+
+class EmailVerificationService(BaseService):
+    """Sends and confirms proof of the address currently on an account."""
+
+    def __init__(self, session: Session):
+        """Initialize the email-verification service."""
+        super().__init__(session)
+        self.user_repository = UserRepository(session)
+        self.otp_service = OTPService(session)
+
+    def send_code(
+        self, current_user: User, *, requester_ip: Optional[str] = None
+    ) -> tuple[str, str]:
+        """Mint a code for the address currently on the account.
+
+        Returns ``(address, code)`` so the caller can hand delivery to a
+        background task; this service sends no mail itself.
+
+        Raises:
+            ValidationError: If the address is already verified, or email
+                delivery is not configured so no code could ever arrive.
+            NotFoundError: If the user no longer exists.
+            OTPRateLimitedError: If too many codes were requested recently.
+        """
+        user = self._reread(current_user)
+
+        if not settings.smtp_configured:
+            raise ValidationError(
+                "Email delivery is not configured, so addresses cannot be verified"
+            )
+        if user.is_email_verified:
+            raise ValidationError("Your email address is already verified")
+
+        code = self.otp_service.generate_otp(
+            user.email, EMAIL_VERIFY_PURPOSE, requester_ip=requester_ip
+        )
+        return user.email, code
+
+    def confirm(self, current_user: User, code: str) -> UserResponse:
+        """Verify a code against the address on the account and record the proof.
+
+        Raises:
+            ValidationError: If the address is already verified.
+            InvalidOTPError: If the code is wrong or expired.
+            OTPMaxAttemptsError: If too many attempts were made.
+            NotFoundError: If the user no longer exists.
+        """
+        user = self._reread(current_user)
+        if user.is_email_verified:
+            raise ValidationError("Your email address is already verified")
+
+        # Verify before recording anything: a bad code must leave the account
+        # untouched so the user can retry.
+        self.otp_service.verify_otp(user.email, code, EMAIL_VERIFY_PURPOSE)
+
+        if not self.user_repository.set_email_verified(user.id):
+            raise NotFoundError("User")
+
+        updated = self.user_repository.get_by_id(user.id)
+        if updated is None:
+            raise NotFoundError("User")
+
+        logger.info("Email verified for user %s (%s)", user.id, user.email)
+        return UserResponse.model_validate(updated)
+
+    def _reread(self, current_user: User) -> User:
+        """Return the user as stored, not as the auth dependency snapshotted them.
+
+        ``current_user`` may predate a change made earlier in this same request —
+        an address updated by ``PUT /users/me``, for instance — so the address and
+        its verified state are always read back from the database.
+        """
+        user = self.user_repository.get_by_id(current_user.id)
+        if user is None:
+            raise NotFoundError("User")
+        return user

--- a/components/backend/src/syfthub/services/user_service.py
+++ b/components/backend/src/syfthub/services/user_service.py
@@ -86,8 +86,20 @@ class UserService(BaseService):
 
     def update_user_profile(
         self, user_id: int, user_data: UserUpdate, current_user: User
-    ) -> UserResponse:
-        """Update user profile."""
+    ) -> tuple[UserResponse, Optional[str]]:
+        """Update user profile.
+
+        Returns ``(user, previous_email)``, where ``previous_email`` is set only
+        when the address actually moved. The caller uses it to send a
+        verification code to the new address and to tell the old address it was
+        replaced — neither of which this service does itself, since it has no
+        business knowing about mail transport.
+
+        Changing an address clears its verified state (see
+        ``UserRepository.update_user``). That is safe here because nothing gates
+        on it: an unverified address costs the user a tick in the UI, not access
+        to their account.
+        """
         # Check permissions - users can only update their own profile, admins can update any
         if current_user.id != user_id and current_user.role != "admin":
             raise PermissionDeniedError("Can only update your own profile")
@@ -106,12 +118,21 @@ class UserService(BaseService):
             if existing_user and existing_user.id != user_id:
                 raise ConflictError("user", "email")
 
-        # Update user
+        # Read the address before the write so the caller can tell whether it
+        # moved, and what it moved from.
+        before = self.user_repository.get_by_id(user_id)
+        if before is None:
+            raise NotFoundError("User")
+        previous_email = before.email
+
         updated_user = self.user_repository.update_user(user_id, user_data)
         if not updated_user:
             raise NotFoundError("User")
 
-        return UserResponse.model_validate(updated_user)
+        changed = updated_user.email.lower() != previous_email.lower()
+        return UserResponse.model_validate(updated_user), (
+            previous_email if changed else None
+        )
 
     def deactivate_user(self, user_id: int, current_user: User) -> bool:
         """Deactivate a user account."""

--- a/components/backend/src/syfthub/templates/email_changed_notice.html
+++ b/components/backend/src/syfthub/templates/email_changed_notice.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<body style="margin:0;padding:0;background-color:#fafafa;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#fafafa;padding:40px 0;">
+        <tr>
+            <td align="center">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:480px;background-color:#ffffff;border-radius:12px;border:1px solid #e4e4e7;">
+                    <tr>
+                        <td style="padding:24px 32px 0;">
+                            <p style="margin:0;font-size:13px;font-weight:600;letter-spacing:0.5px;color:#71717a;text-transform:uppercase;">SyftHub</p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding:24px 32px 32px;">
+                            <p style="margin:0 0 16px;color:#18181b;font-size:17px;font-weight:600;line-height:1.4;">
+                                The email address on your account was changed
+                            </p>
+                            <p style="margin:0 0 16px;color:#3f3f46;font-size:15px;line-height:1.6;">
+                                Your SyftHub account no longer uses <strong>{{ old_email }}</strong>. It now uses
+                                <strong>{{ masked_new_email }}</strong>, and future messages will go there instead.
+                            </p>
+                            <p style="margin:0;color:#71717a;font-size:13px;line-height:1.5;">
+                                If you made this change, nothing more is needed. If you did not, contact support
+                                straight away — this address can no longer receive password resets for the account.
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/components/backend/tests/test_auth_otp.py
+++ b/components/backend/tests/test_auth_otp.py
@@ -80,14 +80,25 @@ def test_register_without_verification(client: TestClient) -> None:
 
 
 @patch("syfthub.auth.router.send_otp_email", new_callable=AsyncMock)
-def test_register_with_verification(mock_send, client: TestClient, monkeypatch) -> None:
-    """Registration withholds tokens when verification is enabled."""
+def test_register_issues_tokens_and_asks_for_verification(
+    mock_send, client: TestClient, monkeypatch
+) -> None:
+    """Registration hands back tokens and *asks* for verification.
+
+    It does not withhold them. Verification is a claim about the address, not a
+    permission on the account, so blocking here would be the same gate login used
+    to apply — and just as bypassable, since the user could simply log in.
+    `requires_email_verification` now means "a code was sent", a cue for the
+    client to prompt.
+    """
     monkeypatch.setattr("syfthub.core.config.settings.resend_api_key", "re_test_key")
     result = _register_user(client)
-    assert result["access_token"] is None
-    assert result["refresh_token"] is None
+    assert result["access_token"] is not None
+    assert result["refresh_token"] is not None
     assert result["requires_email_verification"] is True
     assert result["user"]["email"] == "otp@example.com"
+    # The address itself is not verified — nothing has been proven yet.
+    assert result["user"]["is_email_verified"] is False
 
 
 # =============================================================================
@@ -213,8 +224,15 @@ def test_resend_otp_nonexistent_email(client: TestClient) -> None:
 # POST /login with email verification
 # =============================================================================
 @patch("syfthub.auth.router.send_otp_email", new_callable=AsyncMock)
-def test_login_blocked_unverified(mock_send, client: TestClient, monkeypatch) -> None:
-    """Login with unverified email returns 403."""
+def test_login_allowed_while_unverified(
+    mock_send, client: TestClient, monkeypatch
+) -> None:
+    """An unverified address does not block sign-in.
+
+    Whether the address on file is proven says nothing about whether this person
+    may use their own account. Gating the two together meant every address change
+    locked the user out; clients now surface the unverified state as a prompt.
+    """
     monkeypatch.setattr("syfthub.core.config.settings.resend_api_key", "re_test_key")
     _register_user(client)
 
@@ -222,8 +240,9 @@ def test_login_blocked_unverified(mock_send, client: TestClient, monkeypatch) ->
         "/api/v1/auth/login",
         data={"username": "otpuser", "password": "testpass123"},
     )
-    assert response.status_code == 403
-    assert response.json()["detail"]["code"] == "EMAIL_NOT_VERIFIED"
+    assert response.status_code == 200
+    assert response.json()["access_token"]
+    assert response.json()["user"]["is_email_verified"] is False
 
 
 # =============================================================================

--- a/components/backend/tests/test_email_verification.py
+++ b/components/backend/tests/test_email_verification.py
@@ -1,0 +1,353 @@
+"""Tests for the email-verification model.
+
+The invariant: ``email_verified_at`` is true of the address on file and nothing
+else. It is set only by real proof, cleared whenever the address changes, and
+gates nothing — so a change can never cost anyone access to their account.
+"""
+
+from __future__ import annotations
+
+from typing import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from syfthub.auth.security import token_blacklist
+from syfthub.main import app
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    """Test client against a clean database."""
+    from syfthub.database.connection import create_tables, drop_tables
+
+    drop_tables()
+    create_tables()
+    yield TestClient(app)
+    drop_tables()
+
+
+@pytest.fixture(autouse=True)
+def reset_auth_data() -> None:
+    """Clear the token blacklist between tests."""
+    token_blacklist.clear()
+
+
+@pytest.fixture
+def smtp_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend email delivery is configured."""
+    monkeypatch.setattr("syfthub.core.config.settings.resend_api_key", "re_test_key")
+
+
+def _register(client: TestClient, username: str) -> str:
+    response = client.post(
+        "/api/v1/auth/register",
+        json={
+            "username": username,
+            "email": f"{username}@example.com",
+            "full_name": f"{username.title()} User",
+            "password": "testpass123",
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["access_token"]
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _code_for(email: str) -> str:
+    """Recover a hashed OTP from the store; codes only ever leave by email."""
+    from syfthub.database.connection import SessionLocal
+    from syfthub.repositories.otp import OTPRepository
+    from syfthub.services.otp_service import _hash_code
+
+    session = SessionLocal()
+    try:
+        otp = OTPRepository(session).get_active_otp(email, "registration")
+        assert otp is not None, f"no active code for {email}"
+        for candidate in range(1_000_000):
+            code = f"{candidate:06d}"
+            if _hash_code(code) == otp.code_hash:
+                return code
+        raise AssertionError("could not recover the code")
+    finally:
+        session.close()
+
+
+class TestChangingTheAddress:
+    """An address change is an ordinary profile write."""
+
+    @patch("syfthub.api.endpoints.users.send_otp_email", new_callable=AsyncMock)
+    @patch(
+        "syfthub.api.endpoints.users.send_email_changed_notice", new_callable=AsyncMock
+    )
+    def test_applies_immediately_and_drops_the_verified_state(
+        self, _notice, _code, client: TestClient, smtp_on: None
+    ) -> None:
+        token = _register(client, "alice")
+        # Prove the original address so there is a verified state to lose.
+        client.post(
+            "/api/v1/auth/register/verify-otp",
+            json={"email": "alice@example.com", "code": _code_for("alice@example.com")},
+        )
+
+        response = client.put(
+            "/api/v1/users/me",
+            json={"email": "new@example.com"},
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["email"] == "new@example.com"
+        assert body["is_email_verified"] is False
+        assert body["email_verified_at"] is None
+
+    @patch("syfthub.api.endpoints.users.send_otp_email", new_callable=AsyncMock)
+    @patch(
+        "syfthub.api.endpoints.users.send_email_changed_notice", new_callable=AsyncMock
+    )
+    def test_login_still_works_afterwards(
+        self, _notice, _code, client: TestClient, smtp_on: None
+    ) -> None:
+        """The whole point of the split: a change costs a tick, not access."""
+        token = _register(client, "alice")
+        client.put(
+            "/api/v1/users/me",
+            json={"email": "new@example.com"},
+            headers=_auth(token),
+        )
+
+        response = client.post(
+            "/api/v1/auth/login",
+            data={"username": "new@example.com", "password": "testpass123"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["user"]["is_email_verified"] is False
+
+    @patch("syfthub.api.endpoints.users.send_otp_email", new_callable=AsyncMock)
+    @patch(
+        "syfthub.api.endpoints.users.send_email_changed_notice", new_callable=AsyncMock
+    )
+    def test_warns_the_address_it_replaced(
+        self, notice, _code, client: TestClient, smtp_on: None
+    ) -> None:
+        """The old inbox is the only one the account holder is known to control."""
+        token = _register(client, "alice")
+        client.put(
+            "/api/v1/users/me",
+            json={"email": "new@example.com"},
+            headers=_auth(token),
+        )
+
+        notice.assert_called_once()
+        assert notice.call_args.args[0] == "alice@example.com"
+
+    @patch("syfthub.api.endpoints.users.send_otp_email", new_callable=AsyncMock)
+    @patch(
+        "syfthub.api.endpoints.users.send_email_changed_notice", new_callable=AsyncMock
+    )
+    def test_sends_a_code_to_the_new_address(
+        self, _notice, code, client: TestClient, smtp_on: None
+    ) -> None:
+        token = _register(client, "alice")
+        client.put(
+            "/api/v1/users/me",
+            json={"email": "new@example.com"},
+            headers=_auth(token),
+        )
+
+        assert code.call_args.args[0] == "new@example.com"
+
+    @patch("syfthub.api.endpoints.users.send_otp_email", new_callable=AsyncMock)
+    @patch(
+        "syfthub.api.endpoints.users.send_email_changed_notice", new_callable=AsyncMock
+    )
+    def test_an_unchanged_address_sends_nothing(
+        self, notice, code, client: TestClient, smtp_on: None
+    ) -> None:
+        """A client round-tripping a whole profile object must not trigger mail."""
+        token = _register(client, "alice")
+
+        response = client.put(
+            "/api/v1/users/me",
+            json={"email": "ALICE@example.com", "full_name": "Alice Renamed"},
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 200
+        assert response.json()["full_name"] == "Alice Renamed"
+        notice.assert_not_called()
+        code.assert_not_called()
+
+    def test_an_address_held_by_another_account_is_refused(
+        self, client: TestClient
+    ) -> None:
+        _register(client, "bob")
+        token = _register(client, "alice")
+
+        response = client.put(
+            "/api/v1/users/me",
+            json={"email": "bob@example.com"},
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 409
+
+
+class TestVerifyingTheAddress:
+    """POST /auth/me/email/{resend,verify} prove the address on file."""
+
+    @patch("syfthub.auth.router.send_otp_email", new_callable=AsyncMock)
+    def test_resend_then_verify_records_the_proof(
+        self, _send, client: TestClient, smtp_on: None
+    ) -> None:
+        token = _register(client, "alice")
+
+        assert (
+            client.post(
+                "/api/v1/auth/me/email/resend", headers=_auth(token)
+            ).status_code
+            == 202
+        )
+        response = client.post(
+            "/api/v1/auth/me/email/verify",
+            json={"code": _code_for("alice@example.com")},
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["is_email_verified"] is True
+        assert response.json()["email_verified_at"] is not None
+
+    @patch("syfthub.auth.router.send_otp_email", new_callable=AsyncMock)
+    def test_a_wrong_code_records_nothing(
+        self, _send, client: TestClient, smtp_on: None
+    ) -> None:
+        token = _register(client, "alice")
+        client.post("/api/v1/auth/me/email/resend", headers=_auth(token))
+
+        response = client.post(
+            "/api/v1/auth/me/email/verify",
+            json={"code": "000000"},
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 400
+        me = client.get("/api/v1/auth/me", headers=_auth(token)).json()
+        assert me["is_email_verified"] is False
+
+    @patch("syfthub.auth.router.send_otp_email", new_callable=AsyncMock)
+    def test_verifying_twice_is_refused(
+        self, _send, client: TestClient, smtp_on: None
+    ) -> None:
+        token = _register(client, "alice")
+        client.post("/api/v1/auth/me/email/resend", headers=_auth(token))
+        code = _code_for("alice@example.com")
+        client.post(
+            "/api/v1/auth/me/email/verify", json={"code": code}, headers=_auth(token)
+        )
+
+        response = client.post(
+            "/api/v1/auth/me/email/verify", json={"code": code}, headers=_auth(token)
+        )
+
+        assert response.status_code == 422
+
+    def test_requires_authentication(self, client: TestClient) -> None:
+        assert client.post(
+            "/api/v1/auth/me/email/verify", json={"code": "123456"}
+        ).status_code in (401, 403)
+        assert client.post("/api/v1/auth/me/email/resend").status_code in (401, 403)
+
+
+class TestWithoutEmailDelivery:
+    """No SMTP means nothing can be proven — and nothing pretends otherwise."""
+
+    def test_registration_leaves_the_address_unverified(
+        self, client: TestClient
+    ) -> None:
+        """The old code set the flag true here, with no proof whatsoever."""
+        token = _register(client, "alice")
+
+        me = client.get("/api/v1/auth/me", headers=_auth(token)).json()
+        assert me["is_email_verified"] is False
+        assert me["email_verified_at"] is None
+
+    def test_registration_still_hands_back_tokens(self, client: TestClient) -> None:
+        token = _register(client, "alice")
+        assert token
+
+    @patch(
+        "syfthub.api.endpoints.users.send_email_changed_notice", new_callable=AsyncMock
+    )
+    def test_a_change_applies_and_stays_unverified(
+        self, _notice, client: TestClient
+    ) -> None:
+        token = _register(client, "alice")
+
+        response = client.put(
+            "/api/v1/users/me",
+            json={"email": "new@example.com"},
+            headers=_auth(token),
+        )
+
+        assert response.status_code == 200
+        assert response.json()["email"] == "new@example.com"
+        assert response.json()["is_email_verified"] is False
+
+    def test_asking_for_a_code_is_refused(self, client: TestClient) -> None:
+        """Better a clear 422 than a code nobody can ever receive."""
+        token = _register(client, "alice")
+
+        response = client.post("/api/v1/auth/me/email/resend", headers=_auth(token))
+
+        assert response.status_code == 422
+
+
+class TestAdminChangingAnAddress:
+    """Identical semantics; there is no separate admin mechanism any more."""
+
+    @patch("syfthub.api.endpoints.users.send_otp_email", new_callable=AsyncMock)
+    @patch(
+        "syfthub.api.endpoints.users.send_email_changed_notice", new_callable=AsyncMock
+    )
+    def test_admin_change_cannot_lock_the_user_out(
+        self, _notice, _code, client: TestClient, smtp_on: None
+    ) -> None:
+        alice_token = _register(client, "alice")
+        alice_id = client.get("/api/v1/auth/me", headers=_auth(alice_token)).json()[
+            "id"
+        ]
+        admin_token = _register(client, "root")
+        from syfthub.database.connection import SessionLocal
+        from syfthub.models.user import UserModel
+
+        session = SessionLocal()
+        try:
+            session.query(UserModel).filter(
+                UserModel.username == "root"
+            ).one().role = "admin"
+            session.commit()
+        finally:
+            session.close()
+
+        response = client.put(
+            f"/api/v1/users/{alice_id}",
+            json={"email": "moved@example.com"},
+            headers=_auth(admin_token),
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["email"] == "moved@example.com"
+        assert response.json()["is_email_verified"] is False
+        # And alice can still sign in — the thing that used to break.
+        login = client.post(
+            "/api/v1/auth/login",
+            data={"username": "moved@example.com", "password": "testpass123"},
+        )
+        assert login.status_code == 200

--- a/components/backend/tests/test_repositories/test_user.py
+++ b/components/backend/tests/test_repositories/test_user.py
@@ -17,7 +17,7 @@ def _make_user(username: str, **overrides) -> UserModel:
         "full_name": f"{username.title()} User",
         "role": "user",
         "is_active": True,
-        "is_email_verified": True,
+        "email_verified_at": datetime.now(timezone.utc),
         "auth_provider": "local",
         "password_hash": "x",
     }
@@ -55,7 +55,7 @@ class TestListUsersAdmin:
             [
                 _make_user("alice", role="admin"),
                 _make_user("bob", is_active=False),
-                _make_user("carol", is_email_verified=False),
+                _make_user("carol", email_verified_at=None),
                 _make_user("dave"),
             ]
         )

--- a/components/backend/tests/test_services/test_admin_stats_service.py
+++ b/components/backend/tests/test_services/test_admin_stats_service.py
@@ -16,7 +16,7 @@ def _make_user(username: str, **overrides) -> UserModel:
         "full_name": f"{username.title()} User",
         "role": "user",
         "is_active": True,
-        "is_email_verified": True,
+        "email_verified_at": datetime.now(timezone.utc),
         "auth_provider": "local",
         "password_hash": "x",
     }
@@ -77,7 +77,7 @@ class TestAggregationCorrectness:
                 _make_user(
                     "user2",
                     is_active=False,
-                    is_email_verified=False,
+                    email_verified_at=None,
                     last_login_at=now - timedelta(days=45),
                 ),
                 # guest, active, verified, local, never logged in

--- a/components/backend/tests/test_services/test_user_service.py
+++ b/components/backend/tests/test_services/test_user_service.py
@@ -170,14 +170,21 @@ class TestUserServiceUpdateProfile:
                 user_service.user_repository, "email_exists", return_value=False
             ),
             patch.object(
+                user_service.user_repository, "get_by_id", return_value=sample_user
+            ),
+            patch.object(
                 user_service.user_repository, "update_user", return_value=updated_user
             ),
         ):
-            result = user_service.update_user_profile(1, update_data, sample_user)
+            result, previous_email = user_service.update_user_profile(
+                1, update_data, sample_user
+            )
 
             assert isinstance(result, UserResponse)
             assert result.full_name == "Updated Name"
             assert result.avatar_url == "https://example.com/avatar.png"
+            # The address did not move, so there is nothing for the caller to send.
+            assert previous_email is None
 
     def test_update_user_profile_admin_updates_other(
         self, user_service, sample_user, admin_user
@@ -193,12 +200,46 @@ class TestUserServiceUpdateProfile:
                 user_service.user_repository, "email_exists", return_value=False
             ),
             patch.object(
+                user_service.user_repository, "get_by_id", return_value=sample_user
+            ),
+            patch.object(
                 user_service.user_repository, "update_user", return_value=updated_user
             ),
         ):
-            result = user_service.update_user_profile(1, update_data, admin_user)
+            result, previous_email = user_service.update_user_profile(
+                1, update_data, admin_user
+            )
 
             assert result.full_name == "Admin Updated"
+            assert previous_email is None
+
+    def test_update_user_profile_reports_a_changed_address(
+        self, user_service, sample_user
+    ):
+        """A moved address is reported back, so the caller can send the code and
+        warn the address it replaced."""
+        update_data = UserUpdate(email="moved@example.com")
+        user_dict = sample_user.model_dump()
+        user_dict.update({"email": "moved@example.com", "email_verified_at": None})
+        updated_user = User(**user_dict)
+
+        with (
+            patch.object(
+                user_service.user_repository, "email_exists", return_value=False
+            ),
+            patch.object(
+                user_service.user_repository, "get_by_id", return_value=sample_user
+            ),
+            patch.object(
+                user_service.user_repository, "update_user", return_value=updated_user
+            ),
+        ):
+            result, previous_email = user_service.update_user_profile(
+                1, update_data, sample_user
+            )
+
+            assert result.email == "moved@example.com"
+            assert previous_email == sample_user.email
 
     def test_update_user_profile_permission_denied(self, user_service, sample_user):
         """Test permission denied when updating another user's profile."""

--- a/components/frontend/src/components/__tests__/email-verification-controls.test.tsx
+++ b/components/frontend/src/components/__tests__/email-verification-controls.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EmailVerificationControls } from '@/components/auth/email-verification-controls';
+
+const { mockUpdateUser } = vi.hoisted(() => ({ mockUpdateUser: vi.fn() }));
+vi.mock('@/context/auth-context', () => ({
+  useAuth: (): unknown => ({ updateUser: mockUpdateUser })
+}));
+
+const { mockVerify, mockResend } = vi.hoisted(() => ({
+  mockVerify: vi.fn(),
+  mockResend: vi.fn()
+}));
+vi.mock('@/lib/sdk-client', () => ({
+  verifyEmailAPI: (code: string): unknown => mockVerify(code),
+  resendEmailVerificationAPI: (): unknown => mockResend()
+}));
+
+function setup() {
+  render(<EmailVerificationControls email='alice@example.com' />);
+}
+
+describe('EmailVerificationControls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResend.mockResolvedValue(null);
+    mockVerify.mockResolvedValue({ email: 'alice@example.com', is_email_verified: true });
+  });
+
+  it('offers to send a code, with no input until one is asked for', () => {
+    setup();
+
+    expect(screen.getByRole('button', { name: 'Verify now' })).toBeEnabled();
+    expect(screen.queryByLabelText(/verification code/i)).not.toBeInTheDocument();
+  });
+
+  it('sends a code, reveals the input, and blocks resending briefly', async () => {
+    const user = userEvent.setup();
+    setup();
+
+    await user.click(screen.getByRole('button', { name: 'Verify now' }));
+
+    await waitFor(() => {
+      expect(mockResend).toHaveBeenCalledTimes(1);
+    });
+    expect(await screen.findByLabelText(/verification code/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Resend in \d+s/ })).toBeDisabled();
+    });
+  });
+
+  it('keeps Verify disabled until six digits are entered', async () => {
+    const user = userEvent.setup();
+    setup();
+    await user.click(screen.getByRole('button', { name: 'Verify now' }));
+
+    const input = await screen.findByLabelText(/verification code/i);
+    const verify = screen.getByRole('button', { name: 'Verify' });
+    expect(verify).toBeDisabled();
+
+    await user.type(input, '123456');
+    expect(verify).toBeEnabled();
+  });
+
+  it('strips non-digits from the code', async () => {
+    const user = userEvent.setup();
+    setup();
+    await user.click(screen.getByRole('button', { name: 'Verify now' }));
+
+    const input = await screen.findByLabelText(/verification code/i);
+    await user.type(input, '12ab34cd56');
+
+    expect(input).toHaveValue('123456');
+  });
+
+  it('folds a confirmed address into the session', async () => {
+    const user = userEvent.setup();
+    setup();
+    await user.click(screen.getByRole('button', { name: 'Verify now' }));
+    await user.type(await screen.findByLabelText(/verification code/i), '123456');
+
+    await user.click(screen.getByRole('button', { name: 'Verify' }));
+
+    await waitFor(() => {
+      expect(mockVerify).toHaveBeenCalledWith('123456');
+    });
+    // Both surfaces render off the session, so updating it makes them vanish.
+    expect(mockUpdateUser).toHaveBeenCalled();
+  });
+
+  it('reports a rejected code and clears the field, without touching the session', async () => {
+    const user = userEvent.setup();
+    mockVerify.mockRejectedValue(new Error('Invalid or expired verification code'));
+    setup();
+    await user.click(screen.getByRole('button', { name: 'Verify now' }));
+    await user.type(await screen.findByLabelText(/verification code/i), '000000');
+
+    await user.click(screen.getByRole('button', { name: 'Verify' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid or expired verification code')).toBeInTheDocument();
+    });
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+    expect(screen.getByLabelText(/verification code/i)).toHaveValue('');
+  });
+
+  it('reports a failure to send', async () => {
+    const user = userEvent.setup();
+    mockResend.mockRejectedValue(new Error('Too many codes requested'));
+    setup();
+
+    await user.click(screen.getByRole('button', { name: 'Verify now' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Too many codes requested')).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText(/verification code/i)).not.toBeInTheDocument();
+  });
+});

--- a/components/frontend/src/components/__tests__/profile-view-email.test.tsx
+++ b/components/frontend/src/components/__tests__/profile-view-email.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProfileView } from '@/components/profile-view';
+
+vi.mock('framer-motion', () => import('@/test/mocks/framer-motion'));
+
+const { mockUseAuth } = vi.hoisted(() => ({ mockUseAuth: vi.fn() }));
+vi.mock('@/context/auth-context', () => ({ useAuth: (): unknown => mockUseAuth() }));
+
+const { mockAvailable } = vi.hoisted(() => ({ mockAvailable: vi.fn() }));
+vi.mock('@/hooks/use-auth-config', () => ({
+  useEmailVerificationAvailable: (): unknown => mockAvailable()
+}));
+
+vi.mock('@/lib/sdk-client', () => ({
+  updateUserProfileAPI: vi.fn(),
+  changePasswordAPI: vi.fn(),
+  verifyEmailAPI: vi.fn(),
+  resendEmailVerificationAPI: vi.fn()
+}));
+
+const baseUser = {
+  id: '1',
+  username: 'maguser',
+  email: 'maguser@openmined.org',
+  name: 'Mag User',
+  full_name: 'Mag User',
+  role: 'user',
+  is_active: true,
+  created_at: '2026-07-21T00:00:00Z',
+  updated_at: '2026-07-21T00:00:00Z'
+};
+
+function setup(overrides: Record<string, unknown> = {}) {
+  mockUseAuth.mockReturnValue({
+    user: { ...baseUser, ...overrides },
+    updateUser: vi.fn(),
+    refreshUser: vi.fn()
+  });
+  render(<ProfileView />);
+}
+
+describe('ProfileView email verification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAvailable.mockReturnValue(true);
+  });
+
+  it('offers a way to verify when the address is unverified', () => {
+    // The banner is dismissible, so this must always be reachable — otherwise
+    // dismissing it leaves no route to verify at all.
+    setup({ is_email_verified: false });
+
+    expect(screen.getByText(/not verified/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Verify now' })).toBeInTheDocument();
+  });
+
+  it('shows a tick and no control once verified', () => {
+    setup({ is_email_verified: true });
+
+    expect(screen.getByText('Verified')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Verify now' })).not.toBeInTheDocument();
+  });
+
+  it('says nothing about verification when the server cannot send email', () => {
+    // Addresses cannot be proven in that deployment, so "not verified" would be a
+    // permanent complaint about something the reader cannot fix.
+    mockAvailable.mockReturnValue(false);
+    setup({ is_email_verified: false });
+
+    expect(screen.queryByText(/not verified/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Verify now' })).not.toBeInTheDocument();
+    expect(screen.getByText('Email address')).toBeInTheDocument();
+  });
+});

--- a/components/frontend/src/components/__tests__/verify-email-banner.test.tsx
+++ b/components/frontend/src/components/__tests__/verify-email-banner.test.tsx
@@ -3,15 +3,16 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { VerifyEmailBanner } from '@/components/auth/verify-email-banner';
+import { useVerifyEmailBannerStore } from '@/stores/verify-email-banner-store';
 
 vi.mock('framer-motion', () => import('@/test/mocks/framer-motion'));
 
 const { mockUseAuth } = vi.hoisted(() => ({ mockUseAuth: vi.fn() }));
 vi.mock('@/context/auth-context', () => ({ useAuth: (): unknown => mockUseAuth() }));
 
-const { mockAvailable } = vi.hoisted(() => ({ mockAvailable: vi.fn() }));
+const { mockShouldPrompt } = vi.hoisted(() => ({ mockShouldPrompt: vi.fn() }));
 vi.mock('@/hooks/use-auth-config', () => ({
-  useEmailVerificationAvailable: (): unknown => mockAvailable()
+  useShouldPromptEmailVerification: (): unknown => mockShouldPrompt()
 }));
 
 const { mockVerify, mockResend } = vi.hoisted(() => ({
@@ -47,12 +48,17 @@ describe('VerifyEmailBanner', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sessionStorage.clear();
-    mockAvailable.mockReturnValue(true);
+    mockShouldPrompt.mockReturnValue(true);
+    useVerifyEmailBannerStore.setState({ dismissed: false });
     mockResend.mockResolvedValue(null);
     mockVerify.mockResolvedValue({ ...verifiedUser, is_email_verified: true });
   });
 
-  it('stays hidden when the address is verified', () => {
+  it('stays hidden when the prompt is not wanted', () => {
+    // Verified, dismissed, no user, or a server that cannot send email — the
+    // hook folds all four into one decision so the banner and the layout, which
+    // shifts its header to make room, can never disagree.
+    mockShouldPrompt.mockReturnValue(false);
     setup();
     expect(screen.queryByTestId('verify-email-banner')).not.toBeInTheDocument();
   });
@@ -63,14 +69,18 @@ describe('VerifyEmailBanner', () => {
     expect(screen.getByText('alice@example.com')).toBeInTheDocument();
   });
 
-  it('stays hidden when the server cannot send email', () => {
-    // No code could ever arrive, so prompting would be a dead end.
-    mockAvailable.mockReturnValue(false);
+  it('names the address, with a space before the sentence continues', () => {
+    // Regression: esbuild trimmed the JSX whitespace after </strong>, rendering
+    // "openmined.orgisn't verified yet".
     setup({ is_email_verified: false });
-    expect(screen.queryByTestId('verify-email-banner')).not.toBeInTheDocument();
+
+    expect(screen.getByTestId('verify-email-banner')).toHaveTextContent(
+      "alice@example.com isn't verified yet"
+    );
   });
 
   it('stays hidden when there is no user', () => {
+    mockShouldPrompt.mockReturnValue(false);
     mockUseAuth.mockReturnValue({ user: null, updateUser: vi.fn() });
     render(<VerifyEmailBanner />);
     expect(screen.queryByTestId('verify-email-banner')).not.toBeInTheDocument();
@@ -82,64 +92,9 @@ describe('VerifyEmailBanner', () => {
 
     await user.click(screen.getByRole('button', { name: 'Dismiss' }));
 
-    expect(screen.queryByTestId('verify-email-banner')).not.toBeInTheDocument();
-    // "Not now", not "never" — session-scoped so it returns next visit.
+    // "Not now", not "never" — session-scoped so it returns next visit. The
+    // store carries it, because the layout needs to know too.
+    expect(useVerifyEmailBannerStore.getState().dismissed).toBe(true);
     expect(sessionStorage.getItem('syft_verify_email_dismissed')).toBe('1');
-  });
-
-  it('sends a code and reveals the input', async () => {
-    const user = userEvent.setup();
-    setup({ is_email_verified: false });
-
-    await user.click(screen.getByRole('button', { name: 'Send me a code' }));
-
-    await waitFor(() => {
-      expect(mockResend).toHaveBeenCalledTimes(1);
-    });
-    expect(screen.getByLabelText(/verification code/i)).toBeInTheDocument();
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Resend in \d+s/ })).toBeDisabled();
-    });
-  });
-
-  it('verifies a code and hands the updated user back', async () => {
-    const user = userEvent.setup();
-    const { updateUser } = setup({ is_email_verified: false });
-    await user.click(screen.getByRole('button', { name: 'Send me a code' }));
-
-    await user.type(await screen.findByLabelText(/verification code/i), '123456');
-    await user.click(screen.getByRole('button', { name: 'Verify' }));
-
-    await waitFor(() => {
-      expect(mockVerify).toHaveBeenCalledWith('123456');
-    });
-    expect(updateUser).toHaveBeenCalled();
-  });
-
-  it('reports a rejected code and clears the field', async () => {
-    const user = userEvent.setup();
-    mockVerify.mockRejectedValue(new Error('Invalid or expired verification code'));
-    const { updateUser } = setup({ is_email_verified: false });
-    await user.click(screen.getByRole('button', { name: 'Send me a code' }));
-
-    await user.type(await screen.findByLabelText(/verification code/i), '000000');
-    await user.click(screen.getByRole('button', { name: 'Verify' }));
-
-    await waitFor(() => {
-      expect(screen.getByText('Invalid or expired verification code')).toBeInTheDocument();
-    });
-    expect(updateUser).not.toHaveBeenCalled();
-    expect(screen.getByLabelText(/verification code/i)).toHaveValue('');
-  });
-
-  it('strips non-digits from the code', async () => {
-    const user = userEvent.setup();
-    setup({ is_email_verified: false });
-    await user.click(screen.getByRole('button', { name: 'Send me a code' }));
-
-    const input = await screen.findByLabelText(/verification code/i);
-    await user.type(input, '12ab34cd56');
-
-    expect(input).toHaveValue('123456');
   });
 });

--- a/components/frontend/src/components/__tests__/verify-email-banner.test.tsx
+++ b/components/frontend/src/components/__tests__/verify-email-banner.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { VerifyEmailBanner } from '@/components/auth/verify-email-banner';
+
+vi.mock('framer-motion', () => import('@/test/mocks/framer-motion'));
+
+const { mockUseAuth } = vi.hoisted(() => ({ mockUseAuth: vi.fn() }));
+vi.mock('@/context/auth-context', () => ({ useAuth: (): unknown => mockUseAuth() }));
+
+const { mockAvailable } = vi.hoisted(() => ({ mockAvailable: vi.fn() }));
+vi.mock('@/hooks/use-auth-config', () => ({
+  useEmailVerificationAvailable: (): unknown => mockAvailable()
+}));
+
+const { mockVerify, mockResend } = vi.hoisted(() => ({
+  mockVerify: vi.fn(),
+  mockResend: vi.fn()
+}));
+vi.mock('@/lib/sdk-client', () => ({
+  verifyEmailAPI: (code: string): unknown => mockVerify(code),
+  resendEmailVerificationAPI: (): unknown => mockResend()
+}));
+
+const verifiedUser = {
+  id: '1',
+  username: 'alice',
+  email: 'alice@example.com',
+  name: 'Alice',
+  full_name: 'Alice',
+  role: 'user',
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  is_email_verified: true
+};
+
+function setup(overrides: Record<string, unknown> = {}) {
+  const updateUser = vi.fn();
+  mockUseAuth.mockReturnValue({ user: { ...verifiedUser, ...overrides }, updateUser });
+  render(<VerifyEmailBanner />);
+  return { updateUser };
+}
+
+describe('VerifyEmailBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    mockAvailable.mockReturnValue(true);
+    mockResend.mockResolvedValue(null);
+    mockVerify.mockResolvedValue({ ...verifiedUser, is_email_verified: true });
+  });
+
+  it('stays hidden when the address is verified', () => {
+    setup();
+    expect(screen.queryByTestId('verify-email-banner')).not.toBeInTheDocument();
+  });
+
+  it('shows when the address is unverified', () => {
+    setup({ is_email_verified: false });
+    expect(screen.getByTestId('verify-email-banner')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+  });
+
+  it('stays hidden when the server cannot send email', () => {
+    // No code could ever arrive, so prompting would be a dead end.
+    mockAvailable.mockReturnValue(false);
+    setup({ is_email_verified: false });
+    expect(screen.queryByTestId('verify-email-banner')).not.toBeInTheDocument();
+  });
+
+  it('stays hidden when there is no user', () => {
+    mockUseAuth.mockReturnValue({ user: null, updateUser: vi.fn() });
+    render(<VerifyEmailBanner />);
+    expect(screen.queryByTestId('verify-email-banner')).not.toBeInTheDocument();
+  });
+
+  it('can be dismissed, and stays dismissed for the session', async () => {
+    const user = userEvent.setup();
+    setup({ is_email_verified: false });
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    expect(screen.queryByTestId('verify-email-banner')).not.toBeInTheDocument();
+    // "Not now", not "never" — session-scoped so it returns next visit.
+    expect(sessionStorage.getItem('syft_verify_email_dismissed')).toBe('1');
+  });
+
+  it('sends a code and reveals the input', async () => {
+    const user = userEvent.setup();
+    setup({ is_email_verified: false });
+
+    await user.click(screen.getByRole('button', { name: 'Send me a code' }));
+
+    await waitFor(() => {
+      expect(mockResend).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByLabelText(/verification code/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Resend in \d+s/ })).toBeDisabled();
+    });
+  });
+
+  it('verifies a code and hands the updated user back', async () => {
+    const user = userEvent.setup();
+    const { updateUser } = setup({ is_email_verified: false });
+    await user.click(screen.getByRole('button', { name: 'Send me a code' }));
+
+    await user.type(await screen.findByLabelText(/verification code/i), '123456');
+    await user.click(screen.getByRole('button', { name: 'Verify' }));
+
+    await waitFor(() => {
+      expect(mockVerify).toHaveBeenCalledWith('123456');
+    });
+    expect(updateUser).toHaveBeenCalled();
+  });
+
+  it('reports a rejected code and clears the field', async () => {
+    const user = userEvent.setup();
+    mockVerify.mockRejectedValue(new Error('Invalid or expired verification code'));
+    const { updateUser } = setup({ is_email_verified: false });
+    await user.click(screen.getByRole('button', { name: 'Send me a code' }));
+
+    await user.type(await screen.findByLabelText(/verification code/i), '000000');
+    await user.click(screen.getByRole('button', { name: 'Verify' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid or expired verification code')).toBeInTheDocument();
+    });
+    expect(updateUser).not.toHaveBeenCalled();
+    expect(screen.getByLabelText(/verification code/i)).toHaveValue('');
+  });
+
+  it('strips non-digits from the code', async () => {
+    const user = userEvent.setup();
+    setup({ is_email_verified: false });
+    await user.click(screen.getByRole('button', { name: 'Send me a code' }));
+
+    const input = await screen.findByLabelText(/verification code/i);
+    await user.type(input, '12ab34cd56');
+
+    expect(input).toHaveValue('123456');
+  });
+});

--- a/components/frontend/src/components/auth/email-verification-controls.tsx
+++ b/components/frontend/src/components/auth/email-verification-controls.tsx
@@ -1,0 +1,85 @@
+import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useEmailVerification } from '@/hooks/use-email-verification';
+
+interface EmailVerificationControlsProps {
+  /** The address being proven — shown back in the confirmation notice. */
+  readonly email: string;
+  /** Tighter spacing and smaller text, for use inside a single-line banner. */
+  readonly compact?: boolean;
+  /** Rendered above the controls, e.g. the banner's own message. */
+  readonly children?: React.ReactNode;
+}
+
+/**
+ * Ask for a code, then enter it.
+ *
+ * Shared by the dismissible banner and the profile page, so dismissing the banner
+ * never removes the only way to verify. Both read the same session state, so
+ * confirming in one makes the other disappear.
+ */
+export function EmailVerificationControls({
+  email,
+  compact = false,
+  children
+}: EmailVerificationControlsProps) {
+  const v = useEmailVerification();
+
+  return (
+    <>
+      {children}
+      {(v.error ?? v.notice) ? (
+        <p
+          className={`font-inter text-xs ${v.error ? 'text-red-600' : 'text-green-600'}`}
+          role='status'
+        >
+          {v.error ?? v.notice}
+        </p>
+      ) : null}
+
+      <div className={`flex items-center gap-2 ${compact ? '' : 'mt-1'}`}>
+        {v.codeRequested ? (
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              void v.verify();
+            }}
+            className='flex items-center gap-2'
+          >
+            <Input
+              value={v.code}
+              onChange={(event) => {
+                v.onCodeChange(event.target.value);
+              }}
+              placeholder='123456'
+              disabled={v.busy}
+              autoComplete='one-time-code'
+              inputMode='numeric'
+              maxLength={v.codeLength}
+              aria-label='Email verification code'
+              className='h-8 w-28'
+            />
+            <Button type='submit' size='sm' disabled={!v.canVerify}>
+              {v.isVerifying ? (
+                <Loader2 className='h-3.5 w-3.5 animate-spin' aria-hidden='true' />
+              ) : (
+                'Verify'
+              )}
+            </Button>
+          </form>
+        ) : null}
+
+        <button
+          type='button'
+          onClick={() => void v.send(email)}
+          disabled={!v.canSend}
+          className='font-inter text-xs font-medium underline underline-offset-2 disabled:no-underline disabled:opacity-50'
+        >
+          {v.codeRequested ? v.sendLabel : 'Verify now'}
+        </button>
+      </div>
+    </>
+  );
+}

--- a/components/frontend/src/components/auth/verify-email-banner.tsx
+++ b/components/frontend/src/components/auth/verify-email-banner.tsx
@@ -1,97 +1,32 @@
-import { useState } from 'react';
-
-import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
 import Mail from 'lucide-react/dist/esm/icons/mail';
 import X from 'lucide-react/dist/esm/icons/x';
 
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { EmailVerificationControls } from '@/components/auth/email-verification-controls';
 import { useAuth } from '@/context/auth-context';
-import { useEmailVerificationAvailable } from '@/hooks/use-auth-config';
-import { useResendCooldown } from '@/hooks/use-resend-cooldown';
-import { resendEmailVerificationAPI, verifyEmailAPI } from '@/lib/sdk-client';
-
-const CODE_LENGTH = 6;
-const DISMISS_KEY = 'syft_verify_email_dismissed';
+import { useShouldPromptEmailVerification } from '@/hooks/use-auth-config';
+import { useVerifyEmailBannerStore } from '@/stores/verify-email-banner-store';
 
 /**
  * Prompt to prove the email address on the account.
  *
- * A nudge, not a barrier: an unverified address does not restrict anything, so
- * this is dismissible and nothing waits on it. It reappears next session while
- * the address is still unverified, which is the point — persistent enough to be
- * acted on, never in the way.
+ * A nudge, not a barrier: an unverified address restricts nothing, so this is
+ * dismissible and nothing waits on it. It returns next session while the address
+ * is still unverified.
+ *
+ * Dismissing it is never a dead end — the profile page carries the same controls
+ * permanently, so there is always a way back.
  *
  * Hidden entirely when the server cannot send email, since no code could arrive
  * and there would be nothing the reader could do about it.
  */
 export function VerifyEmailBanner() {
-  const { user, updateUser } = useAuth();
-  const [dismissed, setDismissed] = useState(() => sessionStorage.getItem(DISMISS_KEY) === '1');
-  const [expanded, setExpanded] = useState(false);
-  const [code, setCode] = useState('');
-  const [isVerifying, setIsVerifying] = useState(false);
-  const [isResending, setIsResending] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [notice, setNotice] = useState<string | null>(null);
-  const cooldown = useResendCooldown();
-  const canVerify = useEmailVerificationAvailable();
+  const { user } = useAuth();
+  const shouldPrompt = useShouldPromptEmailVerification();
+  const dismiss = useVerifyEmailBannerStore((state) => state.dismiss);
 
-  if (!user || user.is_email_verified || dismissed || !canVerify) {
+  if (!shouldPrompt || !user) {
     return null;
   }
-
-  const busy = isVerifying || isResending;
-
-  let sendLabel = 'Send me a code';
-  if (cooldown.isCoolingDown) {
-    sendLabel = `Resend in ${String(cooldown.remaining)}s`;
-  } else if (expanded) {
-    sendLabel = 'Resend code';
-  }
-
-  const handleDismiss = () => {
-    // Session-scoped on purpose: dismissing means "not now", not "never".
-    sessionStorage.setItem(DISMISS_KEY, '1');
-    setDismissed(true);
-  };
-
-  const handleCodeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setCode(event.target.value.replaceAll(/\D/g, '').slice(0, CODE_LENGTH));
-    if (error) setError(null);
-  };
-
-  const handleSend = async () => {
-    if (cooldown.isCoolingDown || busy) return;
-    setIsResending(true);
-    setError(null);
-    try {
-      await resendEmailVerificationAPI();
-      cooldown.start();
-      setExpanded(true);
-      setNotice(`Code sent to ${user.email}.`);
-    } catch (error_) {
-      setError(error_ instanceof Error ? error_.message : 'Could not send a code');
-    } finally {
-      setIsResending(false);
-    }
-  };
-
-  const handleVerify = async (event: React.FormEvent) => {
-    event.preventDefault();
-    if (code.length !== CODE_LENGTH || busy) return;
-    setIsVerifying(true);
-    setError(null);
-    setNotice(null);
-    try {
-      updateUser(await verifyEmailAPI(code));
-    } catch (error_) {
-      setError(error_ instanceof Error ? error_.message : 'Could not confirm that code');
-      setCode('');
-    } finally {
-      setIsVerifying(false);
-    }
-  };
 
   return (
     <div
@@ -99,54 +34,25 @@ export function VerifyEmailBanner() {
       data-testid='verify-email-banner'
       role='status'
     >
-      <div className='mx-auto flex max-w-5xl flex-wrap items-center gap-3 px-4 py-2.5'>
-        <Mail
-          className='h-4 w-4 flex-shrink-0 text-amber-600 dark:text-amber-400'
-          aria-hidden='true'
-        />
-        <p className='font-inter flex-1 text-sm text-amber-900 dark:text-amber-100'>
-          {error ?? notice ?? (
-            <>
-              Your email <strong>{user.email}</strong> isn&apos;t verified yet.
-            </>
-          )}
-        </p>
-
-        {expanded ? (
-          <form onSubmit={(event) => void handleVerify(event)} className='flex gap-2'>
-            <Input
-              value={code}
-              onChange={handleCodeChange}
-              placeholder='123456'
-              disabled={busy}
-              autoComplete='one-time-code'
-              inputMode='numeric'
-              maxLength={CODE_LENGTH}
-              aria-label='Email verification code'
-              className='h-8 w-28'
-            />
-            <Button type='submit' size='sm' disabled={busy || code.length !== CODE_LENGTH}>
-              {isVerifying ? (
-                <Loader2 className='h-3.5 w-3.5 animate-spin' aria-hidden='true' />
-              ) : (
-                'Verify'
-              )}
-            </Button>
-          </form>
-        ) : null}
+      <div className='mx-auto flex max-w-5xl flex-wrap items-center gap-3 px-4 py-2.5 text-amber-900 dark:text-amber-100'>
+        <Mail className='h-4 w-4 flex-shrink-0' aria-hidden='true' />
+        <div className='flex flex-1 flex-wrap items-center gap-3'>
+          <EmailVerificationControls email={user.email} compact>
+            {/* String literals rather than bare JSX text: esbuild trims the
+                whitespace around an element boundary, and prettier removes an
+                explicit {' '} because it believes the literal space survives. The
+                two disagree, and the space vanished from the build. */}
+            <p className='font-inter text-sm'>
+              {'Your email '}
+              <strong>{user.email}</strong>
+              {" isn't verified yet."}
+            </p>
+          </EmailVerificationControls>
+        </div>
 
         <button
           type='button'
-          onClick={() => void handleSend()}
-          disabled={cooldown.isCoolingDown || busy}
-          className='font-inter text-xs font-medium text-amber-900 underline underline-offset-2 disabled:no-underline disabled:opacity-50 dark:text-amber-100'
-        >
-          {sendLabel}
-        </button>
-
-        <button
-          type='button'
-          onClick={handleDismiss}
+          onClick={dismiss}
           aria-label='Dismiss'
           className='text-amber-700 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100'
         >

--- a/components/frontend/src/components/auth/verify-email-banner.tsx
+++ b/components/frontend/src/components/auth/verify-email-banner.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react';
+
+import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
+import Mail from 'lucide-react/dist/esm/icons/mail';
+import X from 'lucide-react/dist/esm/icons/x';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useAuth } from '@/context/auth-context';
+import { useEmailVerificationAvailable } from '@/hooks/use-auth-config';
+import { useResendCooldown } from '@/hooks/use-resend-cooldown';
+import { resendEmailVerificationAPI, verifyEmailAPI } from '@/lib/sdk-client';
+
+const CODE_LENGTH = 6;
+const DISMISS_KEY = 'syft_verify_email_dismissed';
+
+/**
+ * Prompt to prove the email address on the account.
+ *
+ * A nudge, not a barrier: an unverified address does not restrict anything, so
+ * this is dismissible and nothing waits on it. It reappears next session while
+ * the address is still unverified, which is the point — persistent enough to be
+ * acted on, never in the way.
+ *
+ * Hidden entirely when the server cannot send email, since no code could arrive
+ * and there would be nothing the reader could do about it.
+ */
+export function VerifyEmailBanner() {
+  const { user, updateUser } = useAuth();
+  const [dismissed, setDismissed] = useState(() => sessionStorage.getItem(DISMISS_KEY) === '1');
+  const [expanded, setExpanded] = useState(false);
+  const [code, setCode] = useState('');
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [isResending, setIsResending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const cooldown = useResendCooldown();
+  const canVerify = useEmailVerificationAvailable();
+
+  if (!user || user.is_email_verified || dismissed || !canVerify) {
+    return null;
+  }
+
+  const busy = isVerifying || isResending;
+
+  let sendLabel = 'Send me a code';
+  if (cooldown.isCoolingDown) {
+    sendLabel = `Resend in ${String(cooldown.remaining)}s`;
+  } else if (expanded) {
+    sendLabel = 'Resend code';
+  }
+
+  const handleDismiss = () => {
+    // Session-scoped on purpose: dismissing means "not now", not "never".
+    sessionStorage.setItem(DISMISS_KEY, '1');
+    setDismissed(true);
+  };
+
+  const handleCodeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setCode(event.target.value.replaceAll(/\D/g, '').slice(0, CODE_LENGTH));
+    if (error) setError(null);
+  };
+
+  const handleSend = async () => {
+    if (cooldown.isCoolingDown || busy) return;
+    setIsResending(true);
+    setError(null);
+    try {
+      await resendEmailVerificationAPI();
+      cooldown.start();
+      setExpanded(true);
+      setNotice(`Code sent to ${user.email}.`);
+    } catch (error_) {
+      setError(error_ instanceof Error ? error_.message : 'Could not send a code');
+    } finally {
+      setIsResending(false);
+    }
+  };
+
+  const handleVerify = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (code.length !== CODE_LENGTH || busy) return;
+    setIsVerifying(true);
+    setError(null);
+    setNotice(null);
+    try {
+      updateUser(await verifyEmailAPI(code));
+    } catch (error_) {
+      setError(error_ instanceof Error ? error_.message : 'Could not confirm that code');
+      setCode('');
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  return (
+    <div
+      className='border-b border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950'
+      data-testid='verify-email-banner'
+      role='status'
+    >
+      <div className='mx-auto flex max-w-5xl flex-wrap items-center gap-3 px-4 py-2.5'>
+        <Mail
+          className='h-4 w-4 flex-shrink-0 text-amber-600 dark:text-amber-400'
+          aria-hidden='true'
+        />
+        <p className='font-inter flex-1 text-sm text-amber-900 dark:text-amber-100'>
+          {error ?? notice ?? (
+            <>
+              Your email <strong>{user.email}</strong> isn&apos;t verified yet.
+            </>
+          )}
+        </p>
+
+        {expanded ? (
+          <form onSubmit={(event) => void handleVerify(event)} className='flex gap-2'>
+            <Input
+              value={code}
+              onChange={handleCodeChange}
+              placeholder='123456'
+              disabled={busy}
+              autoComplete='one-time-code'
+              inputMode='numeric'
+              maxLength={CODE_LENGTH}
+              aria-label='Email verification code'
+              className='h-8 w-28'
+            />
+            <Button type='submit' size='sm' disabled={busy || code.length !== CODE_LENGTH}>
+              {isVerifying ? (
+                <Loader2 className='h-3.5 w-3.5 animate-spin' aria-hidden='true' />
+              ) : (
+                'Verify'
+              )}
+            </Button>
+          </form>
+        ) : null}
+
+        <button
+          type='button'
+          onClick={() => void handleSend()}
+          disabled={cooldown.isCoolingDown || busy}
+          className='font-inter text-xs font-medium text-amber-900 underline underline-offset-2 disabled:no-underline disabled:opacity-50 dark:text-amber-100'
+        >
+          {sendLabel}
+        </button>
+
+        <button
+          type='button'
+          onClick={handleDismiss}
+          aria-label='Dismiss'
+          className='text-amber-700 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100'
+        >
+          <X className='h-4 w-4' aria-hidden='true' />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/frontend/src/components/auth/verify-otp-modal.tsx
+++ b/components/frontend/src/components/auth/verify-otp-modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 
 import type { VerifyOtpFormValues } from '@/lib/schemas';
 
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Modal } from '@/components/ui/modal';
 import { useAuth } from '@/context/auth-context';
+import { useResendCooldown } from '@/hooks/use-resend-cooldown';
 import { verifyOtpSchema } from '@/lib/schemas';
 
 import { AuthErrorAlert, AuthLoadingOverlay } from './auth-utils';
@@ -28,8 +29,7 @@ export function VerifyOtpModal({
   onSwitchToLogin
 }: Readonly<VerifyOtpModalProperties>) {
   const { verifyOtp, resendOtp, isLoading, error, clearError } = useAuth();
-  const [resendCooldown, setResendCooldown] = useState(0);
-  const timerReference = useRef<ReturnType<typeof setTimeout>>(null);
+  const cooldown = useResendCooldown();
 
   const {
     register,
@@ -51,36 +51,27 @@ export function VerifyOtpModal({
   };
 
   const handleResend = async () => {
-    if (resendCooldown > 0) return;
+    if (cooldown.isCoolingDown) return;
     try {
       clearError();
       await resendOtp(email);
-      // Start cooldown timer (60 seconds)
-      setResendCooldown(60);
+      cooldown.start();
     } catch {
       // Error displayed by auth context
     }
   };
 
-  // Cooldown timer — uses setTimeout chain to avoid re-running the effect on every tick
-  useEffect(() => {
-    if (resendCooldown <= 0) return;
-    timerReference.current = setTimeout(() => {
-      setResendCooldown((previous) => previous - 1);
-    }, 1000);
-    return () => {
-      if (timerReference.current) clearTimeout(timerReference.current);
-    };
-  }, [resendCooldown]);
-
-  // Reset when modal closes
+  // Reset when modal closes. Depends on `cooldown.reset` rather than the whole
+  // `cooldown` object: the object's identity tracks the countdown, which ticks
+  // while the modal is open, and this effect only ever needs the reset function.
+  const resetCooldown = cooldown.reset;
   useEffect(() => {
     if (!isOpen) {
       reset();
       clearError();
-      setResendCooldown(0);
+      resetCooldown();
     }
-  }, [isOpen, reset, clearError]);
+  }, [isOpen, reset, clearError, resetCooldown]);
 
   const handleInputChange = () => {
     if (error) clearError();
@@ -131,10 +122,10 @@ export function VerifyOtpModal({
             <button
               type='button'
               onClick={() => void handleResend()}
-              disabled={resendCooldown > 0 || isLoading}
+              disabled={cooldown.isCoolingDown || isLoading}
               className='text-foreground hover:text-secondary font-medium underline disabled:no-underline disabled:opacity-50'
             >
-              {resendCooldown > 0 ? `Resend in ${String(resendCooldown)}s` : 'Resend code'}
+              {cooldown.isCoolingDown ? `Resend in ${String(cooldown.remaining)}s` : 'Resend code'}
             </button>
           </p>
         </div>

--- a/components/frontend/src/components/profile-view.tsx
+++ b/components/frontend/src/components/profile-view.tsx
@@ -50,6 +50,37 @@ interface PasswordChangeData {
   confirm_password: string;
 }
 
+/**
+ * The account's address with its verified state.
+ *
+ * Unverified is a neutral fact here, not a warning: nothing is restricted by it.
+ * The nudge to act lives in the page-level banner.
+ */
+function EmailRow({ email, verified }: { readonly email: string; readonly verified: boolean }) {
+  return (
+    <div className='flex items-center gap-3'>
+      <Mail className='text-muted-foreground h-5 w-5' />
+      <div>
+        <p className='text-foreground flex items-center gap-1.5 text-sm font-medium'>
+          {email}
+          {verified ? (
+            <span
+              className='inline-flex items-center gap-0.5 text-xs font-normal text-green-600'
+              title='This address has been verified'
+            >
+              <Check className='h-3 w-3' aria-hidden='true' />
+              Verified
+            </span>
+          ) : null}
+        </p>
+        <p className='text-muted-foreground text-xs'>
+          {verified ? 'Email address' : 'Email address — not verified'}
+        </p>
+      </div>
+    </div>
+  );
+}
+
 export function ProfileView() {
   const { user, updateUser } = useAuth();
   const [isEditing, setIsEditing] = useState(false);
@@ -301,13 +332,7 @@ export function ProfileView() {
               ) : (
                 /* View Mode */
                 <div className='space-y-4'>
-                  <div className='flex items-center gap-3'>
-                    <Mail className='text-muted-foreground h-5 w-5' />
-                    <div>
-                      <p className='text-foreground text-sm font-medium'>{user.email}</p>
-                      <p className='text-muted-foreground text-xs'>Email address</p>
-                    </div>
-                  </div>
+                  <EmailRow email={user.email} verified={user.is_email_verified ?? false} />
 
                   <div className='flex items-center gap-3'>
                     <Shield className='text-muted-foreground h-5 w-5' />

--- a/components/frontend/src/components/profile-view.tsx
+++ b/components/frontend/src/components/profile-view.tsx
@@ -6,6 +6,7 @@ import Calendar from 'lucide-react/dist/esm/icons/calendar';
 import Check from 'lucide-react/dist/esm/icons/check';
 import Edit3 from 'lucide-react/dist/esm/icons/edit-3';
 import Key from 'lucide-react/dist/esm/icons/key';
+import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
 import Lock from 'lucide-react/dist/esm/icons/lock';
 import Mail from 'lucide-react/dist/esm/icons/mail';
 import Save from 'lucide-react/dist/esm/icons/save';
@@ -14,6 +15,8 @@ import UserIcon from 'lucide-react/dist/esm/icons/user';
 import X from 'lucide-react/dist/esm/icons/x';
 
 import { useAuth } from '@/context/auth-context';
+import { useEmailVerificationAvailable } from '@/hooks/use-auth-config';
+import { useEmailVerification } from '@/hooks/use-email-verification';
 import { formatDateLong } from '@/lib/date-utils';
 import { changePasswordAPI, updateUserProfileAPI } from '@/lib/sdk-client';
 
@@ -50,32 +53,119 @@ interface PasswordChangeData {
   confirm_password: string;
 }
 
+type Verification = ReturnType<typeof useEmailVerification>;
+
+/** The verified tick, or the action that starts proving the address. */
+function EmailStateBadge({
+  email,
+  verified,
+  v
+}: {
+  readonly email: string;
+  readonly verified: boolean;
+  readonly v: Verification;
+}) {
+  if (verified) {
+    return (
+      <span
+        className='inline-flex items-center gap-0.5 text-xs font-normal text-green-600'
+        title='This address has been verified'
+      >
+        <Check className='h-3 w-3' aria-hidden='true' />
+        Verified
+      </span>
+    );
+  }
+  return (
+    <Button
+      type='button'
+      variant='outline'
+      size='sm'
+      onClick={() => void v.send(email)}
+      disabled={!v.canSend}
+      className='h-6 px-2 text-xs font-medium'
+    >
+      {v.isSending ? <Loader2 className='h-3 w-3 animate-spin' aria-hidden='true' /> : null}
+      {v.codeRequested ? v.sendLabel : 'Verify now'}
+    </Button>
+  );
+}
+
+/** Code entry, revealed only once a code has been asked for. */
+function EmailCodeForm({ v }: { readonly v: Verification }) {
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        void v.verify();
+      }}
+      className='mt-2 flex items-center gap-2'
+    >
+      <Input
+        value={v.code}
+        onChange={(event) => {
+          v.onCodeChange(event.target.value);
+        }}
+        placeholder='123456'
+        disabled={v.busy}
+        autoComplete='one-time-code'
+        inputMode='numeric'
+        maxLength={v.codeLength}
+        aria-label='Email verification code'
+        className='h-8 w-28'
+      />
+      <Button type='submit' size='sm' disabled={!v.canVerify}>
+        {v.isVerifying ? (
+          <Loader2 className='h-3.5 w-3.5 animate-spin' aria-hidden='true' />
+        ) : (
+          'Verify'
+        )}
+      </Button>
+    </form>
+  );
+}
+
 /**
  * The account's address with its verified state.
  *
- * Unverified is a neutral fact here, not a warning: nothing is restricted by it.
- * The nudge to act lives in the page-level banner.
+ * The tick and the "Verify now" action share one slot beside the address — same
+ * concept, same place — so the row never grows a third line. Code entry appears
+ * underneath once asked for, where there is room.
+ *
+ * Says nothing about verification when the server cannot send email: addresses
+ * cannot be proven in that deployment, so "not verified" would be a permanent
+ * complaint about something the reader cannot fix.
+ *
+ * Always present while unverified, so dismissing the page-level banner never
+ * removes the only way to verify.
  */
 function EmailRow({ email, verified }: { readonly email: string; readonly verified: boolean }) {
+  const showState = useEmailVerificationAvailable();
+  const v = useEmailVerification();
+  const unverified = showState && !verified;
+
   return (
-    <div className='flex items-center gap-3'>
-      <Mail className='text-muted-foreground h-5 w-5' />
+    <div className='flex items-start gap-3'>
+      <Mail className='text-muted-foreground mt-0.5 h-5 w-5' />
       <div>
-        <p className='text-foreground flex items-center gap-1.5 text-sm font-medium'>
+        <p className='text-foreground flex flex-wrap items-center gap-2 text-sm font-medium'>
           {email}
-          {verified ? (
-            <span
-              className='inline-flex items-center gap-0.5 text-xs font-normal text-green-600'
-              title='This address has been verified'
-            >
-              <Check className='h-3 w-3' aria-hidden='true' />
-              Verified
-            </span>
-          ) : null}
+          {showState ? <EmailStateBadge email={email} verified={verified} v={v} /> : null}
         </p>
         <p className='text-muted-foreground text-xs'>
-          {verified ? 'Email address' : 'Email address — not verified'}
+          {unverified ? 'Email address — not verified' : 'Email address'}
         </p>
+
+        {(v.error ?? v.notice) ? (
+          <p
+            className={`mt-1 text-xs ${v.error ? 'text-red-600' : 'text-green-600'}`}
+            role='status'
+          >
+            {v.error ?? v.notice}
+          </p>
+        ) : null}
+
+        {unverified && v.codeRequested ? <EmailCodeForm v={v} /> : null}
       </div>
     </div>
   );

--- a/components/frontend/src/components/settings/profile-settings-tab.tsx
+++ b/components/frontend/src/components/settings/profile-settings-tab.tsx
@@ -370,6 +370,20 @@ export function ProfileSettingsTab() {
               </div>
             ) : null}
           </div>
+          {/* Verified state of the address as stored, not as typed. Changing the
+              field clears it server-side and a code is sent to the new address;
+              nothing is blocked in the meantime. */}
+          {user?.is_email_verified ? (
+            <p className='flex items-center gap-1 text-xs text-green-600'>
+              <Check className='h-3 w-3' aria-hidden='true' />
+              Verified
+            </p>
+          ) : (
+            <p className='text-muted-foreground text-xs'>
+              Not verified — check your inbox for a code, or use the banner at the top of the page
+              to send a new one.
+            </p>
+          )}
           {emailAvailability.message ? (
             <p
               className={`text-xs ${

--- a/components/frontend/src/components/settings/profile-settings-tab.tsx
+++ b/components/frontend/src/components/settings/profile-settings-tab.tsx
@@ -15,6 +15,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { useAuth } from '@/context/auth-context';
+import { useEmailVerificationAvailable } from '@/hooks/use-auth-config';
 import {
   checkEmailAvailability,
   checkUsernameAvailability,
@@ -51,8 +52,26 @@ function normalizeDomainInput(value: string): string {
   return scheme.toLowerCase() + trimmed.slice(scheme.length);
 }
 
+function EmailVerifiedHint({ verified }: { readonly verified: boolean }) {
+  if (verified) {
+    return (
+      <p className='flex items-center gap-1 text-xs text-green-600'>
+        <Check className='h-3 w-3' aria-hidden='true' />
+        Verified
+      </p>
+    );
+  }
+  return (
+    <p className='text-muted-foreground text-xs'>
+      Not verified — check your inbox for a code, or use the banner at the top of the page to send a
+      new one.
+    </p>
+  );
+}
+
 export function ProfileSettingsTab() {
   const { user, updateUser } = useAuth();
+  const canVerifyEmail = useEmailVerificationAvailable();
   const { closeSettings } = useSettingsModalStore();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -372,18 +391,13 @@ export function ProfileSettingsTab() {
           </div>
           {/* Verified state of the address as stored, not as typed. Changing the
               field clears it server-side and a code is sent to the new address;
-              nothing is blocked in the meantime. */}
-          {user?.is_email_verified ? (
-            <p className='flex items-center gap-1 text-xs text-green-600'>
-              <Check className='h-3 w-3' aria-hidden='true' />
-              Verified
-            </p>
-          ) : (
-            <p className='text-muted-foreground text-xs'>
-              Not verified — check your inbox for a code, or use the banner at the top of the page
-              to send a new one.
-            </p>
-          )}
+              nothing is blocked in the meantime.
+
+              Silent when the server cannot send email: addresses cannot be proven
+              in that deployment, so neither a tick nor a complaint is meaningful. */}
+          {canVerifyEmail ? (
+            <EmailVerifiedHint verified={user?.is_email_verified ?? false} />
+          ) : null}
           {emailAvailability.message ? (
             <p
               className={`text-xs ${

--- a/components/frontend/src/context/__tests__/auth-context.test.tsx
+++ b/components/frontend/src/context/__tests__/auth-context.test.tsx
@@ -4,6 +4,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ThemeProvider } from '@/context/theme-context';
+import { useVerifyEmailBannerStore } from '@/stores/verify-email-banner-store';
 import { createMockSdkUser } from '@/test/mocks/fixtures';
 import {
   AuthenticationError,
@@ -348,6 +349,29 @@ describe('auth-context', () => {
 
       expect(result.current.user).toBeNull();
       expect(clearPersistedTokens).toHaveBeenCalled();
+    });
+
+    it('clears a dismissed verify-email prompt', async () => {
+      // sessionStorage outlives an app-level logout, so without this the
+      // dismissal would follow the next sign-in — and could hide the prompt from
+      // a different user signing in on the same tab. Dismissing must mean
+      // "not now", never "never".
+      vi.mocked(syftClient.auth.login).mockResolvedValue(createMockSdkUser() as never);
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => {
+        expect(result.current.isInitializing).toBe(false);
+      });
+      await act(async () => {
+        await result.current.login({ email: 'test@example.com', password: 'password' });
+      });
+      useVerifyEmailBannerStore.getState().dismiss();
+      expect(useVerifyEmailBannerStore.getState().dismissed).toBe(true);
+
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      expect(useVerifyEmailBannerStore.getState().dismissed).toBe(false);
     });
 
     it('clears state even if SDK logout throws', async () => {

--- a/components/frontend/src/context/auth-context.tsx
+++ b/components/frontend/src/context/auth-context.tsx
@@ -147,7 +147,9 @@ export function mapSdkUserToFrontend(sdkUser: SdkUser): User {
     domain: sdkUser.domain ?? undefined,
     aggregator_url: sdkUser.aggregatorUrl ?? undefined,
     bio: sdkUser.bio ?? undefined,
-    is_email_public: sdkUser.isEmailPublic ?? false
+    is_email_public: sdkUser.isEmailPublic ?? false,
+    is_email_verified: sdkUser.isEmailVerified ?? false,
+    email_verified_at: sdkUser.emailVerifiedAt?.toISOString()
   };
 }
 

--- a/components/frontend/src/context/auth-context.tsx
+++ b/components/frontend/src/context/auth-context.tsx
@@ -22,6 +22,7 @@ import {
   UserAlreadyExistsError,
   ValidationError
 } from '@/lib/sdk-client';
+import { useVerifyEmailBannerStore } from '@/stores/verify-email-banner-store';
 
 interface RegisterData {
   name: string;
@@ -374,11 +375,17 @@ export function AuthProvider({ children }: Readonly<AuthProviderProperties>) {
       // Update state
       setUser(null);
       setError(null);
+
+      // A dismissed "verify your email" prompt must not outlive the session that
+      // dismissed it — it would follow the next sign-in, and could even hide the
+      // prompt from a different user on the same tab.
+      useVerifyEmailBannerStore.getState().reset();
     } catch (logoutError) {
       console.error('Logout error:', logoutError);
       // Even if logout fails, clear local state
       clearPersistedTokens();
       setUser(null);
+      useVerifyEmailBannerStore.getState().reset();
     } finally {
       setIsLoading(false);
     }

--- a/components/frontend/src/hooks/__tests__/use-resend-cooldown.test.ts
+++ b/components/frontend/src/hooks/__tests__/use-resend-cooldown.test.ts
@@ -1,0 +1,92 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useResendCooldown } from '@/hooks/use-resend-cooldown';
+
+describe('useResendCooldown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts ready and blocks after start()', () => {
+    const { result } = renderHook(() => useResendCooldown(60));
+
+    expect(result.current.remaining).toBe(0);
+    expect(result.current.isCoolingDown).toBe(false);
+
+    act(() => {
+      result.current.start();
+    });
+
+    expect(result.current.remaining).toBe(60);
+    expect(result.current.isCoolingDown).toBe(true);
+  });
+
+  it('counts down and becomes ready again', () => {
+    const { result } = renderHook(() => useResendCooldown(3));
+
+    act(() => {
+      result.current.start();
+    });
+
+    // One second per act: each tick is scheduled by an effect that only
+    // re-registers once React has flushed the previous state update, so a single
+    // bulk advance would fire just the first timeout.
+    for (let index = 0; index < 3; index++) {
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+    }
+
+    expect(result.current.remaining).toBe(0);
+    expect(result.current.isCoolingDown).toBe(false);
+  });
+
+  it('reset() clears an active countdown', () => {
+    const { result } = renderHook(() => useResendCooldown(60));
+
+    act(() => {
+      result.current.start();
+    });
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.isCoolingDown).toBe(false);
+  });
+
+  it('keeps a stable identity across unrelated re-renders', () => {
+    // Regression: returning a fresh object every render made this unusable as a
+    // useEffect dependency — the effect re-ran on every render, and a body that
+    // triggered a render looped until React bailed with "Maximum update depth
+    // exceeded".
+    const { result, rerender } = renderHook(() => useResendCooldown(60));
+
+    const first = result.current;
+    rerender();
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+
+  it('keeps start and reset stable even as the countdown ticks', () => {
+    const { result } = renderHook(() => useResendCooldown(3));
+    const { start, reset } = result.current;
+
+    act(() => {
+      result.current.start();
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.start).toBe(start);
+    expect(result.current.reset).toBe(reset);
+    // The object itself does change, because `remaining` did.
+    expect(result.current.remaining).toBe(2);
+  });
+});

--- a/components/frontend/src/hooks/use-auth-config.ts
+++ b/components/frontend/src/hooks/use-auth-config.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { authKeys } from '@/lib/query-keys';
+import { getAuthConfigAPI } from '@/lib/sdk-client';
+
+/**
+ * The server's public auth configuration.
+ *
+ * Deployment-level and fixed for the life of the process, so it is fetched once
+ * and never refetched.
+ */
+export function useAuthConfig() {
+  return useQuery({
+    queryKey: authKeys.config(),
+    queryFn: getAuthConfigAPI,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: Number.POSITIVE_INFINITY,
+    retry: false
+  });
+}
+
+/**
+ * Whether an address can be proven at all in this deployment.
+ *
+ * False when the server has no mail transport: no code could ever arrive, so a
+ * prompt to verify would be a dead end and nothing is ever marked verified.
+ * Defaults to false until the config resolves, so the prompt cannot flash.
+ */
+export function useEmailVerificationAvailable(): boolean {
+  const { data } = useAuthConfig();
+  return data?.smtpConfigured ?? false;
+}

--- a/components/frontend/src/hooks/use-auth-config.ts
+++ b/components/frontend/src/hooks/use-auth-config.ts
@@ -1,7 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { useAuth } from '@/context/auth-context';
 import { authKeys } from '@/lib/query-keys';
 import { getAuthConfigAPI } from '@/lib/sdk-client';
+import { useVerifyEmailBannerStore } from '@/stores/verify-email-banner-store';
 
 /**
  * The server's public auth configuration.
@@ -29,4 +31,19 @@ export function useAuthConfig() {
 export function useEmailVerificationAvailable(): boolean {
   const { data } = useAuthConfig();
   return data?.smtpConfigured ?? false;
+}
+
+/**
+ * Whether the "verify your email" prompt should be on screen.
+ *
+ * Shared by the banner and by the layout, which needs it to shift its floating
+ * header down so the two do not overlap. Keeping the decision in one place stops
+ * the two disagreeing.
+ */
+export function useShouldPromptEmailVerification(): boolean {
+  const { user } = useAuth();
+  const dismissed = useVerifyEmailBannerStore((state) => state.dismissed);
+  const canVerify = useEmailVerificationAvailable();
+
+  return Boolean(user) && !user?.is_email_verified && !dismissed && canVerify;
 }

--- a/components/frontend/src/hooks/use-email-verification.ts
+++ b/components/frontend/src/hooks/use-email-verification.ts
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+
+import { useAuth } from '@/context/auth-context';
+import { useResendCooldown } from '@/hooks/use-resend-cooldown';
+import { resendEmailVerificationAPI, verifyEmailAPI } from '@/lib/sdk-client';
+
+const CODE_LENGTH = 6;
+
+/**
+ * Sending and confirming proof of the address on the account.
+ *
+ * Held here rather than in a component because two surfaces need it: the
+ * page-level banner, and the always-present control on the profile page. The
+ * banner is dismissible, so it cannot be the only way in — dismissing it means
+ * "not now", and something must still be there afterwards.
+ */
+export function useEmailVerification() {
+  const { updateUser } = useAuth();
+  const [code, setCode] = useState('');
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [codeRequested, setCodeRequested] = useState(false);
+  const cooldown = useResendCooldown();
+
+  const busy = isVerifying || isSending;
+
+  /** Keep only digits, capped at the code length. */
+  const onCodeChange = (value: string) => {
+    setCode(value.replaceAll(/\D/g, '').slice(0, CODE_LENGTH));
+    if (error) setError(null);
+  };
+
+  const send = async (address: string) => {
+    if (cooldown.isCoolingDown || busy) return;
+    setIsSending(true);
+    setError(null);
+    try {
+      await resendEmailVerificationAPI();
+      cooldown.start();
+      setCodeRequested(true);
+      setNotice(`Code sent to ${address}.`);
+    } catch (error_) {
+      setError(error_ instanceof Error ? error_.message : 'Could not send a code');
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const verify = async () => {
+    if (code.length !== CODE_LENGTH || busy) return;
+    setIsVerifying(true);
+    setError(null);
+    setNotice(null);
+    try {
+      // Folding the result into the session is what makes both surfaces
+      // disappear at once: they render off the user's verified state.
+      updateUser(await verifyEmailAPI(code));
+    } catch (error_) {
+      setError(error_ instanceof Error ? error_.message : 'Could not confirm that code');
+      setCode('');
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  let sendLabel = 'Send me a code';
+  if (cooldown.isCoolingDown) {
+    sendLabel = `Resend in ${String(cooldown.remaining)}s`;
+  } else if (codeRequested) {
+    sendLabel = 'Resend code';
+  }
+
+  return {
+    code,
+    onCodeChange,
+    /** True once a code has been asked for, so the input can be revealed. */
+    codeRequested,
+    send,
+    verify,
+    sendLabel,
+    canSend: !cooldown.isCoolingDown && !busy,
+    canVerify: code.length === CODE_LENGTH && !busy,
+    busy,
+    isVerifying,
+    isSending,
+    error,
+    notice,
+    codeLength: CODE_LENGTH
+  };
+}

--- a/components/frontend/src/hooks/use-resend-cooldown.ts
+++ b/components/frontend/src/hooks/use-resend-cooldown.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+/**
+ * Countdown that throttles "resend code" buttons.
+ *
+ * Extracted so every OTP surface (registration, email change) shares one
+ * implementation rather than each keeping its own timer.
+ *
+ * Uses a setTimeout chain rather than setInterval so the effect is not
+ * re-registered on every tick.
+ *
+ * @param seconds - How long to block resending after each send. Default 60.
+ */
+export function useResendCooldown(seconds = 60) {
+  const [remaining, setRemaining] = useState(0);
+  const timerReference = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (remaining <= 0) return;
+    timerReference.current = setTimeout(() => {
+      setRemaining((previous) => previous - 1);
+    }, 1000);
+    return () => {
+      if (timerReference.current) clearTimeout(timerReference.current);
+    };
+  }, [remaining]);
+
+  const start = useCallback(() => {
+    setRemaining(seconds);
+  }, [seconds]);
+
+  const reset = useCallback(() => {
+    setRemaining(0);
+  }, []);
+
+  // Memoised so the identity only changes when the countdown does. Returning a
+  // fresh object every render makes this unusable as a `useEffect` dependency:
+  // the effect re-runs on every render, and if its body triggers one — a
+  // react-hook-form `reset()`, say — that is an infinite loop.
+  return useMemo(
+    () => ({
+      /** Seconds left before another send is allowed; 0 when ready. */
+      remaining,
+      /** True while a resend must be blocked. */
+      isCoolingDown: remaining > 0,
+      /** Begin the countdown — call after a successful send. */
+      start,
+      /** Clear the countdown, e.g. when the surface is dismissed. */
+      reset
+    }),
+    [remaining, start, reset]
+  );
+}

--- a/components/frontend/src/layouts/main-layout.tsx
+++ b/components/frontend/src/layouts/main-layout.tsx
@@ -4,6 +4,7 @@ import User from 'lucide-react/dist/esm/icons/user';
 import { Link, Outlet } from 'react-router-dom';
 
 import { AuthModals } from '@/components/auth/auth-modals';
+import { VerifyEmailBanner } from '@/components/auth/verify-email-banner';
 import { BalanceIndicator } from '@/components/balance';
 import { ContextBar } from '@/components/context-bar';
 import { SettingsModal } from '@/components/settings/settings-modal';
@@ -120,6 +121,9 @@ export function MainLayout() {
 
       {/* Main content with left margin for sidebar */}
       <main id='main-content' className='ml-20'>
+        {/* A nudge to prove the address on the account. Renders nothing when
+            verified, dismissed, or when the server cannot send email. */}
+        <VerifyEmailBanner />
         <Outlet />
       </main>
 

--- a/components/frontend/src/layouts/main-layout.tsx
+++ b/components/frontend/src/layouts/main-layout.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { ModeToggle } from '@/components/ui/mode-toggle';
 import { useAuth } from '@/context/auth-context';
+import { useShouldPromptEmailVerification } from '@/hooks/use-auth-config';
 import { useModalStore } from '@/stores/modal-store';
 import { useSettingsModalStore } from '@/stores/settings-modal-store';
 
@@ -28,6 +29,9 @@ import { useSettingsModalStore } from '@/stores/settings-modal-store';
  */
 export function MainLayout() {
   const { user, logout, isInitializing } = useAuth();
+  // The header floats, so it would sit on top of the banner. Drop it below the
+  // banner's height while the banner is up.
+  const promptingEmailVerification = useShouldPromptEmailVerification();
   const { openLogin, openRegister } = useModalStore();
   const { openSettings } = useSettingsModalStore();
 
@@ -54,7 +58,11 @@ export function MainLayout() {
       <Sidebar />
 
       {/* User Menu - Top Right */}
-      <div className='fixed top-4 right-4 z-40 flex items-center gap-3'>
+      <div
+        className={`fixed right-4 z-40 flex items-center gap-3 transition-[top] duration-200 ${
+          promptingEmailVerification ? 'top-16' : 'top-4'
+        }`}
+      >
         {user ? (
           <>
             {/* Balance Indicator */}
@@ -119,11 +127,16 @@ export function MainLayout() {
         )}
       </div>
 
+      {/* A nudge to prove the address on the account. Renders nothing when
+          verified, dismissed, or when the server cannot send email. Sits above
+          the content in the flow so it pushes the page down rather than covering
+          it; the floating header offsets itself to match. */}
+      <div className='ml-20'>
+        <VerifyEmailBanner />
+      </div>
+
       {/* Main content with left margin for sidebar */}
       <main id='main-content' className='ml-20'>
-        {/* A nudge to prove the address on the account. Renders nothing when
-            verified, dismissed, or when the server cannot send email. */}
-        <VerifyEmailBanner />
         <Outlet />
       </main>
 

--- a/components/frontend/src/lib/query-keys.ts
+++ b/components/frontend/src/lib/query-keys.ts
@@ -27,6 +27,11 @@ export const userKeys = {
   publicProfile: (username: string) => [...userKeys.all, 'public', username] as const
 };
 
+export const authKeys = {
+  all: ['auth'] as const,
+  config: () => [...authKeys.all, 'config'] as const
+};
+
 export const modelKeys = {
   all: ['models'] as const,
   chat: (limit: number, isAuthenticated: boolean) =>

--- a/components/frontend/src/lib/sdk-client.ts
+++ b/components/frontend/src/lib/sdk-client.ts
@@ -2,6 +2,7 @@
 // User Profile Utilities
 // ============================================================================
 
+import type { AuthConfig, User as SdkUser } from '@syfthub/sdk';
 import type {
   AvailabilityResponse,
   User as FrontendUser,
@@ -279,7 +280,16 @@ export async function updateUserProfileAPI(profileData: UserUpdate): Promise<Fro
     isEmailPublic: profileData.is_email_public
   });
 
-  // Convert SDK User to frontend User format
+  return mapSdkUser(sdkUser);
+}
+
+/**
+ * Convert an SDK User into the frontend User shape.
+ *
+ * Shared by every call here that returns a user, so a newly added field is
+ * mapped once rather than in each caller.
+ */
+function mapSdkUser(sdkUser: SdkUser): FrontendUser {
   return {
     id: String(sdkUser.id),
     username: sdkUser.username,
@@ -294,7 +304,9 @@ export async function updateUserProfileAPI(profileData: UserUpdate): Promise<Fro
     domain: sdkUser.domain ?? undefined,
     aggregator_url: sdkUser.aggregatorUrl ?? undefined,
     bio: sdkUser.bio ?? undefined,
-    is_email_public: sdkUser.isEmailPublic ?? false
+    is_email_public: sdkUser.isEmailPublic ?? false,
+    is_email_verified: sdkUser.isEmailVerified ?? false,
+    email_verified_at: sdkUser.emailVerifiedAt?.toISOString()
   };
 }
 
@@ -421,6 +433,32 @@ export async function googleLoginAPI(credential: string): Promise<FrontendUser> 
     created_at: data.user.created_at,
     updated_at: data.user.created_at
   };
+}
+
+/**
+ * Read the server's public auth configuration.
+ *
+ * Used to tell whether email verification is even possible: with no mail
+ * transport configured, no code can arrive, so prompting for one would be a
+ * dead end.
+ */
+export async function getAuthConfigAPI(): Promise<AuthConfig> {
+  return syftClient.auth.getAuthConfig();
+}
+
+/**
+ * Confirm the address on the account with the code sent to it.
+ *
+ * A wrong code changes nothing and can be retried.
+ */
+export async function verifyEmailAPI(code: string): Promise<FrontendUser> {
+  const sdkUser = await syftClient.auth.verifyEmail(code);
+  return mapSdkUser(sdkUser);
+}
+
+/** Send a fresh verification code to the address on the account. */
+export async function resendEmailVerificationAPI(): Promise<void> {
+  await syftClient.auth.resendEmailVerification();
 }
 
 /**

--- a/components/frontend/src/lib/types.ts
+++ b/components/frontend/src/lib/types.ts
@@ -53,6 +53,11 @@ export interface User {
   is_email_public?: boolean;
   /** Timestamp of the user's last successful login (null/undefined if never) */
   last_login_at?: string;
+  /** Whether the address on file has been proven. Gates nothing — it drives the
+   *  verified tick and the prompt to verify, not access. */
+  is_email_verified?: boolean;
+  /** When the address on file was proven, or undefined if it has not been. */
+  email_verified_at?: string;
 }
 
 // Authentication request schemas

--- a/components/frontend/src/stores/__tests__/verify-email-banner-store.test.ts
+++ b/components/frontend/src/stores/__tests__/verify-email-banner-store.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useVerifyEmailBannerStore } from '@/stores/verify-email-banner-store';
+
+const DISMISS_KEY = 'syft_verify_email_dismissed';
+
+describe('useVerifyEmailBannerStore', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    useVerifyEmailBannerStore.setState({ dismissed: false });
+  });
+
+  it('starts undismissed', () => {
+    expect(useVerifyEmailBannerStore.getState().dismissed).toBe(false);
+  });
+
+  it('dismiss() persists so a reload does not re-nag mid-session', () => {
+    useVerifyEmailBannerStore.getState().dismiss();
+
+    expect(useVerifyEmailBannerStore.getState().dismissed).toBe(true);
+    expect(sessionStorage.getItem(DISMISS_KEY)).toBe('1');
+  });
+
+  it('reset() clears both the state and the stored flag', () => {
+    // Called on logout. sessionStorage outlives an app-level logout, so without
+    // this a dismissal would follow the next sign-in — and could hide the prompt
+    // from a *different* user signing in on the same tab.
+    useVerifyEmailBannerStore.getState().dismiss();
+
+    useVerifyEmailBannerStore.getState().reset();
+
+    expect(useVerifyEmailBannerStore.getState().dismissed).toBe(false);
+    expect(sessionStorage.getItem(DISMISS_KEY)).toBeNull();
+  });
+});

--- a/components/frontend/src/stores/verify-email-banner-store.ts
+++ b/components/frontend/src/stores/verify-email-banner-store.ts
@@ -5,22 +5,30 @@ const DISMISS_KEY = 'syft_verify_email_dismissed';
 interface VerifyEmailBannerState {
   dismissed: boolean;
   dismiss: () => void;
+  reset: () => void;
 }
 
 /**
- * Whether the "verify your email" prompt has been dismissed this session.
+ * Whether the "verify your email" prompt has been dismissed.
  *
  * In a store rather than component state because two places need it: the banner
  * itself, and the layout, which shifts its floating header down to make room so
  * the two do not overlap.
  *
- * Session-scoped on purpose — dismissing means "not now", not "never", so the
- * prompt returns next visit while the address is still unverified.
+ * Dismissing means "not now", never "never" — the prompt must come back for as
+ * long as the address is unverified. `sessionStorage` alone is not enough for
+ * that: it outlives an app-level logout, so without `reset()` on the way out a
+ * dismissal would follow the next sign-in, and even leak to a *different* user
+ * signing in on the same tab. AuthContext calls `reset()` on logout.
  */
 export const useVerifyEmailBannerStore = create<VerifyEmailBannerState>((set) => ({
   dismissed: sessionStorage.getItem(DISMISS_KEY) === '1',
   dismiss: () => {
     sessionStorage.setItem(DISMISS_KEY, '1');
     set({ dismissed: true });
+  },
+  reset: () => {
+    sessionStorage.removeItem(DISMISS_KEY);
+    set({ dismissed: false });
   }
 }));

--- a/components/frontend/src/stores/verify-email-banner-store.ts
+++ b/components/frontend/src/stores/verify-email-banner-store.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+
+const DISMISS_KEY = 'syft_verify_email_dismissed';
+
+interface VerifyEmailBannerState {
+  dismissed: boolean;
+  dismiss: () => void;
+}
+
+/**
+ * Whether the "verify your email" prompt has been dismissed this session.
+ *
+ * In a store rather than component state because two places need it: the banner
+ * itself, and the layout, which shifts its floating header down to make room so
+ * the two do not overlap.
+ *
+ * Session-scoped on purpose — dismissing means "not now", not "never", so the
+ * prompt returns next visit while the address is still unverified.
+ */
+export const useVerifyEmailBannerStore = create<VerifyEmailBannerState>((set) => ({
+  dismissed: sessionStorage.getItem(DISMISS_KEY) === '1',
+  dismiss: () => {
+    sessionStorage.setItem(DISMISS_KEY, '1');
+    set({ dismissed: true });
+  }
+}));

--- a/sdk/typescript/src/models/user.ts
+++ b/sdk/typescript/src/models/user.ts
@@ -21,6 +21,15 @@ export interface User {
   readonly bio?: string | null;
   /** Whether the user's email is shown on their public profile */
   readonly isEmailPublic?: boolean;
+  /** Whether the address on file has been proven. Gates nothing. */
+  readonly isEmailVerified?: boolean;
+  /**
+   * When the address on file was proven, or null if it has not been. Cleared
+   * whenever the address changes — so changing an email leaves the account fully
+   * usable and merely unverified until a code sent to the new address is
+   * confirmed with `auth.verifyEmail()`.
+   */
+  readonly emailVerifiedAt?: Date | null;
 }
 
 /**

--- a/sdk/typescript/src/resources/auth.ts
+++ b/sdk/typescript/src/resources/auth.ts
@@ -269,6 +269,32 @@ export class AuthResource {
   }
 
   /**
+   * Confirm the email address on the account with the code sent to it.
+   *
+   * The address is not passed in: the server reads it from the authenticated
+   * user, so a caller can only ever verify their own. A wrong code changes
+   * nothing and can be retried.
+   *
+   * @param code - The 6-digit code sent to the address on the account
+   * @returns The updated User, with `emailVerifiedAt` set
+   * @throws {ValidationError} If the address is already verified
+   */
+  async verifyEmail(code: string): Promise<User> {
+    return this.http.post<User>('/api/v1/auth/me/email/verify', { code });
+  }
+
+  /**
+   * Send a fresh verification code to the address on the account.
+   *
+   * @throws {ValidationError} If already verified, or email delivery is not
+   *   configured on the server — in which case addresses cannot be proven at all
+   *   and nothing will ever be marked verified.
+   */
+  async resendEmailVerification(): Promise<void> {
+    await this.http.post<void>('/api/v1/auth/me/email/resend');
+  }
+
+  /**
    * Request a password reset OTP.
    *
    * Always returns successfully to prevent email enumeration.


### PR DESCRIPTION
This pull request introduces significant improvements to user identity and email verification handling, focusing on privacy, security, and user experience. The most important changes are the migration from sequential user IDs to stable public UUIDs, the replacement of the ambiguous `is_email_verified` boolean with a timestamp-based `email_verified_at` field, and a redesign of email verification flows to ensure users are never locked out due to email changes. Additionally, new API endpoints and supporting logic have been added to manage email verification in a more user-friendly and robust way.

**Database migrations and user identity:**

* Added a new `public_id` UUID column to the `users` table as a stable, opaque external identifier, replacing the use of internal sequential IDs for external references. This enhances privacy and is now used for OIDC `sub` claims. The migration ensures safe rollout with backfill and proper defaults for both PostgreSQL and SQLite. [[1]](diffhunk://#diff-eb425f785113ccc93f4344759feb238b921e16cb68e59a10970cb699e4795caeR1-R114) [[2]](diffhunk://#diff-50414e758ca6f3b6d66c9ab71b2622c13b2b4a8f607438bb40101eedc809309fR3-R7) [[3]](diffhunk://#diff-50414e758ca6f3b6d66c9ab71b2622c13b2b4a8f607438bb40101eedc809309fR23-R37)
* Replaced the `is_email_verified` boolean with a nullable `email_verified_at` timestamp, clarifying the semantics of email verification and preventing users from being locked out when their email changes. The migration backfills existing data to preserve current behavior.

**API and backend logic changes:**

* Redesigned user profile update endpoints (`PUT /users/me` and admin `PUT /users/{id}`) to handle email changes gracefully: changing an email clears its verified state, sends a verification code to the new address, and notifies the old address, without gating login or access on verification status. [[1]](diffhunk://#diff-b0ab1187117d7db77896d7dc66390c3c8060a8080166456406d956123ece39abL4-R26) [[2]](diffhunk://#diff-b0ab1187117d7db77896d7dc66390c3c8060a8080166456406d956123ece39abR35-R39) [[3]](diffhunk://#diff-b0ab1187117d7db77896d7dc66390c3c8060a8080166456406d956123ece39abR191-R279)
* Removed login gating on email verification—users can now sign in even if their email is unverified, with the UI responsible for prompting verification as needed. [[1]](diffhunk://#diff-2eb5cb56c042c163e6c900c885c87518b0f1b19c364a0b91e748350d9fdaf7a2L178-L188) [[2]](diffhunk://#diff-3e20d5de9fdea87fd38d4b4c6f7d2fb9a0228105d77e486d698ba6be7e80d03cL215-L226)

**Email verification API endpoints:**

* Introduced new endpoints to (re)send verification codes and confirm email addresses (`POST /auth/me/email/verify` and `POST /auth/me/email/resend`), decoupling verification from registration and allowing users to verify or re-verify their email at any time.

**Dependency injection and service wiring:**

* Added `EmailVerificationService` to the dependency injection system, making it available to endpoints and services that require email verification logic. [[1]](diffhunk://#diff-1fe28ad525d26645f139a03c50fd2cd0d6bdcb1816029c91d848504fb5a9ac57R22) [[2]](diffhunk://#diff-1fe28ad525d26645f139a03c50fd2cd0d6bdcb1816029c91d848504fb5a9ac57R108-R114)

These changes collectively improve privacy, make email verification more robust and user-friendly, and prevent accidental user lockouts during email changes.